### PR TITLE
Align paired inference with excess log returns

### DIFF
--- a/docs/RESEARCH_STATUS.md
+++ b/docs/RESEARCH_STATUS.md
@@ -15,3 +15,7 @@ ProductionRelease: BLOCKED
 Configuration A was the identity baseline and had no selected PPO model path. The signal gate failed because mean OOS IC was below its required threshold. The final production gate also failed, including the positive-return significance check. Positive holdout return and positive 2x-cost return remain evidence, but they do not override failed mandatory gates.
 
 The migration fixture exists to prevent this evidence from being mislabeled as a selected policy ensemble or a production release.
+
+## Paired reward and inference contract
+
+The maintained residual environment optimizes candidate growth relative to the independent shadow baseline in log-return space. Paired moving-block inference therefore uses the same per-period quantity, `log1p(candidate_return) - log1p(shadow_return)`, for its mean, confidence interval, and p-value. Arithmetic period-return differences are retained only as a diagnostic field and do not drive statistical superiority decisions.

--- a/tests/evaluation/test_comparisons.py
+++ b/tests/evaluation/test_comparisons.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+from statistics import fmean
 
 import pytest
 
@@ -27,18 +28,49 @@ def test_paired_comparison_keeps_arithmetic_and_log_excess_separate() -> None:
 
     result = compare_paired_returns(candidate, benchmark, n_bootstrap=250, seed=17)
 
+    simple_differences = tuple(
+        left - right
+        for left, right in zip(candidate.values, benchmark.values, strict=True)
+    )
+    log_differences = tuple(
+        math.log1p(left) - math.log1p(right)
+        for left, right in zip(candidate.values, benchmark.values, strict=True)
+    )
     candidate_total = 1.02 * 0.99 * 1.03 - 1.0
     benchmark_total = 1.01 * 0.99 * 1.01 - 1.0
     assert result.excess_total_return == pytest.approx(
         candidate_total - benchmark_total
     )
-    assert result.excess_log_return == pytest.approx(
-        sum(math.log1p(value) for value in candidate.values)
-        - sum(math.log1p(value) for value in benchmark.values)
+    assert result.excess_log_return == pytest.approx(sum(log_differences))
+    assert result.mean_period_excess == pytest.approx(fmean(log_differences))
+    assert result.mean_period_simple_excess == pytest.approx(
+        fmean(simple_differences)
     )
-    assert result.mean_period_excess == pytest.approx(0.0075)
     assert 0.0 <= result.p_value <= 1.0
     assert result.block_size >= 1
+
+
+def test_paired_bootstrap_uses_log_excess_when_large_returns_diverge() -> None:
+    candidate = series((0.50, -0.20, 0.35, -0.10))
+    benchmark = series((0.40, -0.10, 0.15, -0.05))
+
+    result = compare_paired_returns(candidate, benchmark, n_bootstrap=400, seed=31)
+
+    log_differences = tuple(
+        math.log1p(left) - math.log1p(right)
+        for left, right in zip(candidate.values, benchmark.values, strict=True)
+    )
+    simple_differences = tuple(
+        left - right
+        for left, right in zip(candidate.values, benchmark.values, strict=True)
+    )
+    assert result.mean_period_excess == pytest.approx(fmean(log_differences))
+    assert result.mean_period_simple_excess == pytest.approx(
+        fmean(simple_differences)
+    )
+    assert result.mean_period_excess != pytest.approx(
+        result.mean_period_simple_excess
+    )
 
 
 def test_identity_comparison_is_exact_and_non_significant() -> None:
@@ -49,6 +81,7 @@ def test_identity_comparison_is_exact_and_non_significant() -> None:
     assert result.excess_total_return == 0.0
     assert result.excess_log_return == 0.0
     assert result.mean_period_excess == 0.0
+    assert result.mean_period_simple_excess == 0.0
     assert result.p_value == 1.0
     assert result.lower_ci == 0.0
     assert result.upper_ci == 0.0

--- a/tests/evaluation/test_comparisons.py
+++ b/tests/evaluation/test_comparisons.py
@@ -43,9 +43,7 @@ def test_paired_comparison_keeps_arithmetic_and_log_excess_separate() -> None:
     )
     assert result.excess_log_return == pytest.approx(sum(log_differences))
     assert result.mean_period_excess == pytest.approx(fmean(log_differences))
-    assert result.mean_period_simple_excess == pytest.approx(
-        fmean(simple_differences)
-    )
+    assert result.mean_period_simple_excess == pytest.approx(fmean(simple_differences))
     assert 0.0 <= result.p_value <= 1.0
     assert result.block_size >= 1
 
@@ -65,12 +63,8 @@ def test_paired_bootstrap_uses_log_excess_when_large_returns_diverge() -> None:
         for left, right in zip(candidate.values, benchmark.values, strict=True)
     )
     assert result.mean_period_excess == pytest.approx(fmean(log_differences))
-    assert result.mean_period_simple_excess == pytest.approx(
-        fmean(simple_differences)
-    )
-    assert result.mean_period_excess != pytest.approx(
-        result.mean_period_simple_excess
-    )
+    assert result.mean_period_simple_excess == pytest.approx(fmean(simple_differences))
+    assert result.mean_period_excess != pytest.approx(result.mean_period_simple_excess)
 
 
 def test_identity_comparison_is_exact_and_non_significant() -> None:

--- a/trade_rl/evaluation/comparisons.py
+++ b/trade_rl/evaluation/comparisons.py
@@ -18,6 +18,7 @@ class PairedComparison:
     excess_total_return: float
     excess_log_return: float
     mean_period_excess: float
+    mean_period_simple_excess: float
     p_value: float
     lower_ci: float
     upper_ci: float
@@ -40,10 +41,10 @@ def compare_paired_returns(
     n_bootstrap: int = 1_000,
     seed: int = 0,
 ) -> PairedComparison:
-    """Compare chronologically paired candidate and benchmark returns."""
+    """Compare paired returns using excess log growth for statistical inference."""
 
     _validate_compatible(candidate, benchmark)
-    differences = tuple(
+    simple_differences = tuple(
         candidate_value - benchmark_value
         for candidate_value, benchmark_value in zip(
             candidate.values,
@@ -51,8 +52,16 @@ def compare_paired_returns(
             strict=True,
         )
     )
+    log_differences = tuple(
+        math.log1p(candidate_value) - math.log1p(benchmark_value)
+        for candidate_value, benchmark_value in zip(
+            candidate.values,
+            benchmark.values,
+            strict=True,
+        )
+    )
     bootstrap = moving_block_mean_test(
-        differences,
+        log_differences,
         n_bootstrap=n_bootstrap,
         seed=seed,
     )
@@ -63,7 +72,8 @@ def compare_paired_returns(
         excess_total_return=compound_return(candidate.values)
         - compound_return(benchmark.values),
         excess_log_return=candidate_log_return - benchmark_log_return,
-        mean_period_excess=fmean(differences),
+        mean_period_excess=fmean(log_differences),
+        mean_period_simple_excess=fmean(simple_differences),
         p_value=bootstrap.p_value,
         lower_ci=bootstrap.lower_ci,
         upper_ci=bootstrap.upper_ci,


### PR DESCRIPTION
Superseded by PR #20, which contains the same isolated reward-statistics change but is based on the completed realistic-environment mainline. PR #17's merge CI was blocked by formatting in its older, concurrently changing base rather than by its own changed files.