### PR TITLE
Harden residual reward semantics

### DIFF
--- a/docs/superpowers/plans/2026-07-13-residual-reward-hardening.md
+++ b/docs/superpowers/plans/2026-07-13-residual-reward-hardening.md
@@ -1,0 +1,88 @@
+# Residual Reward Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the rebuilt residual RL core optimize, observe, terminate, and statistically evaluate the same paired excess-log-growth objective.
+
+**Architecture:** Add a strict long-horizon gamma contract at the typed training boundary, enrich only the residual observation with paired shadow-relative state, separate hybrid and shadow insolvency in the environment and reward function, and centralize paired per-period log excess in evaluation. The removed direct-action and DSR paths remain absent.
+
+**Tech Stack:** Python 3.12, dataclasses, NumPy, Gymnasium, Stable-Baselines3, pytest, Hypothesis, Ruff, mypy, Import Linter.
+
+## Global Constraints
+
+- Production remains **NO-GO**.
+- Preserve exact zero-action baseline identity.
+- Do not reintroduce `mars_lite`, direct-action PPO, turnover reward penalties, DSR, or compatibility adapters.
+- One action continues to control one complete decision interval.
+- Reward scaling remains numerical only.
+- Paired statistical decisions use excess log returns.
+
+---
+
+### Task 1: Lock the residual gamma contract
+
+**Files:**
+- Modify: `trade_rl/rl/training.py`
+- Modify: `trade_rl/cli/app.py`
+- Modify: `tests/rl/test_ensemble_training.py`
+- Modify: `tests/cli/test_cli.py`
+
+**Interfaces:**
+- Produces constants `DEFAULT_RESIDUAL_GAMMA = 0.99` and `MIN_RESIDUAL_GAMMA = 0.95`.
+- Extends `ResidualTrainingConfig` with `allow_low_gamma: bool = False`.
+- Adds CLI option `--allow-low-gamma`.
+
+- [ ] Add failing tests for the default, minimum, explicit override, and backend propagation.
+- [ ] Run the PR CI and confirm RED is caused by the missing contract.
+- [ ] Implement the typed validation and CLI v2 output.
+- [ ] Run focused tests and commit.
+
+### Task 2: Expose paired state and separate insolvency
+
+**Files:**
+- Modify: `trade_rl/rl/observations.py`
+- Modify: `trade_rl/rl/rewards.py`
+- Modify: `trade_rl/rl/environment.py`
+- Modify: `tests/rl/test_environment_timing.py`
+
+**Interfaces:**
+- `build_observation` consumes `hybrid` and `shadow` books.
+- `ResidualMarketEnvConfig` adds `hybrid_insolvency_penalty: float = 1.0`.
+- `relative_interval_reward` consumes `hybrid_insolvent` and `hybrid_insolvency_penalty`.
+- Environment `info` adds `hybrid_insolvent`, `shadow_insolvent`, and `rollout_valid`.
+
+- [ ] Add failing tests for paired layout, reset zeros, identity parity, hybrid-only penalty, and shadow-only invalidity without penalty.
+- [ ] Confirm RED in CI.
+- [ ] Implement paired observation fields and terminal semantics.
+- [ ] Run focused tests and commit.
+
+### Task 3: Align paired inference with the reward quantity
+
+**Files:**
+- Modify: `trade_rl/evaluation/comparisons.py`
+- Modify: `tests/evaluation/test_comparisons.py`
+
+**Interfaces:**
+- `mean_period_excess` becomes mean period excess log return.
+- `PairedComparison` adds `mean_period_simple_excess` for descriptive arithmetic differences.
+- Bootstrap input is the period excess-log-return series.
+
+- [ ] Add a failing large-return test where arithmetic and log differences diverge.
+- [ ] Confirm RED in CI.
+- [ ] Implement log-difference bootstrap and diagnostic arithmetic mean.
+- [ ] Run evaluation tests and commit.
+
+### Task 4: Document and verify the complete contract
+
+**Files:**
+- Modify: `README.md`
+- Modify: `README.ja.md`
+- Modify: `docs/ARCHITECTURE.md`
+- Modify: `docs/RESEARCH_STATUS.md`
+- Modify: `tests/test_architecture_contract.py` only if an explicit DSR absence assertion is needed.
+
+- [ ] Document gamma, paired state, insolvency, and log-bootstrap semantics.
+- [ ] Verify no direct-action or DSR path exists.
+- [ ] Run Ruff, format, mypy, Import Linter, full pytest with branch coverage, and CLI smoke test.
+- [ ] Inspect the complete diff against the design.
+- [ ] Open a draft PR and require successful GitHub Actions before merge.

--- a/docs/superpowers/specs/2026-07-13-residual-reward-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-13-residual-reward-hardening-design.md
@@ -1,0 +1,83 @@
+# Residual Reward Hardening Design
+
+## Status
+
+Approved for implementation from the prior reward-design review. This specification is adapted to the rebuilt `trade_rl` architecture merged in commit `8407d664d1d7ea35ccc5ff105cffdb26a3512df6`.
+
+Production remains **NO-GO**.
+
+## Scope adjustment after the residual-core rebuild
+
+The rebuilt repository already removed the legacy direct-action PPO environment, turnover-penalty reward, ignored-action decision timing, curriculum DSR mode, and all compatibility paths. Those items are therefore complete by deletion and must not be reintroduced.
+
+The remaining reward-design work is limited to four residual-core issues:
+
+1. preserve long-horizon paired wealth optimization through the training discount contract;
+2. expose the shadow-relative state needed to predict the paired reward;
+3. separate controllable hybrid insolvency from uncontrollable shadow insolvency;
+4. use per-period excess log returns consistently for reward, bootstrap inference, checkpoint evidence, and reporting.
+
+## Training discount contract
+
+Residual training uses a default discount factor of `0.99`. `ResidualTrainingConfig` rejects `gamma < 0.95` unless `allow_low_gamma=True` is explicitly supplied for a research ablation.
+
+The CLI makes `--gamma` optional with default `0.99` and exposes `--allow-low-gamma`. The resolved configuration output records both values and uses schema `residual_training_config_v2`.
+
+This is not a claim that `0.99` is universally optimal. It is a guard against accidentally optimizing only the next one or two decision intervals when the environment contains persistent weights, costs, drawdown state, and compounding.
+
+## Paired observation state
+
+The residual policy observation keeps all existing market, trend, alpha, and hybrid-book fields, and adds:
+
+- per-symbol `hybrid_weight - shadow_weight`;
+- global log wealth ratio `log(hybrid_value / shadow_value)`;
+- shadow drawdown;
+- shadow gross exposure;
+- cumulative turnover excess `hybrid_turnover - shadow_turnover`.
+
+The zero action must remain exact identity. At reset, all paired-state additions are zero.
+
+## Insolvency semantics
+
+The environment computes separate flags:
+
+- `hybrid_insolvent`: controlled candidate book is below the configured equity threshold;
+- `shadow_insolvent`: deterministic reference book is below the threshold.
+
+The realized interval excess log return is always retained. A configurable `hybrid_insolvency_penalty` in unscaled log-return units is subtracted only when the hybrid book is insolvent. Shadow insolvency does not apply that penalty because the agent cannot control the reference book.
+
+Either insolvency terminates the episode. `info` exposes both flags and `rollout_valid = not shadow_insolvent`. Evaluation and selection code must fail closed when `rollout_valid` is false.
+
+## Paired statistical quantity
+
+For each paired base period:
+
+```text
+period_excess_log_return = log1p(candidate_return) - log1p(benchmark_return)
+```
+
+Moving-block bootstrap inference, confidence intervals, p-values, and `mean_period_excess` use this series. Arithmetic return differences remain available only as `mean_period_simple_excess` diagnostic output.
+
+Total arithmetic-return difference and total excess log return remain separate fields.
+
+## Documentation and artifacts
+
+README and architecture documentation state:
+
+- default and minimum residual gamma policy;
+- the paired observation additions;
+- separate insolvency semantics;
+- bootstrap on excess log returns;
+- direct-action and DSR changes are already complete by deletion.
+
+## Required tests
+
+1. default CLI gamma is `0.99`;
+2. `gamma < 0.95` fails without the explicit override and succeeds with it;
+3. paired observation layout and reset values are exact;
+4. zero action still matches the shadow book exactly;
+5. hybrid-only insolvency applies the configured penalty;
+6. shadow-only insolvency does not apply the hybrid penalty and marks the rollout invalid;
+7. paired bootstrap and period mean use log differences, with arithmetic difference retained only as a diagnostic;
+8. the architecture continues to contain no direct-action or DSR training path;
+9. all quality checks and the complete test suite pass.

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from io import StringIO
 
+import pytest
+
 from trade_rl.cli.app import build_parser, main
 
 
@@ -54,7 +56,7 @@ def test_walk_forward_plan_outputs_typed_fold_plan() -> None:
     assert payload["folds"][0]["test"] == [106, 126]
 
 
-def test_train_config_outputs_validated_residual_configuration() -> None:
+def test_train_config_defaults_to_validated_long_horizon_gamma() -> None:
     stdout = StringIO()
 
     exit_code = main(
@@ -63,8 +65,6 @@ def test_train_config_outputs_validated_residual_configuration() -> None:
             "config",
             "--timesteps",
             "1024",
-            "--gamma",
-            "0.5",
             "--seed",
             "0",
             "--seed",
@@ -76,11 +76,54 @@ def test_train_config_outputs_validated_residual_configuration() -> None:
     payload = json.loads(stdout.getvalue())
     assert exit_code == 0
     assert payload == {
-        "gamma": 0.5,
-        "schema": "residual_training_config_v1",
+        "allow_low_gamma": False,
+        "gamma": 0.99,
+        "schema": "residual_training_config_v2",
         "seeds": [0, 1],
         "timesteps": 1024,
     }
+
+
+def test_train_config_rejects_low_gamma_without_explicit_override() -> None:
+    with pytest.raises(ValueError, match="allow_low_gamma"):
+        main(
+            [
+                "train",
+                "config",
+                "--timesteps",
+                "1024",
+                "--gamma",
+                "0.5",
+                "--seed",
+                "0",
+            ],
+            stdout=StringIO(),
+        )
+
+
+def test_train_config_accepts_explicit_low_gamma_research_ablation() -> None:
+    stdout = StringIO()
+
+    exit_code = main(
+        [
+            "train",
+            "config",
+            "--timesteps",
+            "1024",
+            "--gamma",
+            "0.5",
+            "--allow-low-gamma",
+            "--seed",
+            "0",
+        ],
+        stdout=stdout,
+    )
+
+    payload = json.loads(stdout.getvalue())
+    assert exit_code == 0
+    assert payload["gamma"] == 0.5
+    assert payload["allow_low_gamma"] is True
+    assert payload["schema"] == "residual_training_config_v2"
 
 
 def test_version_command_uses_trade_rl_package_name() -> None:

--- a/tests/evaluation/test_comparisons.py
+++ b/tests/evaluation/test_comparisons.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+from statistics import fmean
 
 import pytest
 
@@ -27,18 +28,43 @@ def test_paired_comparison_keeps_arithmetic_and_log_excess_separate() -> None:
 
     result = compare_paired_returns(candidate, benchmark, n_bootstrap=250, seed=17)
 
+    simple_differences = tuple(
+        left - right
+        for left, right in zip(candidate.values, benchmark.values, strict=True)
+    )
+    log_differences = tuple(
+        math.log1p(left) - math.log1p(right)
+        for left, right in zip(candidate.values, benchmark.values, strict=True)
+    )
     candidate_total = 1.02 * 0.99 * 1.03 - 1.0
     benchmark_total = 1.01 * 0.99 * 1.01 - 1.0
     assert result.excess_total_return == pytest.approx(
         candidate_total - benchmark_total
     )
-    assert result.excess_log_return == pytest.approx(
-        sum(math.log1p(value) for value in candidate.values)
-        - sum(math.log1p(value) for value in benchmark.values)
-    )
-    assert result.mean_period_excess == pytest.approx(0.0075)
+    assert result.excess_log_return == pytest.approx(sum(log_differences))
+    assert result.mean_period_excess == pytest.approx(fmean(log_differences))
+    assert result.mean_period_simple_excess == pytest.approx(fmean(simple_differences))
     assert 0.0 <= result.p_value <= 1.0
     assert result.block_size >= 1
+
+
+def test_paired_bootstrap_uses_log_excess_when_large_returns_diverge() -> None:
+    candidate = series((0.50, -0.20, 0.35, -0.10))
+    benchmark = series((0.40, -0.10, 0.15, -0.05))
+
+    result = compare_paired_returns(candidate, benchmark, n_bootstrap=400, seed=31)
+
+    log_differences = tuple(
+        math.log1p(left) - math.log1p(right)
+        for left, right in zip(candidate.values, benchmark.values, strict=True)
+    )
+    simple_differences = tuple(
+        left - right
+        for left, right in zip(candidate.values, benchmark.values, strict=True)
+    )
+    assert result.mean_period_excess == pytest.approx(fmean(log_differences))
+    assert result.mean_period_simple_excess == pytest.approx(fmean(simple_differences))
+    assert result.mean_period_excess != pytest.approx(result.mean_period_simple_excess)
 
 
 def test_identity_comparison_is_exact_and_non_significant() -> None:
@@ -49,6 +75,7 @@ def test_identity_comparison_is_exact_and_non_significant() -> None:
     assert result.excess_total_return == 0.0
     assert result.excess_log_return == 0.0
     assert result.mean_period_excess == 0.0
+    assert result.mean_period_simple_excess == 0.0
     assert result.p_value == 1.0
     assert result.lower_ci == 0.0
     assert result.upper_ci == 0.0

--- a/tests/rl/test_ensemble_training.py
+++ b/tests/rl/test_ensemble_training.py
@@ -7,6 +7,8 @@ import pytest
 
 from trade_rl.domain.datasets import DatasetManifest
 from trade_rl.rl.training import (
+    DEFAULT_RESIDUAL_GAMMA,
+    MIN_RESIDUAL_GAMMA,
     ResidualTrainingConfig,
     train_residual_ensemble,
 )
@@ -40,6 +42,29 @@ def manifest(dataset_id: str = "a" * 64) -> DatasetManifest:
     )
 
 
+def test_training_config_defaults_to_long_horizon_gamma() -> None:
+    config = ResidualTrainingConfig(timesteps=1_024, seeds=(0, 1))
+
+    assert DEFAULT_RESIDUAL_GAMMA == pytest.approx(0.99)
+    assert MIN_RESIDUAL_GAMMA == pytest.approx(0.95)
+    assert config.gamma == pytest.approx(DEFAULT_RESIDUAL_GAMMA)
+    assert config.allow_low_gamma is False
+
+
+def test_training_config_rejects_low_gamma_without_explicit_override() -> None:
+    with pytest.raises(ValueError, match="allow_low_gamma"):
+        ResidualTrainingConfig(timesteps=1_024, gamma=0.5, seeds=(0,))
+
+    config = ResidualTrainingConfig(
+        timesteps=1_024,
+        gamma=0.5,
+        seeds=(0,),
+        allow_low_gamma=True,
+    )
+    assert config.gamma == pytest.approx(0.5)
+    assert config.allow_low_gamma is True
+
+
 def test_train_residual_ensemble_creates_one_member_per_seed(tmp_path: Path) -> None:
     backend = FakeBackend()
     created_at = datetime(2026, 7, 13, 7, 0, tzinfo=UTC)
@@ -49,7 +74,7 @@ def test_train_residual_ensemble_creates_one_member_per_seed(tmp_path: Path) -> 
         environment_dataset_id="a" * 64,
         config=ResidualTrainingConfig(
             timesteps=1_024,
-            gamma=0.5,
+            gamma=0.99,
             seeds=(0, 1, 2),
         ),
         backend=backend,
@@ -64,7 +89,7 @@ def test_train_residual_ensemble_creates_one_member_per_seed(tmp_path: Path) -> 
     assert result.action_schema == "baseline_residual_v1"
     assert len(backend.calls) == 3
     assert all(call[1] == 1_024 for call in backend.calls)
-    assert all(call[2] == 0.5 for call in backend.calls)
+    assert all(call[2] == 0.99 for call in backend.calls)
 
 
 def test_training_rejects_dataset_identity_mismatch(tmp_path: Path) -> None:
@@ -72,7 +97,7 @@ def test_training_rejects_dataset_identity_mismatch(tmp_path: Path) -> None:
         train_residual_ensemble(
             dataset=manifest(),
             environment_dataset_id="b" * 64,
-            config=ResidualTrainingConfig(timesteps=10, gamma=0.5, seeds=(0,)),
+            config=ResidualTrainingConfig(timesteps=10, seeds=(0,)),
             backend=FakeBackend(),
             output_dir=tmp_path,
             created_at=datetime(2026, 7, 13, tzinfo=UTC),
@@ -81,6 +106,6 @@ def test_training_rejects_dataset_identity_mismatch(tmp_path: Path) -> None:
 
 def test_training_config_requires_unique_non_negative_seeds() -> None:
     with pytest.raises(ValueError, match="unique"):
-        ResidualTrainingConfig(timesteps=10, gamma=0.5, seeds=(0, 0))
+        ResidualTrainingConfig(timesteps=10, seeds=(0, 0))
     with pytest.raises(ValueError, match="non-negative"):
-        ResidualTrainingConfig(timesteps=10, gamma=0.5, seeds=(-1,))
+        ResidualTrainingConfig(timesteps=10, seeds=(-1,))

--- a/tests/rl/test_environment_timing.py
+++ b/tests/rl/test_environment_timing.py
@@ -5,6 +5,7 @@ import pytest
 
 from trade_rl.data.market import MarketDataset
 from trade_rl.rl.environment import ResidualMarketEnv, ResidualMarketEnvConfig
+from trade_rl.rl.observations import observation_layout
 from trade_rl.simulation.execution import ExecutionCostConfig
 from trade_rl.strategies.trend import TrendConfig, TrendStrategy
 
@@ -30,7 +31,12 @@ def dataset(n_bars: int = 160) -> MarketDataset:
     )
 
 
-def environment(*, decision_every: int = 4) -> ResidualMarketEnv:
+def environment(
+    *,
+    decision_every: int = 4,
+    reward_scale: float = 100.0,
+    hybrid_insolvency_penalty: float = 1.0,
+) -> ResidualMarketEnv:
     return ResidualMarketEnv(
         dataset(),
         trend_strategy=TrendStrategy(
@@ -43,7 +49,8 @@ def environment(*, decision_every: int = 4) -> ResidualMarketEnv:
         config=ResidualMarketEnvConfig(
             episode_bars=40,
             decision_every=decision_every,
-            reward_scale=100.0,
+            reward_scale=reward_scale,
+            hybrid_insolvency_penalty=hybrid_insolvency_penalty,
             execution_cost=ExecutionCostConfig.zero(),
         ),
     )
@@ -62,6 +69,9 @@ def test_identity_action_matches_shadow_book_exactly() -> None:
             abs=1e-12,
         )
         assert info["bars_advanced"] == 4
+        assert info["hybrid_insolvent"] is False
+        assert info["shadow_insolvent"] is False
+        assert info["rollout_valid"] is True
         if terminated or truncated:
             break
 
@@ -81,14 +91,58 @@ def test_one_action_receives_one_interval_reward() -> None:
     assert reward == pytest.approx(100.0 * info["excess_log_return"])
 
 
-def test_observation_and_action_spaces_have_stable_shapes() -> None:
+def test_observation_exposes_shadow_relative_state_with_stable_shape() -> None:
+    market = dataset()
     env = environment()
     observation, _ = env.reset(options={"start_idx": 24})
+    layout = observation_layout(market)
 
+    assert layout.per_symbol_width == market.n_features + 6
+    assert layout.global_width == len(market.global_feature_names) + 7
     assert env.action_space.shape == (2,)
-    assert observation.shape == env.observation_space.shape
+    assert observation.shape == env.observation_space.shape == (layout.size,)
     assert observation.dtype == np.float32
     assert np.isfinite(observation).all()
+    np.testing.assert_allclose(observation[-4:], np.zeros(4), atol=1e-12)
+
+    env.hybrid.weights = np.array([0.4, -0.2])
+    env.shadow.weights = np.array([0.1, -0.1])
+    paired = env._observation()
+    symbol_rows = paired[: market.n_symbols * layout.per_symbol_width].reshape(
+        market.n_symbols,
+        layout.per_symbol_width,
+    )
+    np.testing.assert_allclose(symbol_rows[:, -1], np.array([0.3, -0.1]))
+
+
+def test_hybrid_only_insolvency_preserves_excess_and_applies_hybrid_penalty() -> None:
+    env = environment(reward_scale=10.0, hybrid_insolvency_penalty=1.25)
+    env.reset(options={"start_idx": 24})
+    threshold = env.config.initial_capital * env.config.minimum_equity_fraction
+    env.hybrid.portfolio_value = threshold / 10.0
+
+    _, reward, terminated, _, info = env.step(np.zeros(2))
+
+    assert terminated is True
+    assert info["hybrid_insolvent"] is True
+    assert info["shadow_insolvent"] is False
+    assert info["rollout_valid"] is True
+    assert reward == pytest.approx(10.0 * info["excess_log_return"] - 12.5)
+
+
+def test_shadow_only_insolvency_terminates_without_hybrid_penalty() -> None:
+    env = environment(reward_scale=10.0, hybrid_insolvency_penalty=1.25)
+    env.reset(options={"start_idx": 24})
+    threshold = env.config.initial_capital * env.config.minimum_equity_fraction
+    env.shadow.portfolio_value = threshold / 10.0
+
+    _, reward, terminated, _, info = env.step(np.zeros(2))
+
+    assert terminated is True
+    assert info["hybrid_insolvent"] is False
+    assert info["shadow_insolvent"] is True
+    assert info["rollout_valid"] is False
+    assert reward == pytest.approx(10.0 * info["excess_log_return"])
 
 
 def test_terminal_info_uses_base_bar_return_identity() -> None:


### PR DESCRIPTION
Superseded before implementation because `main` advanced by eight commits adding the OHLCV, self-financing accounting, and next-open execution contracts. Reward hardening is being recreated from the latest main so it composes with those environment changes rather than overriding their tests.