### PR TITLE
docs: add complete Japanese documentation set

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,104 @@
+# Trade RL
+
+[English](README.md) | **日本語**
+
+Trade RLは、複数の金融商品に対してリスク制約付きの目標ウェイトを生成する、ポートフォリオ強化学習の研究・デプロイ用コードベースです。
+
+## 状態
+
+**Production: NO-GO（本番投入不可）。**
+
+このリポジトリは、オフラインのControl Planeと、認証付き・読み取り専用のServing Planeに分離されています。コードとCIが正常であるだけでは、ライブ取引は許可されません。[`docs/ja/PRODUCTION_READINESS.md`](docs/ja/PRODUCTION_READINESS.md)の未完了項目に運用証拠が添付されるまで、本番投入はブロックされます。
+
+このリポジトリ内のリターン、Sharpe比、ベンチマーク結果、合成データ実験は、将来の収益性を保証するものではありません。
+
+## アーキテクチャ
+
+```text
+Control Plane
+  データ -> 品質ゲート -> 学習 -> Walk-Forward／Holdout評価
+         -> ServingBundle候補 -> 証拠 -> 不変Registry
+         -> 承認後の原子的activation
+
+Serving Plane
+  認証済み口座状態 + キャッシュ済み市場スナップショット
+         -> 共通Observation Builder -> Policy -> DecisionPipeline
+         -> Guardrails -> Pre-Trade Risk判定 -> 読み取り専用レスポンス
+```
+
+アーキテクチャの唯一の正典は[`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)です。日本語版は[`docs/ja/ARCHITECTURE.md`](docs/ja/ARCHITECTURE.md)にあります。
+
+## セットアップ
+
+Python 3.12と`uv`を推奨します。
+
+```bash
+uv sync --all-extras --dev
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy mars_lite
+uv run pytest --cov=mars_lite --cov-fail-under=70 tests/
+```
+
+## Control Plane
+
+完全な検証・学習パイプラインを実行します。
+
+```bash
+uv run python scripts/run_pipeline.py \
+  --source postgres \
+  --git-sha "$(git rev-parse HEAD)" \
+  --model-version model-YYYYMMDD-N
+```
+
+成功した実行は、不変の候補Bundleを構築してRegistryへ登録します。ただし、候補を**activationしません**。activationは、証拠検証とEnvironment承認を通過した後、デプロイworkflowだけが実行します。
+
+Registry操作:
+
+```bash
+uv run python scripts/manage_registry.py --registry-dir output/model_registry list
+uv run python scripts/manage_registry.py --registry-dir output/model_registry show-active
+```
+
+## Serving Plane
+
+必要な環境変数:
+
+```text
+TRADE_RL_SERVING_TOKEN      必須Bearer token
+TRADE_RL_REGISTRY_DIR       Registryディレクトリ
+TRADE_RL_AUDIT_DB           SQLite監査・リプレイ防止DB
+TRADE_RL_DATA_DIR           市場データディレクトリ
+TRADE_RL_ALLOWED_ORIGINS    カンマ区切りの許可origin
+TRADE_RL_HOST               既定値 127.0.0.1
+TRADE_RL_PORT               既定値 8001
+```
+
+Servingを開始します。
+
+```bash
+uv run python scripts/run_server.py
+```
+
+公開route:
+
+- `GET /health`
+- `GET /ready`
+- `POST /api/signal/latest`（`Authorization: Bearer ...`が必要）
+
+Serving Planeには、学習、モデル削除、昇格、rollback、Registry変更用のrouteはありません。
+
+## ドキュメント
+
+- [`docs/ja/ARCHITECTURE.md`](docs/ja/ARCHITECTURE.md) — 現行システムアーキテクチャ
+- [`docs/ja/MODEL_LIFECYCLE.md`](docs/ja/MODEL_LIFECYCLE.md) — 候補、証拠、Registry、activation、rollback
+- [`docs/ja/OPERATIONS.md`](docs/ja/OPERATIONS.md) — デプロイとインシデント対応
+- [`docs/ja/SECURITY.md`](docs/ja/SECURITY.md) — 信頼境界と脅威
+- [`docs/ja/TESTING.md`](docs/ja/TESTING.md) — テストと受入ゲート
+- [`docs/ja/PRODUCTION_READINESS.md`](docs/ja/PRODUCTION_READINESS.md) — GO／NO-GOチェックリスト
+- [`docs/ja/DECISIONS.md`](docs/ja/DECISIONS.md) — アーキテクチャ上の意思決定
+- [`docs/ja/RESEARCH_HISTORY.md`](docs/ja/RESEARCH_HISTORY.md) — 非正典の研究履歴
+
+日本語ドキュメント一覧は[`docs/ja/README.md`](docs/ja/README.md)を参照してください。
+
+承認済みの仕様書と実装計画は`docs/superpowers/`に履歴資料として保持されています。

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Trade RL
 
+**English** | [日本語](README.ja.md)
+
 Trade RL is a portfolio reinforcement-learning research and deployment codebase for producing risk-constrained target weights across multiple instruments.
 
 ## Status
@@ -88,6 +90,7 @@ The Serving Plane contains no training, model deletion, promotion, rollback, or 
 
 ## Documentation
 
+- [Japanese documentation / 日本語ドキュメント](docs/ja/README.md)
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — current system architecture
 - [`docs/MODEL_LIFECYCLE.md`](docs/MODEL_LIFECYCLE.md) — candidate, evidence, registry, activation, rollback
 - [`docs/OPERATIONS.md`](docs/OPERATIONS.md) — deployment and incident procedures

--- a/docs/ja/ARCHITECTURE.md
+++ b/docs/ja/ARCHITECTURE.md
@@ -1,0 +1,166 @@
+# アーキテクチャ
+
+[English](../ARCHITECTURE.md) | **日本語**
+
+この文書は、現在のTrade RLアーキテクチャを説明する日本語版です。正式な正典は英語版[`../ARCHITECTURE.md`](../ARCHITECTURE.md)です。不一致が見つかった場合はコードとテストを優先し、続いて英語版と日本語版を修正してください。
+
+## 状態
+
+[`PRODUCTION_READINESS.md`](PRODUCTION_READINESS.md)が証拠付きで完了するまで、Productionは**NO-GO**です。
+
+## 原則
+
+1. 各Production責務に対して、権威ある実装を1つだけ持つ。
+2. 無効なArtifact、状態、schema、認証情報、市場データはfail-closedで拒否する。
+3. 証拠は、1つの正確なBundle digestとGit commitに拘束する。
+4. 学習・評価とServingは、Observationおよび意思決定契約を共有する。
+5. オンラインServingは認証付き・読み取り専用とする。
+6. Registryのversionは不変とし、activationは原子的なpointer更新で行う。
+7. 口座状態は明示的に扱い、Trade Platformがrequestごとに提供する。
+8. 研究結果だけではProduction動作を許可しない。
+
+## システム境界
+
+### Control Plane
+
+オフラインControl Planeは次を担当します。
+
+- データ準備と品質ゲート
+- 学習、PBT、Walk-Forward、sealed holdout評価、統計検査
+- 完全な`ServingBundle`の構築
+- デプロイ証拠の生成と検証
+- 不変Registryへの登録
+- CLIおよびGitHub Actionsによるactivationとrollback
+
+Control Planeはライブシグナルを配信しません。サポート対象interfaceは、CLI commandと信頼済みGitHub Actions workflowです。
+
+### Serving Plane
+
+オンラインServing Planeが公開するのは次だけです。
+
+- `GET /health`
+- `GET /ready`
+- 認証付き`POST /api/signal/latest`
+
+学習、モデル削除、Registry変更、昇格、rollbackは公開しません。
+
+## ServingBundle
+
+Bundleは、決定論的推論に必要な完全な単位です。
+
+```text
+serving_candidate/
+  manifest.json
+  model.zip | ensemble/
+  metadata.json
+  preprocessing.json
+  risk.json
+```
+
+Bundleには次を含めます。
+
+- モデルversionと学習時Git SHA
+- 順序付きsymbol一覧
+- 順序付きの銘柄別feature名とglobal feature名
+- feature正規化とzero-mask設定
+- Observation schemaと次元
+- Serving互換のprogress mode
+- 推論用environment設定
+- post-processing設定
+- guardrailとpre-trade risk設定
+- 評価summary
+- 全ファイルのSHA-256とcanonical bundle digest
+
+Digest、ファイル集合、次元、symbol順序、feature順序、schemaのいずれかが一致しなければ、Bundleを拒否します。
+
+## Registry
+
+唯一のRegistry実装は`mars_lite.serving.registry.ModelRegistry`です。
+
+```text
+registry/
+  versions/<version>/...   不変Bundle
+  active.json              原子的なactive identity
+  activation-history.jsonl
+```
+
+登録処理は、候補を不変versionディレクトリへコピーして再検証します。登録だけではactivationしません。Activationは登録済みBundleを検証し、`active.json`を原子的に置換します。登録またはactivationが失敗した場合、以前のactive versionを維持します。
+
+## 学習・昇格フロー
+
+```text
+データ構築
+  -> 品質・leak検査
+  -> P0
+  -> development data上のPBT
+  -> 複数fold Walk-Forwardとcost sensitivity
+  -> 最終学習
+  -> sealed holdoutとbaseline gate
+  -> 完全なServingBundle候補
+  -> 不変登録
+  -> Bundle digestに拘束されたShadow／Canary証拠
+  -> deployment gate
+  -> Environment承認
+  -> 原子的activation
+```
+
+学習が成功しても、候補を登録するだけでactivationは行いません。
+
+## オンライン推論フロー
+
+Trade Platformは次を送信します。
+
+- request IDとmarket snapshot identity
+- Bundleのsymbol順序に対応する現在weight
+- portfolio value、day-start value、peak value
+- 連続損失数とturnover状態
+- pending order
+- model schemaが要求する場合のdisagreementおよびrisk-state値
+
+Serving Planeは次を実行します。
+
+```text
+認証
+  -> request IDをclaimし、replayを拒否
+  -> キャッシュ済みの不変feature snapshotを取得
+  -> symbolとfeature schemaを検証
+  -> preprocessingを復元
+  -> 実際の現在positionでbuild_observation
+  -> policy.predict
+  -> DecisionPipeline
+  -> 実注文turnoverを使うstateful guardrails
+  -> pending-order-aware PreTradeRiskVerifier
+  -> responseと構造化audit event
+```
+
+Trade Platformが最終的な執行・risk enforcement境界です。Responseが有効で、risk判定がapprovedでない限り、注文を実行してはいけません。
+
+## 共有契約
+
+- `mars_lite.env.observation.build_observation` — 共通Observation Builder
+- `mars_lite.trading.pipeline.DecisionPipeline` — actionからtargetまでの共通path
+- `mars_lite.trading.guardrails.evaluate_guardrails` — 実口座状態の評価
+- `mars_lite.trading.pre_trade_risk.PreTradeRiskVerifier` — delta、pending order、liquidity、restriction、reduce-onlyの評価
+- `mars_lite.serving.runtime.ServingRuntime` — キャッシュload、安全なhot-swap、推論orchestration、readinessの所有者
+
+## 可用性とhot-swap
+
+Servingは、現在load済みBundleを維持したまま新しいactive Bundleをloadします。Digest、schema、preprocessing、model load、readiness checkがすべて成功した後にだけ、新Bundleを公開します。不正な新Bundleは、既存の健全なin-memory Bundleを置き換えず、readinessを`degraded`にします。健全なBundleが1つもない場合、signal routeは`503`を返し、実行可能なweightを返しません。
+
+## 信頼境界
+
+Control processとServing processは別のcredentialを使用します。ServingはBearer token、明示的origin allowlist、既定のlocal bind、audit logging、request replay防止を使用します。RegistryへのwriteにはControl Plane identityが必要です。Secretはdeployment secret managementから供給し、repositoryへ保存しません。
+
+## Package map
+
+- `mars_lite/data`, `mars_lite/features` — データ・feature構築
+- `mars_lite/env`, `mars_lite/learning` — RL environmentと学習
+- `mars_lite/eval` — 評価とreplay simulation
+- `mars_lite/pipeline` — オフラインorchestration
+- `mars_lite/serving` — Bundle、Registry、契約、runtime、audit、feature snapshot
+- `mars_lite/server` — 読み取り専用Serving HTTP境界とdeployment gate
+- `mars_lite/trading` — execution cost、decision processing、guardrail、pre-trade risk
+
+## 明示的な非保証事項
+
+CI合格は、テスト対象の契約が成立していることを示すだけです。収益性やProduction readinessを証明しません。合成結果、過去backtest、単発実験は、ライブ取引の許可ではありません。

--- a/docs/ja/DECISIONS.md
+++ b/docs/ja/DECISIONS.md
@@ -1,0 +1,63 @@
+# アーキテクチャ上の意思決定
+
+[English](../DECISIONS.md) | **日本語**
+
+## ADR-001: Control PlaneとServing Planeを分離する
+
+**決定:** 学習、証拠生成、Registry変更、activation、rollbackはオフラインで実行する。オンラインServingは認証付き・読み取り専用とする。
+
+**理由:** 権限付き管理機能とライブsignal配信を統合すると、不要な信頼境界と障害境界が生じるため。
+
+## ADR-002: 不変Bundle Registryを1つだけ使用する
+
+**決定:** `mars_lite.serving.registry.ModelRegistry`をmodel lifecycleの唯一の権威とする。登録済みversion directoryは不変で、`active.json`を唯一のactive pointerとする。
+
+**理由:** 複数Registryと固定file nameにより、昇格identityとServing identityが乖離していたため。
+
+## ADR-003: 登録とactivationを分離する
+
+**決定:** 学習処理は候補を構築・登録できるが、activationしてはならない。Activationにはdeployment証拠とEnvironment承認が必要である。
+
+**理由:** 学習processの成功はdeployment許可ではないため。
+
+## ADR-004: 推論依存関係をすべてBundle化する
+
+**決定:** Model、symbol、feature schema、preprocessing、observation contract、post-processing、risk設定、Git SHA、metrics identity、digestを1つのServingBundleに含める。
+
+**理由:** 不完全なmetadataにより、train／serve間の分布とshapeが一致しない問題が発生したため。
+
+## ADR-005: Policy推論前に実positionを使用する
+
+**決定:** `predict()`より前に、認証済みの現在口座状態からpolicy observationを構築する。
+
+**理由:** 推論後にのみprevious weightを適用する方式は、学習時observation contractに違反するため。
+
+## ADR-006: 決定論的なonline progressを使用する
+
+**決定:** Production互換modelはobservation progress modeとして`zero`を使用する。オンラインで同等状態を設計・検証するまでは、episode相対progressを研究専用とする。
+
+**理由:** 任意の学習episode位置は、stateless online inferenceで再現できないため。
+
+## ADR-007: Trade Platformを執行権威とする
+
+**決定:** Servingはguardrailとpre-trade risk判定を計算し、Trade Platformが最終enforcementと注文執行を行う。
+
+**理由:** Servingは権威あるexchange connectionやaccount storeを持たず、注文を実行したと主張してはいけないため。
+
+## ADR-008: Serving状態を最小限にする
+
+**決定:** 口座状態は認証済みrequestごとに受け取る。SQLiteにはaudit eventとreplay claimだけを保存する。
+
+**理由:** Serving内部にportfolioの真実を複製すると、reconciliationとstale stateのriskが生じるため。
+
+## ADR-009: Known-good serviceを維持しながらfail-closedにする
+
+**決定:** 無効requestには実行可能signalを返さない。無効な新Bundleは健全なin-memory Bundleを置き換えず、readinessを`degraded`にする。
+
+**理由:** 可用性を完全性より優先してはならないが、不正候補によって検証済み既存serviceまで不要に停止させるべきではないため。
+
+## ADR-010: 正典ドキュメントを1系列にする
+
+**決定:** `docs/ARCHITECTURE.md`を唯一のアーキテクチャ正典とする。研究結果は分離して保存し、Productionを許可できないものとする。
+
+**理由:** 過去文書では、歴史的実験、将来構想、実行可能な現行動作が混在していたため。

--- a/docs/ja/MODEL_LIFECYCLE.md
+++ b/docs/ja/MODEL_LIFECYCLE.md
@@ -1,0 +1,69 @@
+# モデルライフサイクル
+
+[English](../MODEL_LIFECYCLE.md) | **日本語**
+
+## 1. 学習と評価
+
+Control Planeは1つのfeature setを構築し、可能な場合はdevelopment dataとsealed holdout dataを分離します。そのうえでP0、PBT、Walk-Forward／cost sensitivity、最終学習、baseline比較、必要に応じた統計的有意性検査を実行します。
+
+Gateに失敗した実行から、昇格可能なmodelを生成してはいけません。`--force`は研究専用であり、deploymentを許可しません。
+
+## 2. 候補を構築する
+
+合格したrunは、model、順序付きfeature schema、preprocessing、observation contract、post-processing、risk設定、評価identity、Git SHA、digestを含む完全な`ServingBundle`を1つ作成します。
+
+Production互換modelは、observation progress modeとして`zero`を使用します。Episode相対progressはオンラインで再構築できないため、Bundle検証時に拒否されます。
+
+## 3. 登録する
+
+```bash
+uv run python scripts/manage_registry.py \
+  --registry-dir <registry> register <candidate-directory>
+```
+
+登録処理:
+
+1. Source Bundleを検証する。
+2. 同階層のtemporary directoryへcopyする。
+3. Copy後のBundleを再検証する。
+4. `versions/<version>`へ原子的にrenameする。
+5. `active.json`は変更しない。
+
+同じversion・同じdigestの再登録は、management CLI上でidempotentです。同じversionを異なる内容に再利用する操作は拒否されます。
+
+## 4. 証拠を生成する
+
+ShadowおよびCanary評価は、正確なmodel version、Git SHA、bundle identity、source run、必要に応じたparent evidenceを参照しなければなりません。Production証拠には、Canary結果、incident状態、approval ticket、Environment承認を追加します。
+
+## 5. Activation
+
+Activationは、Gate成功後のdeployment Control Planeでのみ実行します。
+
+```bash
+uv run python scripts/manage_registry.py \
+  --registry-dir <registry> activate <version> \
+  --evidence-identity <trusted-identity>
+```
+
+Activationは登録済みBundleを検証し、`active.json`を原子的に置換します。Modelファイルをcopyまたはrenameしません。
+
+## 6. Serving
+
+`ServingRuntime`はactive identityを読み、現在load中のversionを維持したまま新Bundleを検証・loadし、readiness check成功後にだけin-memory referenceを切り替えます。
+
+ResponseにはServing中のmodel versionとbundle digestを含め、callerがidentityを検証できるようにします。
+
+## 7. Rollback
+
+Rollbackは、登録済みのknown-good versionを選択し、`active.json`を原子的に変更します。Servingは同じ検証済みhot-swap pathを通じて、そのversionへ戻ります。
+
+## Registry不変条件
+
+- Registry実装は1つだけ
+- active pointerは1つだけ
+- version directoryは不変
+- すべての境界でdigestを検証
+- 登録とactivationは別操作
+- activation失敗時は以前のpointerを維持
+- Served identityはactive identityと一致
+- Serving Planeはmodel lifecycle変更操作を公開しない

--- a/docs/ja/OPERATIONS.md
+++ b/docs/ja/OPERATIONS.md
@@ -1,0 +1,101 @@
+# 運用
+
+[English](../OPERATIONS.md) | **日本語**
+
+[`PRODUCTION_READINESS.md`](PRODUCTION_READINESS.md)が完了するまで、Productionは**NO-GO**です。
+
+## Control Plane実行
+
+```bash
+uv run python scripts/run_pipeline.py \
+  --source postgres \
+  --git-sha "$(git rev-parse HEAD)" \
+  --model-version model-YYYYMMDD-N
+```
+
+P0、Walk-Forward、最終baseline、設定済みsignificance gateのいずれかが失敗した場合、明示的に文書化された研究専用`--force`実行でない限り、pipelineは停止しなければなりません。Forced runを昇格してはいけません。
+
+出力候補は`output/.../candidates/<version>`に配置され、不変Registryへ登録されます。学習処理はactivationを行いません。
+
+## 証拠とデプロイ
+
+CanaryおよびProductionデプロイには、次を含む`deployment-evidence` Artifactを生成した、成功済みのGitHub Actions runが必要です。
+
+- `candidate.json`
+- deployment gateが要求するmodel／reportファイル
+- 正確な不変ServingBundleを含む`serving_candidate/`
+- Shadow、drift、incident、Productionの場合はCanary report
+
+Deployment workflowは、source runの成功、Git SHA、model version、report hash、bundle digest、証拠lineage、incident、approval ticket、Environment承認を検証します。その後、stageごとの`TRADE_RL_REGISTRY_DIR`で指定されたRegistryへ、正確な`serving_candidate/`を登録し、原子的にactivationします。
+
+## Serving開始
+
+必要なsecretおよび設定:
+
+```text
+TRADE_RL_SERVING_TOKEN
+TRADE_RL_REGISTRY_DIR
+TRADE_RL_AUDIT_DB
+TRADE_RL_DATA_DIR
+TRADE_RL_ALLOWED_ORIGINS
+```
+
+起動:
+
+```bash
+uv run python scripts/run_server.py
+```
+
+確認:
+
+```bash
+curl http://127.0.0.1:8001/health
+curl http://127.0.0.1:8001/ready
+```
+
+最後の健全なin-memory Bundleが継続してServingしている間、`/ready`は`degraded`になる場合があります。`unavailable`は、実行可能なsignalを返せないことを意味します。
+
+## Rollback
+
+Registryを確認します。
+
+```bash
+uv run python scripts/manage_registry.py \
+  --registry-dir "$TRADE_RL_REGISTRY_DIR" list
+uv run python scripts/manage_registry.py \
+  --registry-dir "$TRADE_RL_REGISTRY_DIR" show-active
+```
+
+Rollback:
+
+```bash
+uv run python scripts/manage_registry.py \
+  --registry-dir "$TRADE_RL_REGISTRY_DIR" rollback \
+  --target-version <known-good-version>
+```
+
+`/ready`が期待するversionとdigestを報告していることを確認してください。Serving Planeは通常の検証済みhot-swap pathを使用します。運用者がmodelファイルをcopyまたはrenameしてはいけません。
+
+## インシデント対応
+
+1. Trade Platformで新規live riskをブロックする。
+2. request ID、bundle digest、active version、market snapshot ID、Registry状態、audit databaseを保存する。
+3. Exposureがある場合、固有のidempotency keyを使用して、実際のplatform固有emergency adapterを実行する。
+4. Flatten成功を報告する前に、注文取消、reconciliation、reduce-only closure、残存exposureがゼロであることの検証を必須とする。
+5. 登録済みでdigestが有効なknown-good Bundleにのみrollbackする。
+6. 根本原因、証拠、復旧検証が文書化されるまでProductionを無効のまま維持する。
+
+Repository codeには、架空のexchange adapterや運用連絡先を意図的に含めていません。
+
+## GameDay最低要件
+
+GO承認前に、testnetで次を証明する演習を実施してください。
+
+- stale dataでは実行可能なsignalを返さない
+- 無効またはreplayされたrequestはfail-closedになる
+- 破損した候補が健全なBundleを置き換えない
+- activationとrollbackにより、Servingされるversion／digestが期待どおり変化する
+- emergency cancellation／flattenがidempotentで、reconciliation済みである
+- audit recordからeventを再構築できる
+
+Command、timestamp、identity、output、reviewer承認をreadiness checklistへ添付してください。

--- a/docs/ja/PRODUCTION_READINESS.md
+++ b/docs/ja/PRODUCTION_READINESS.md
@@ -1,0 +1,64 @@
+# Production Readiness
+
+[English](../PRODUCTION_READINESS.md) | **日本語**
+
+現在の判断: **NO-GO**。
+
+チェック済み項目には、主張ではなく添付証拠が必要です。Code ownerはrepository内で検証可能な項目を確認できます。運用、法務、セキュリティ、取引所関連の項目は、責任を持つownerによる確認が必要です。
+
+## CodeとCI
+
+- [ ] 正確なrelease headでRuff lintに合格している。
+- [ ] 正確なrelease headでRuff format checkに合格している。
+- [ ] 正確なrelease headでmypyに合格している。
+- [ ] 正確なrelease headで完全なpytest suiteに合格している。
+- [ ] Coverageが70%以上である。
+- [ ] Architecture reviewのCriticalおよびImportant findingが解消されている。
+
+## Artifactとmodel identity
+
+- [ ] 承認されたControl Plane runから、完全なServingBundleが1つ生成されている。
+- [ ] Bundleのmodel version、Git SHA、file digest、canonical digestが記録されている。
+- [ ] ShadowおよびCanary証拠が、正確に同じbundle identityを参照している。
+- [ ] Deployment gateのsource run制限とrelease branch制限が設定されている。
+- [ ] Activation済みRegistry identityが、Servingの返すversion／digestと一致する。
+- [ ] 登録済みknown-good versionへのrollbackが実証されている。
+
+## Serving Plane
+
+- [ ] Servingがhealth、readiness、認証付きsignal routeだけを公開している。
+- [ ] Machine-to-machine tokenとrotation手順が設定されている。
+- [ ] Network bind、proxy、TLS、origin allowlistが設定されている。
+- [ ] 現在positionと口座状態がrequestごとに提供される。
+- [ ] Request IDとmarket snapshot identityが固有で、auditされている。
+- [ ] 破損activation時に、以前の健全なBundleを維持する。
+- [ ] 健全なBundleがない場合、実行可能なweightを含めず`503`を返す。
+
+## Riskと執行
+
+- [ ] Trade Platformが注文前に、返されたpre-trade risk判定を強制する。
+- [ ] Pending order、symbol restriction、liquidity、reduce-only、exposure limitをend-to-endで検証している。
+- [ ] 実取引所／platform用`EmergencyExecutionAdapter`が実装され、review済みである。
+- [ ] Emergency cancellation、reconciliation、reduce-only closure、residual position検査がtestnetで合格している。
+- [ ] Idempotency keyがemergency executionの重複を防止する。
+
+## Deployment governance
+
+- [ ] `shadow`、`canary`、`production` GitHub Environmentが存在する。
+- [ ] Productionに必要な独立reviewerが設定されている。
+- [ ] `TRADE_RL_REGISTRY_DIR`がstageに適したpersistent storageを指している。
+- [ ] 証拠producer identityが信頼され、branch制限されている。
+- [ ] Secretがrepository外に保存され、rotationがテストされている。
+
+## 運用とコンプライアンス
+
+- [ ] On-call、risk、security、complianceの連絡先が実在し、テスト済みである。
+- [ ] Incident severity、escalation、communication手順が承認されている。
+- [ ] 適用jurisdictionとretention periodが、資格を持つownerによって決定されている。
+- [ ] Audit storage、access、backup、deletion policyが承認されている。
+- [ ] Testnet GameDay証拠が添付されている。
+- [ ] 最終運用ownerがGO承認へ署名している。
+
+## GOルール
+
+適用されるすべての項目が証拠付きでチェックされ、未解決のCriticalまたはImportant findingが存在しない場合に限り、ProductionをGOへ変更できます。それまでは、すべての文書とinterfaceで**NO-GO**を維持しなければなりません。

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -1,0 +1,24 @@
+# Trade RL 日本語ドキュメント
+
+[English documentation](../ARCHITECTURE.md) | **日本語**
+
+このディレクトリには、現在の利用者向け正典ドキュメントの日本語版を配置しています。
+
+英語版が正式な正典です。日本語版との間に差異が見つかった場合は、コードとテスト、続いて英語版を優先し、日本語版を修正してください。
+
+## 文書一覧
+
+- [`ARCHITECTURE.md`](ARCHITECTURE.md) — システム境界、ServingBundle、Registry、オンライン推論フロー
+- [`MODEL_LIFECYCLE.md`](MODEL_LIFECYCLE.md) — 学習から登録、証拠、activation、rollbackまで
+- [`OPERATIONS.md`](OPERATIONS.md) — Control Plane実行、デプロイ、Serving起動、インシデント対応
+- [`SECURITY.md`](SECURITY.md) — 認証、Artifact完全性、request完全性、fail-closed条件
+- [`TESTING.md`](TESTING.md) — 必須CI、テスト層、テスト置換方針
+- [`PRODUCTION_READINESS.md`](PRODUCTION_READINESS.md) — 本番GO／NO-GOの証拠付きチェックリスト
+- [`DECISIONS.md`](DECISIONS.md) — 主要なArchitecture Decision Record
+- [`RESEARCH_HISTORY.md`](RESEARCH_HISTORY.md) — 本番判断を変更しない研究履歴
+
+ルートの日本語案内は[`../../README.ja.md`](../../README.ja.md)を参照してください。
+
+## 状態
+
+現在の本番判断は**NO-GO**です。コードやCIの成功だけでライブ取引は許可されません。

--- a/docs/ja/RESEARCH_HISTORY.md
+++ b/docs/ja/RESEARCH_HISTORY.md
@@ -1,0 +1,55 @@
+# 研究履歴
+
+[English](../RESEARCH_HISTORY.md) | **日本語**
+
+この文書は、過去の実験の役割を記録するものです。現行システム要件や収益性の主張を定義する正典ではありません。
+
+## 対象範囲
+
+このrepositoryでは、次を検討してきました。
+
+- synthetic positive／negative control
+- feature predictive powerとleakage診断
+- forecast horizonとtarget定義
+- PPO hyperparameterとbehavioral-cloning warm start
+- multi-timeframe feature encoder
+- post-processing、turnover penalty、no-trade band、volatility targeting
+- seed ensembleとdisagreement scaling
+- rule-basedおよびRL risk overlay
+- Walk-Forward、cost sensitivity、bootstrap比較、replay simulation
+- 履歴制約の異なる複数の公開exchange data source
+
+## 解釈ルール
+
+Data、symbol、date range、target、horizon、decision frequency、fee、execution model、random seed、code revision、evaluation protocolが同一でない限り、過去結果を直接比較してはいけません。
+
+Synthetic returnとSharpe比は、softwareまたはhypothesis診断です。実現可能なlive performanceの推定値ではありません。
+
+Single split、single seed、繰り返し確認したholdout結果はexploratoryです。昇格証拠には、現行のgated Control Planeと正確なServingBundle identityが必要です。
+
+## 重要な過去の教訓
+
+1. 適切なwarmup除外、Walk-Forward評価、繰り返しhorizon／target探索の補正後に、見かけの予測力が消える場合がある。
+2. 高いin-sampleまたはdiagnostic ICだけでは、cost控除後のtrading valueを証明できない。
+3. 固定baselineは1つのsplitで強く見えてもfold全体で失敗する場合がある。RLと同じprotocolで評価しなければならない。
+4. Turnover penalty、smoothing、no-trade bandは、学習action scaleとexecution behaviorの両方を変える。それぞれの効果を分離し、1回のrunから原因を断定してはいけない。
+5. Train／serve parityには、同一model fileだけでなく、完全なobservation、preprocessing、portfolio state、decision pathが必要である。
+6. 公開OHLCVのみのdataには、安定したedgeが不足している可能性がある。定義済みwithdrawal criterionを超えてparameter searchを続けるとselection biasが増える。
+
+## 詳細数値の扱い
+
+過去のMarkdownには、耐久性のあるmachine-readable provenance standardを伴わない、実験固有の数値が多数含まれていました。それらのfileは正典ドキュメントから削除されています。Forensic referenceとしてGit履歴に残っています。
+
+新しい研究証拠は、次を含む不変Artifactとして保存してください。
+
+- commandと完全なconfiguration
+- datasetとtime range identity
+- symbolとsample count
+- 適用可能な場合のGit SHAとbundle digest
+- foldとseedの詳細
+- raw metricとconfidence interval
+- limitation、およびexploratory resultかpromotion evidenceかの区分
+
+## Production境界
+
+この文書内の記録だけでProductionをNO-GOからGOへ変更することはできません。その判断を許可できるのは、[`PRODUCTION_READINESS.md`](PRODUCTION_READINESS.md)の証拠checklistと、承認済みdeployment processだけです。

--- a/docs/ja/SECURITY.md
+++ b/docs/ja/SECURITY.md
@@ -1,0 +1,63 @@
+# セキュリティ
+
+[English](../SECURITY.md) | **日本語**
+
+## 信頼境界
+
+Control PlaneとServing Planeは、別process・別identityとして動作します。
+
+- Control Plane: 権限付き学習、証拠生成、Registry write、activation、rollback
+- Serving Plane: 認証付き・読み取り専用のsignal配信
+- Trade Platform: 権威ある口座状態、注文執行、最終pre-trade enforcement
+
+## 認証とnetwork exposure
+
+`POST /api/signal/latest`には`Authorization: Bearer <token>`が必要です。期待tokenは`TRADE_RL_SERVING_TOKEN`から供給され、constant-timeで比較されます。Credentialがない場合は`401`、不正なcredentialは`403`を返します。
+
+Servingは既定で`127.0.0.1`へbindします。CORSは明示的allowlistを使用します。Credential付きwildcard originは有効化しません。
+
+## Artifact完全性
+
+すべてのServingBundleは、全ファイルのSHA-256 digestとcanonical bundle digestを持ちます。登録、activation、起動、hot-swapの各境界でBundleを再検証します。Version directoryは不変です。
+
+証拠は、model version、Git SHA、bundle identity、source run、evaluation lineageに拘束されなければなりません。候補側が指定するthresholdは信頼しません。
+
+## Request完全性
+
+Trade Platformは固有のrequest IDとmarket snapshot identityを提供します。SQLiteはclaim済みrequest IDと不変audit eventを保存します。同一request IDの再利用は拒否し、異なるpayloadでの再利用はintegrity violationとして扱います。
+
+SQLiteは口座状態のsource of truthではありません。現在positionとrisk stateは、認証済みTrade Platformがrequestごとに送信しなければなりません。
+
+## Fail-closed条件
+
+次の場合、実行可能なweightを返しません。
+
+- Bearer credentialが無効
+- active Bundleが存在しない、または不健全
+- digest、schema、symbol順序、feature順序、observation次元の不一致
+- stale、NaN、all-zero、または不正形式の市場データ
+- 無効な口座値またはpending order
+- request replay
+- guardrailによるflatten／rejection
+- pre-trade risk判定の失敗
+
+Bundle refreshに失敗した場合、以前の健全なin-memory Bundleを維持し、readinessを`degraded`にします。
+
+## Secret
+
+Secret、live endpoint、private key、API key、運用連絡先をcommitしてはいけません。Deployment secret managementとstageごとのGitHub Environmentを使用してください。
+
+## テストで扱う脅威
+
+- path traversalとmanifest改ざん
+- 別modelからの証拠流用
+- non-finiteおよび範囲外metric
+- 無効なfeature maskとschema次元
+- replayされたrequest ID
+- 未認証signal request
+- destructive routeの公開
+- 原子的activation失敗と破損hot-swap候補
+
+## 外部セキュリティ対応
+
+Production承認には、deployment固有のnetwork policy、secret rotation policy、machine identity、reviewer policy、audit retention決定、incident連絡先、GameDay証拠が引き続き必要です。

--- a/docs/ja/TESTING.md
+++ b/docs/ja/TESTING.md
@@ -1,0 +1,70 @@
+# テスト
+
+[English](../TESTING.md) | **日本語**
+
+## 必須CIゲート
+
+すべてのmerge候補は、正確なPR headで次を合格しなければなりません。
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy mars_lite
+uv run pytest --cov=mars_lite --cov-fail-under=70 tests/
+```
+
+以前のcommitで成功したrunは、新しいcommitの検証にはなりません。
+
+## テスト層
+
+### Unit
+
+- ServingBundleのdigest、path、file set、schema検証
+- 不変Registry登録と原子的active pointer
+- 実際の現在weightを使うobservation構築
+- 口座状態とpending orderの検証
+- guardrailのturnover、損失、drawdown計算
+- pre-trade worst-case exposure
+- Bearer認証とreplay store
+
+### Integration
+
+- 候補構築、登録、activation、served identity
+- 破損した候補が以前の健全なruntimeを維持すること
+- policy prediction前に現在positionが含まれること
+- feature正規化、feature mask、symbol順序、global feature順序がBundleと一致すること
+- 読み取り専用Serving routeがdestructive operationを公開しないこと
+- Registry activationより先にdeployment gateが実行されること
+- rollbackによりserved identityがknown-good versionへ戻ること
+
+### Adversarial
+
+- manifest改ざんとpath traversal
+- non-finite metricとthreshold上書き試行
+- concurrent Registry operation
+- 部分的disk copyとactive pointer失敗
+- pending orderの片側約定scenario
+- request replayと競合payload
+- stale、NaN、all-zero市場データ
+
+### 研究・strategy regression
+
+P0、Walk-Forward、replay simulation、baseline、synthetic data、training testはalgorithm regressionの検出に有用です。ただし、成功してもlive profitabilityを証明しません。
+
+## テスト置換方針
+
+基礎となる契約が削除された場合、そのテストを削除できます。ただし、新しい契約に対して同等のsafety coverageを追加しなければなりません。古い実装を存続させるためだけにobsolete behaviorをテストへ残してはいけません。
+
+## Slow test
+
+Full suiteにはCPU負荷の高い学習・評価caseが含まれます。開発中はfocused testを使用できますが、merge可否はcomplete CI suiteとcoverage gateだけで判断します。
+
+## PRに記載する証拠
+
+PR descriptionには次を記載してください。
+
+- 正確なhead SHA
+- CI run ID
+- lint、format、mypy、pytest、coverage結果
+- 未テストの外部integration
+- 残っているProduction blocker

--- a/tests/test_documentation_contract.py
+++ b/tests/test_documentation_contract.py
@@ -13,6 +13,7 @@ NORMATIVE_DOCS = {
     "DECISIONS.md",
     "RESEARCH_HISTORY.md",
 }
+JAPANESE_DOCS = NORMATIVE_DOCS | {"README.md"}
 
 
 def test_normative_documentation_set_is_complete() -> None:
@@ -22,10 +23,26 @@ def test_normative_documentation_set_is_complete() -> None:
     assert (ROOT / "README.md").is_file()
 
 
+def test_japanese_documentation_set_is_complete() -> None:
+    japanese_dir = ROOT / "docs" / "ja"
+    actual = {path.name for path in japanese_dir.glob("*.md")}
+    assert actual == JAPANESE_DOCS
+    assert (ROOT / "README.ja.md").is_file()
+
+
 def test_root_readme_declares_no_go_and_links_architecture() -> None:
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     assert "docs/ARCHITECTURE.md" in readme
     assert "Production: NO-GO" in readme
+    assert "README.ja.md" in readme
+    assert "docs/ja/README.md" in readme
+
+
+def test_japanese_docs_link_to_english_sources() -> None:
+    japanese_dir = ROOT / "docs" / "ja"
+    for name in sorted(NORMATIVE_DOCS):
+        text = (japanese_dir / name).read_text(encoding="utf-8")
+        assert f"../{name}" in text
 
 
 def test_normative_docs_do_not_describe_removed_paths_as_current() -> None:
@@ -44,6 +61,14 @@ def test_normative_docs_do_not_describe_removed_paths_as_current() -> None:
 
 
 def test_production_readiness_remains_no_go() -> None:
-    readiness = (ROOT / "docs" / "PRODUCTION_READINESS.md").read_text(encoding="utf-8")
+    readiness = (ROOT / "docs" / "PRODUCTION_READINESS.md").read_text(
+        encoding="utf-8"
+    )
     assert "Current decision: **NO-GO**" in readiness
     assert "- [ ]" in readiness
+
+    japanese_readiness = (
+        ROOT / "docs" / "ja" / "PRODUCTION_READINESS.md"
+    ).read_text(encoding="utf-8")
+    assert "現在の判断: **NO-GO**" in japanese_readiness
+    assert "- [ ]" in japanese_readiness

--- a/tests/test_documentation_contract.py
+++ b/tests/test_documentation_contract.py
@@ -61,14 +61,12 @@ def test_normative_docs_do_not_describe_removed_paths_as_current() -> None:
 
 
 def test_production_readiness_remains_no_go() -> None:
-    readiness = (ROOT / "docs" / "PRODUCTION_READINESS.md").read_text(
-        encoding="utf-8"
-    )
+    readiness = (ROOT / "docs" / "PRODUCTION_READINESS.md").read_text(encoding="utf-8")
     assert "Current decision: **NO-GO**" in readiness
     assert "- [ ]" in readiness
 
-    japanese_readiness = (
-        ROOT / "docs" / "ja" / "PRODUCTION_READINESS.md"
-    ).read_text(encoding="utf-8")
+    japanese_readiness = (ROOT / "docs" / "ja" / "PRODUCTION_READINESS.md").read_text(
+        encoding="utf-8"
+    )
     assert "現在の判断: **NO-GO**" in japanese_readiness
     assert "- [ ]" in japanese_readiness


### PR DESCRIPTION
## Summary

Adds a complete Japanese edition of the current user-facing normative documentation while preserving the English documents as the source of truth.

### Added

- `README.ja.md`
- `docs/ja/README.md`
- Japanese editions of Architecture, Operations, Security, Model Lifecycle, Testing, Production Readiness, Decisions, and Research History

### Navigation

- adds an English/Japanese language switch to the root README
- every Japanese normative document links back to its English source
- adds a Japanese documentation index

### Contract tests

- verifies the complete Japanese document set exists
- verifies language links are present
- verifies both English and Japanese Production Readiness documents remain NO-GO

The English documentation remains normative. The Japanese documents are complete translations for maintainers and operators.