### PR TITLE
CI diagnostics: reward v2

### DIFF
--- a/.ci-reward-v2-trigger
+++ b/.ci-reward-v2-trigger
@@ -1,0 +1,1 @@
+reward-v2 diagnostics

--- a/.ci-reward-v2-trigger
+++ b/.ci-reward-v2-trigger
@@ -1,1 +1,1 @@
-reward-v2 diagnostics rerun 1
+reward-v2 diagnostics rerun 2

--- a/.ci-reward-v2-trigger
+++ b/.ci-reward-v2-trigger
@@ -1,1 +1,1 @@
-reward-v2 diagnostics
+reward-v2 diagnostics rerun 1


### PR DESCRIPTION
Temporary diagnostics PR. Its failures were fixed on `agent/reward-design-v2`, and full repository CI later passed on head `d78a328ce14b881e95ef312d78a5a3a194778d56`. Closed during final reward-v2 audit.