### PR TITLE
Overhaul RL reward design and decision semantics

### DIFF
--- a/docs/superpowers/plans/2026-07-13-reward-design-overhaul.md
+++ b/docs/superpowers/plans/2026-07-13-reward-design-overhaul.md
@@ -1,0 +1,161 @@
+# Reward Design Overhaul Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Align reward optimization, decision timing, observability, statistical inference, and release metadata for residual and direct-weight RL.
+
+**Architecture:** Keep baseline-residual paired log growth as the primary objective, but make its horizon, state, termination, and inference internally consistent. Refactor direct-weight execution to use the shared interval execution core and express optional turnover aversion in return units inside the reward scale. Gate DSR behind an explicit research-only contract.
+
+**Tech Stack:** Python 3.11+, Gymnasium, NumPy, Stable-Baselines3 PPO, pytest, GitHub Actions.
+
+## Global Constraints
+
+- Preserve exact identity-action parity between residual hybrid and shadow books.
+- Do not alter trend-family, alpha-model, HTF, post-processing, or execution-cost formulas except where required for interval execution reuse.
+- Use excess log returns for all residual optimization and paired statistical decisions.
+- `reward_scale` must be numerical only and must not change the economic objective.
+- Production/release registration remains disabled for residual research runs.
+
+---
+
+### Task 1: Residual gamma contract and metadata
+
+**Files:**
+- Modify: `mars_lite/pipeline/cli.py`
+- Modify: `mars_lite/pipeline/training_engine.py`
+- Modify: `mars_lite/pipeline/residual_pipeline.py`
+- Modify: `mars_lite/pipeline/residual_walk_forward.py`
+- Test: `tests/test_residual_reward_contract.py`
+- Test: `tests/test_residual_wf_config.py`
+
+**Interfaces:**
+- Produces: `resolve_training_gamma(action_mode: str, gamma: float, allow_low_residual_gamma: bool) -> float`
+- Produces CLI flag: `--allow-low-residual-gamma`
+
+- [ ] Write tests asserting residual default gamma is `0.99`, residual gamma below `0.95` fails without the override, direct gamma remains configurable, and manifests/reports record the effective value.
+- [ ] Run the focused tests and confirm they fail for the missing contract.
+- [ ] Implement gamma resolution in one shared function and route all residual training and walk-forward configuration through it.
+- [ ] Run the focused tests and existing residual configuration tests.
+- [ ] Commit.
+
+### Task 2: Residual paired-state observation and termination
+
+**Files:**
+- Modify: `mars_lite/env/baseline_residual_env.py`
+- Modify: `mars_lite/eval/relative_evaluation.py`
+- Test: `tests/test_baseline_residual_env.py`
+- Test: `tests/test_residual_reward_contract.py`
+
+**Interfaces:**
+- Residual per-symbol observation appends `hybrid_weight - shadow_weight`.
+- Residual global observation appends log wealth ratio, shadow drawdown, shadow gross, and turnover excess.
+- Environment constructor adds `hybrid_insolvency_penalty: float = 1.0` in unscaled log-return units.
+- `info` adds `hybrid_insolvent`, `shadow_insolvent`, and `rollout_valid`.
+
+- [ ] Write tests for observation layout, exact identity parity, hybrid-only penalty, shadow-only no-penalty termination, and fail-closed evaluation.
+- [ ] Run tests and confirm expected failures.
+- [ ] Add paired state to the residual observation without changing the direct schema.
+- [ ] Replace the fixed `-reward_scale` terminal reward with realized paired reward plus hybrid-only penalty.
+- [ ] Make relative evaluation reject invalid shadow-insolvent rollouts.
+- [ ] Run focused and parity tests.
+- [ ] Commit.
+
+### Task 3: Log-return statistical alignment
+
+**Files:**
+- Modify: `mars_lite/eval/relative_evaluation.py`
+- Modify: `mars_lite/learning/relative_val_selection.py`
+- Test: `tests/test_relative_evaluation.py`
+- Test: `tests/test_relative_val_selection.py`
+
+**Interfaces:**
+- Produces: `excess_log_return_series(hybrid_returns, shadow_returns) -> np.ndarray`
+- `paired.mean_base_bar_excess` is retained for compatibility but becomes the mean excess log return and adds `mean_base_bar_simple_excess` as diagnostic-only.
+
+- [ ] Write tests with non-small returns where simple differences and log differences diverge.
+- [ ] Confirm checkpoint blocks and bootstrap currently use the wrong quantity.
+- [ ] Implement one shared excess-log series helper and use it for validation blocks, bootstrap, and paired means.
+- [ ] Run focused tests.
+- [ ] Commit.
+
+### Task 4: Direct reward scale invariance
+
+**Files:**
+- Modify: `mars_lite/env/portfolio_env.py`
+- Modify: `mars_lite/pipeline/cli.py`
+- Modify: `mars_lite/pipeline/training_engine.py`
+- Test: `tests/test_portfolio_reward_contract.py`
+- Test: `tests/test_target_wiring.py`
+
+**Interfaces:**
+- `PortfolioTradingEnv(..., turnover_penalty_rate: float = 0.0)`.
+- Deprecated alias `lambda_turnover` is accepted only when `turnover_penalty_rate` is not supplied and is converted as `lambda_turnover / reward_scale`.
+- CLI adds `--turnover-penalty-rate`; `--lambda-turnover` defaults to `None` and is deprecated.
+
+- [ ] Write tests showing doubling reward scale doubles reward but leaves implied turnover-return penalty unchanged.
+- [ ] Write tests for alias conversion and mutually exclusive CLI/config use.
+- [ ] Confirm failures.
+- [ ] Implement the return-unit penalty inside the reward scale and configuration translation.
+- [ ] Run focused wiring and environment tests.
+- [ ] Commit.
+
+### Task 5: Direct interval execution semantics
+
+**Files:**
+- Modify: `mars_lite/env/portfolio_env.py`
+- Reuse: `mars_lite/env/market_execution_core.py`
+- Test: `tests/test_portfolio_interval_execution.py`
+- Test: `tests/test_portfolio_env.py`
+
+**Interfaces:**
+- One `step(action)` advances `min(decision_every, remaining_episode_bars)` base bars.
+- `info` adds `bars_advanced`, `interval_net_return`, `interval_log_return`, `interval_cost`, and `decision_step_index`.
+- Entry turnover and cost are applied once per decision interval.
+
+- [ ] Write deterministic tests proving full interval advancement, one entry cost, funding on each bar, one reward, and correct truncation.
+- [ ] Confirm the current ignored-action behavior fails the tests.
+- [ ] Refactor direct state to use `BookState` and `MarketExecutionCore` while preserving existing public metrics and info compatibility.
+- [ ] Compute reward from interval log return and interval turnover penalty.
+- [ ] Run all direct environment, baseline, and pipeline tests.
+- [ ] Commit.
+
+### Task 6: DSR research-only boundary
+
+**Files:**
+- Modify: `mars_lite/env/portfolio_env.py`
+- Modify: `mars_lite/pipeline/cli.py`
+- Modify: `mars_lite/pipeline/training_engine.py`
+- Modify: `mars_lite/pipeline/production_pipeline.py`
+- Test: `tests/test_dsr_reward_contract.py`
+- Test: `tests/test_candidate_eligibility.py`
+
+**Interfaces:**
+- CLI flag `--experimental-dsr`.
+- Environment options `experimental_dsr: bool = False`, `dsr_clip: float = 10.0`.
+- DSR state `A` and `B` is included in the observation only when enabled.
+- Release eligibility is false whenever experimental DSR is enabled.
+
+- [ ] Write tests that old implicit DSR activation is rejected, explicit activation enriches observation, clips rewards, and disqualifies registration.
+- [ ] Confirm failures.
+- [ ] Implement the explicit boundary and remove in-episode reward-mode switching from production paths.
+- [ ] Run focused tests.
+- [ ] Commit.
+
+### Task 7: Documentation, manifests, and full verification
+
+**Files:**
+- Modify: `docs/BASELINE_RESIDUAL_RL.md`
+- Modify: `docs/ja/BASELINE_RESIDUAL_RL.md`
+- Modify: `README.md`
+- Modify: `README_ja.md`
+- Modify: relevant manifest/report builders
+- Modify: `.github/workflows/ci.yml` only if new focused tests are not already covered by the full suite.
+
+- [ ] Update user-facing formulas, gamma policy, observation state, terminal semantics, direct penalty units, interval transitions, and DSR boundary.
+- [ ] Add resolved reward semantics to manifests and reports.
+- [ ] Run formatting/lint checks configured by the repository.
+- [ ] Run the focused reward contract suite.
+- [ ] Run the complete pytest suite.
+- [ ] Run or inspect GitHub Actions for the branch/PR and fix every failure.
+- [ ] Review the final diff against every requirement in the design spec.
+- [ ] Open a draft pull request with validation evidence.

--- a/docs/superpowers/specs/2026-07-13-reward-design-overhaul-design.md
+++ b/docs/superpowers/specs/2026-07-13-reward-design-overhaul-design.md
@@ -1,0 +1,117 @@
+# Reward Design Overhaul Design
+
+## Objective
+
+Make reward optimization, execution timing, validation, and release evaluation mathematically consistent across the baseline-residual and legacy direct-weight research paths.
+
+The baseline-residual path remains the preferred architecture. The direct-weight path remains available for diagnostics and comparison, but its reward scaling and decision timing must no longer alter the economic objective accidentally.
+
+## Baseline-residual reward
+
+The environment continues to optimize paired excess log growth:
+
+```text
+excess_log_return = log(hybrid_value_after / hybrid_value_before)
+                  - log(shadow_value_after / shadow_value_before)
+reward = reward_scale * excess_log_return
+```
+
+The default residual discount factor becomes `0.99`. The CLI rejects residual training with `gamma < 0.95` unless an explicit research-only override is supplied. This preserves the additive wealth-ratio interpretation over multi-step episodes while still permitting controlled ablations.
+
+Reward scaling is numerical only. It must not change costs, turnover preferences, risk limits, or candidate selection.
+
+## Residual observability
+
+The residual observation includes the state needed to explain the paired reward:
+
+- hybrid minus shadow weights for each symbol;
+- log hybrid-to-shadow wealth ratio;
+- shadow drawdown;
+- shadow gross exposure;
+- cumulative hybrid-minus-shadow turnover.
+
+These fields are added only to the residual observation schema. The direct observation schema and serving contract remain unchanged.
+
+## Residual termination
+
+Hybrid insolvency and shadow insolvency are handled separately.
+
+- Hybrid insolvency: preserve the realized paired excess log return for the interval, then add a configurable hybrid-insolvency penalty.
+- Shadow insolvency: terminate and mark the episode invalid with `shadow_insolvent=True`; do not assign an uncontrollable fixed penalty to the agent.
+- Both conditions must be exposed in `info`.
+
+The evaluation layer fails closed when a shadow-insolvent rollout is encountered.
+
+## Statistical alignment
+
+Checkpoint selection, paired bootstrap inference, candidate selection, and reported excess performance use the same base quantity: per-base-bar excess log return.
+
+Simple-return differences remain available only as descriptive diagnostics and never drive selection or significance tests.
+
+## Direct-weight reward
+
+The direct reward becomes:
+
+```text
+reward = reward_scale * (interval_net_log_return - turnover_penalty_rate * interval_turnover)
+```
+
+`turnover_penalty_rate` is expressed in return units per unit turnover. Changing `reward_scale` must not change the implied economic turnover penalty.
+
+The legacy `lambda_turnover` CLI option remains as a deprecated alias for one release cycle, but is converted explicitly to `turnover_penalty_rate` and cannot be combined with the new option.
+
+The default direct turnover penalty becomes zero because the execution model already includes fee, spread, and nonlinear impact costs. Nonzero values are research-only stress assumptions.
+
+## Direct decision intervals
+
+One direct environment action advances one complete `decision_every` interval, exactly as in the residual environment.
+
+- The action is processed once at the start of the interval.
+- Entry execution cost is charged once.
+- The target is held for the interval.
+- Funding and mark-to-market returns accrue on every base bar.
+- One aggregated reward and one transition are returned.
+
+This removes ignored-action transitions and makes reward attribution valid when `decision_every > 1`.
+
+## DSR boundary
+
+Differential Sharpe reward is removed from the production/control-plane training path. It remains available only through an explicit `--experimental-dsr` research flag.
+
+When enabled:
+
+- `dsr_A` and `dsr_B` are included in the observation;
+- the DSR reward is clipped to a configurable finite bound;
+- DSR cannot be switched on or off during an episode;
+- checkpoint and release reports are marked experimental and ineligible for registration.
+
+## Configuration and manifests
+
+Resolved reports and manifests record:
+
+- requested and effective gamma;
+- reward scale;
+- direct turnover penalty rate;
+- residual hybrid-insolvency penalty;
+- whether experimental DSR was enabled;
+- decision interval semantics version `interval_v2`.
+
+## Tests
+
+The implementation must include regression tests proving:
+
+1. residual default gamma is at least 0.95 and defaults to 0.99;
+2. residual observation exposes paired state and identity action remains exact;
+3. shadow-only insolvency does not apply the hybrid penalty and evaluation fails closed;
+4. paired inference uses excess log returns;
+5. direct reward economics are invariant to reward scaling;
+6. direct `decision_every > 1` advances a full interval and charges one entry cost;
+7. DSR is unavailable without the explicit research flag and its hidden state is observable when enabled;
+8. existing train/eval/serve parity and residual identity contracts remain green.
+
+## Non-goals
+
+- No new alpha model or feature engineering.
+- No change to baseline trend construction.
+- No production registration of residual candidates.
+- No automatic merge into `main` without passing CI and review.

--- a/tests/test_reward_design_overhaul.py
+++ b/tests/test_reward_design_overhaul.py
@@ -1,0 +1,205 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from mars_lite.env.baseline_residual_env import BaselineResidualTradingEnv
+from mars_lite.env.portfolio_env import PortfolioTradingEnv
+from mars_lite.eval import relative_evaluation
+from mars_lite.features.feature_pipeline import FeatureSet
+from mars_lite.pipeline import production_pipeline, training_engine
+from mars_lite.pipeline.cli import build_parser
+from mars_lite.trading.post_processor import make_legacy_processor
+from mars_lite.trading.trend_family import TrendFamily, TrendFamilyConfig
+
+
+def _feature_set(
+    *, n_bars: int = 160, n_symbols: int = 2, alternating: bool = False
+) -> FeatureSet:
+    timestamps = np.datetime64("2026-01-01T00:00:00", "ns") + np.arange(
+        n_bars
+    ) * np.timedelta64(1, "h")
+    if alternating:
+        step_returns = np.where(np.arange(n_bars - 1) % 2 == 0, 0.02, -0.015)
+        one = np.concatenate([[1.0], np.cumprod(1.0 + step_returns)])
+    else:
+        one = np.ones(n_bars, dtype=np.float64)
+    close = np.column_stack([one * (1.0 + 0.001 * idx) for idx in range(n_symbols)])
+    return FeatureSet(
+        symbols=[f"S{idx}" for idx in range(n_symbols)],
+        timestamps=timestamps,
+        features=np.zeros((n_bars, n_symbols, 1), dtype=np.float32),
+        global_features=np.zeros((n_bars, 1), dtype=np.float32),
+        close=close,
+        open_next=close.copy(),
+        funding_rate=np.zeros_like(close),
+        feature_names=["dummy"],
+        global_feature_names=["dummy_global"],
+    )
+
+
+def _residual_env(**overrides: object) -> BaselineResidualTradingEnv:
+    kwargs: dict[str, object] = {
+        "trend_family": TrendFamily(
+            TrendFamilyConfig(
+                fast_lookback=12,
+                base_lookback=24,
+                slow_lookback=48,
+                rebalance_every=12,
+            )
+        ),
+        "decision_every": 4,
+        "episode_bars": 48,
+        "post_processor": make_legacy_processor(0.0),
+        "min_trade_delta": 0.0,
+        "fee_rate": 0.0,
+        "spread_rate": 0.0,
+        "impact_rate": 0.0,
+    }
+    kwargs.update(overrides)
+    return BaselineResidualTradingEnv(_feature_set(), **kwargs)
+
+
+def test_pipeline_default_gamma_is_long_horizon() -> None:
+    args = build_parser().parse_args([])
+    assert args.gamma == pytest.approx(0.99)
+
+
+def test_residual_low_gamma_requires_explicit_override() -> None:
+    with pytest.raises(ValueError, match="residual gamma"):
+        training_engine.resolve_training_gamma(
+            "baseline-residual", 0.5, allow_low_residual_gamma=False
+        )
+    assert training_engine.resolve_training_gamma(
+        "baseline-residual", 0.5, allow_low_residual_gamma=True
+    ) == pytest.approx(0.5)
+    assert training_engine.resolve_training_gamma(
+        "direct", 0.5, allow_low_residual_gamma=False
+    ) == pytest.approx(0.5)
+
+
+def test_residual_observation_exposes_paired_state() -> None:
+    env = _residual_env()
+    obs, _ = env.reset(options={"start_idx": 72})
+
+    assert env.n_per_symbol == env.fs.n_features + 6
+    assert env.n_global == env.fs.global_features.shape[1] + 7
+    assert obs.shape == env.observation_space.shape
+    np.testing.assert_allclose(obs[-4:], np.zeros(4), atol=1e-12)
+
+
+def test_shadow_only_insolvency_does_not_apply_hybrid_penalty() -> None:
+    env = _residual_env(reward_scale=1.0, hybrid_insolvency_penalty=5.0)
+    env.reset(options={"start_idx": 72})
+    env.shadow.portfolio_value = 1e-12
+
+    _, reward, terminated, _, info = env.step(np.zeros(2))
+
+    assert terminated is True
+    assert info["shadow_insolvent"] is True
+    assert info["hybrid_insolvent"] is False
+    assert info["rollout_valid"] is False
+    assert reward > -5.0
+
+
+def test_excess_log_return_series_is_the_paired_statistic() -> None:
+    hybrid = np.asarray([0.50, -0.20], dtype=np.float64)
+    shadow = np.asarray([0.40, -0.10], dtype=np.float64)
+    expected = np.log1p(hybrid) - np.log1p(shadow)
+
+    actual = relative_evaluation.excess_log_return_series(hybrid, shadow)
+
+    np.testing.assert_allclose(actual, expected)
+    assert not np.allclose(actual, hybrid - shadow)
+
+
+def test_direct_turnover_penalty_is_invariant_to_reward_scale() -> None:
+    fs = _feature_set(n_bars=12, n_symbols=1)
+
+    def run(scale: float) -> float:
+        env = PortfolioTradingEnv(
+            fs,
+            episode_bars=6,
+            fee_rate=0.0,
+            spread_rate=0.0,
+            impact_rate=0.0,
+            min_trade_delta=0.0,
+            post_processor=make_legacy_processor(0.0),
+            turnover_penalty_rate=0.001,
+            reward_scale=scale,
+        )
+        env.reset(options={"start_idx": 0})
+        _, reward, _, _, _ = env.step(np.asarray([0.5]))
+        return reward
+
+    reward_100 = run(100.0)
+    reward_200 = run(200.0)
+
+    assert reward_100 == pytest.approx(-0.05)
+    assert reward_200 == pytest.approx(-0.10)
+    assert reward_100 / 100.0 == pytest.approx(reward_200 / 200.0)
+
+
+def test_direct_step_advances_one_complete_decision_interval() -> None:
+    fs = _feature_set(n_bars=12, n_symbols=1, alternating=True)
+    env = PortfolioTradingEnv(
+        fs,
+        episode_bars=6,
+        decision_every=3,
+        fee_rate=0.0,
+        spread_rate=0.0,
+        impact_rate=0.0,
+        min_trade_delta=0.0,
+        post_processor=make_legacy_processor(0.0),
+        turnover_penalty_rate=0.0,
+    )
+    env.reset(options={"start_idx": 0})
+
+    _, _, _, _, info = env.step(np.asarray([1.0]))
+
+    assert env.t == 3
+    assert info["bars_advanced"] == 3
+    assert info["decision_step_index"] == 1
+    assert len(env._returns_history) == 3
+    assert env.n_trades == 1
+
+
+def test_dsr_requires_explicit_research_mode_and_exposes_state() -> None:
+    fs = _feature_set(n_bars=12, n_symbols=1, alternating=True)
+    with pytest.raises(ValueError, match="experimental"):
+        PortfolioTradingEnv(fs, use_dsr=True)
+
+    env = PortfolioTradingEnv(
+        fs,
+        episode_bars=6,
+        fee_rate=0.0,
+        spread_rate=0.0,
+        impact_rate=0.0,
+        min_trade_delta=0.0,
+        post_processor=make_legacy_processor(0.0),
+        experimental_dsr=True,
+        dsr_clip=0.25,
+        reward_scale=1.0,
+    )
+    obs, _ = env.reset(options={"start_idx": 0})
+    assert env.n_global == fs.global_features.shape[1] + 5
+    np.testing.assert_allclose(obs[-2:], np.zeros(2), atol=1e-12)
+
+    for action in (np.asarray([1.0]), np.asarray([-1.0]), np.asarray([1.0])):
+        obs, reward, terminated, truncated, _ = env.step(action)
+        assert abs(reward) <= 0.25
+        if terminated or truncated:
+            break
+    assert np.isfinite(obs).all()
+
+
+def test_experimental_dsr_disqualifies_release_intent() -> None:
+    args = SimpleNamespace(
+        force=False,
+        skip_p0=False,
+        skip_wf=False,
+        skip_gate=False,
+        experimental_dsr=True,
+    )
+    reasons = production_pipeline.release_disqualifying_reasons(args)
+    assert "experimental_dsr" in reasons


### PR DESCRIPTION
Superseded by the residual-core rebuild merged in #13. The old branch targeted deleted `mars_lite` and direct-action code, so continuing it would reintroduce obsolete architecture. Reward hardening is being restarted from the current `trade_rl` main branch.