### PR TITLE
Add copy-paste training quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Trade RL is a research-grade, baseline-anchored residual reinforcement-learning 
 
 > Production status: **NO-GO**. The repository provides research, evaluation, artifact and serving contracts. It does not claim profitability or production authorization.
 
+## Start here
+
+For a copy-paste first training run, including deterministic demo-data generation, a maintained PPO configuration, artifact inspection, real-data replacement, GPU settings and troubleshooting, read [START.md](START.md).
+
 ## Action and environment v3
 
 The maintained environment now provides:

--- a/START.md
+++ b/START.md
@@ -1,0 +1,288 @@
+# Trade RL 学習クイックスタート
+
+このページは、リポジトリを取得した直後に、**データartifact生成 → PPO学習 → 成果物確認**までを最短で実行する手順です。
+
+最初の例では決定論的なデモ相場を使います。デモデータは学習パイプラインの動作確認用であり、収益性の検証には使用できません。
+
+> Production status: **NO-GO**  
+> 学習やテストの成功は、本番資金での運用許可や利益を保証しません。
+
+## 1. 環境を準備する
+
+Python 3.12以上が必要です。リポジトリのルートで実行してください。
+
+```bash
+python -m pip install uv
+uv sync --extra dev
+uv run trade-rl --version
+```
+
+GPUやONNX/TorchScript exportを初回から使わない場合、`--extra export`は不要です。
+
+## 2. デモ用の市場データを作る
+
+```bash
+uv run python examples/quickstart/create_demo_dataset.py \
+  --output var/quickstart/dataset
+```
+
+成功すると、次の2ファイルが作られます。
+
+```text
+var/quickstart/dataset/
+├── manifest.json
+└── arrays.npz
+```
+
+`manifest.json`にはデータセット識別子、配列名、shape、dtype、SHA-256が保存されます。`arrays.npz`が変更・破損すると、学習前の検証で拒否されます。
+
+バー数を増やす場合は次のように指定します。
+
+```bash
+uv run python examples/quickstart/create_demo_dataset.py \
+  --output var/quickstart/dataset \
+  --bars 4096
+```
+
+## 3. 学習を開始する
+
+最小設定は`examples/quickstart/training.json`にあります。
+
+```bash
+uv run trade-rl train run \
+  --config examples/quickstart/training.json \
+  --dataset var/quickstart/dataset \
+  --output var/quickstart/artifacts \
+  --run-id quickstart-001
+```
+
+この設定は、CPU、PPO、1 seed、512 timestepsの小規模な動作確認です。行動空間は次の3次元です。
+
+```text
+fast_tilt
+slow_tilt
+risk_tilt
+```
+
+alphaとfactorは初回設定では無効です。
+
+成功時、CLIは1行のJSONを出力します。
+
+```json
+{
+  "artifact_path": "var/quickstart/artifacts/runs/quickstart-001",
+  "production_status": "NO-GO",
+  "run_id": "quickstart-001",
+  "status": "published"
+}
+```
+
+実際のJSONにはdataset、run、policyのdigestも含まれます。
+
+## 4. 学習成果物を確認する
+
+```bash
+cat var/quickstart/artifacts/latest.json
+find var/quickstart/artifacts/runs/quickstart-001 -maxdepth 4 -type f | sort
+```
+
+主な成果物は次のとおりです。
+
+```text
+var/quickstart/artifacts/
+├── latest.json
+└── runs/
+    └── quickstart-001/
+        ├── run.json
+        ├── training-config.json
+        ├── dataset-reference.json
+        ├── environment.json
+        ├── ensemble.json
+        ├── policy-loader.json
+        └── members/
+            └── member-000/
+                └── policy.zip
+```
+
+- `run.json`: 全成果物のpath、size、SHA-256を束ねた最終manifest
+- `training-config.json`: 実際に使用された学習設定
+- `dataset-reference.json`: 学習対象データの識別情報
+- `environment.json`: action、risk、reward、trend、execution設定
+- `ensemble.json`: seedごとのpolicyを束ねるmanifest
+- `policy.zip`: Stable-Baselines3の正式な保存形式
+- `latest.json`: 最後に正常publishされたrunへのポインタ
+
+## 5. 再学習する
+
+runは不変artifactとして扱われるため、同じ`--run-id`を再利用しないでください。
+
+```bash
+uv run trade-rl train run \
+  --config examples/quickstart/training.json \
+  --dataset var/quickstart/dataset \
+  --output var/quickstart/artifacts \
+  --run-id quickstart-002
+```
+
+失敗したrunは`failed/<run-id>`へ隔離され、正常な`latest.json`は変更されません。
+
+## 6. 本格的な学習設定へ変更する
+
+`examples/quickstart/training.json`の`training`を変更します。
+
+研究用の開始例:
+
+```json
+{
+  "timesteps": 102400,
+  "seeds": [0, 1, 2],
+  "n_steps": 2048,
+  "batch_size": 64,
+  "n_epochs": 10,
+  "device": "cpu",
+  "policy_net_arch": [128, 128]
+}
+```
+
+設定全体を上の断片で置き換えるのではなく、既存JSONの`training`セクション内の値を変更してください。
+
+### GPUを使う
+
+まずCUDAが認識されるか確認します。
+
+```bash
+uv run python -c "import torch; print(torch.cuda.is_available())"
+```
+
+`True`の場合、設定の次の値を変更します。
+
+```json
+"device": "cuda"
+```
+
+CUDAが利用できない環境では`cpu`を使用してください。
+
+### 学習アルゴリズムを変える
+
+`algorithm`は次を選択できます。
+
+```text
+ppo
+sac
+td3
+tqc
+```
+
+PPO以外では`buffer_size`、`learning_starts`、`train_freq`、`gradient_steps`も確認してください。アルゴリズム間の比較では、データ範囲、action contract、reward、cost、seedを固定します。
+
+## 7. 実データへ置き換える
+
+`trade-rl train run`が受け取るのは、次の形式の市場データartifactです。
+
+```text
+my-dataset/
+├── manifest.json
+└── arrays.npz
+```
+
+Python側では`MarketDataset`を作成し、正式writerで保存します。
+
+```python
+from pathlib import Path
+
+from trade_rl.data import MarketDataset, write_market_dataset_files
+
+# dataset = MarketDataset(...)
+write_market_dataset_files(Path("artifacts/datasets/btc-usdt"), dataset)
+```
+
+最低限、次の配列が必要です。
+
+- `timestamps`: bar close時刻。連続市場では完全に等間隔
+- `features`: `(bars, symbols, features)`
+- `global_features`: `(bars, global_features)`
+- `open`, `high`, `low`, `close`, `volume`, `funding_rate`: `(bars, symbols)`
+- `tradable`: `(bars, symbols)`
+- `feature_available`: `features`と同じshape
+
+重要な因果契約:
+
+- 行`t`の特徴量は行`t`のbar close時点までに利用可能な情報だけで作る
+- 行`t`の意思決定は最短でも行`t + 1`のopenで約定する
+- future return、将来のhigh/low、後日改訂値を特徴量へ混入させない
+- 欠損を0に置換するだけでなく、availabilityとstalenessを保存する
+- split、dividend、delisting、funding、borrow、session gapを対象市場に合わせる
+- データ期間はslow lookback、reward preroll、episode期間、評価範囲より十分長くする
+
+実データartifactを作った後は、`--dataset`だけを差し替えます。
+
+```bash
+uv run trade-rl train run \
+  --config configs/btc-usdt-ppo.json \
+  --dataset artifacts/datasets/btc-usdt \
+  --output artifacts/research \
+  --run-id btc-usdt-ppo-001
+```
+
+## 8. alphaやfactorを使う
+
+初回設定では無効です。利用する場合は、先にcontent-addressed signal artifactを用意し、設定を一致させる必要があります。
+
+alphaの例:
+
+```json
+"alpha_artifact": "artifacts/signals/my-alpha",
+"action": {
+  "alpha_enabled": true,
+  "n_factors": 0,
+  "validation_mode": "clip"
+}
+```
+
+factorの例では、`factor_artifact`と`action.n_factors`の両方を一致させます。不一致、symbol順序違い、dataset ID違い、digest不一致は学習前に拒否されます。
+
+## 9. よくあるエラー
+
+### `run already exists`
+
+`--run-id`を新しい値へ変更してください。publish済みrunは上書きしません。
+
+### `dataset digest mismatch`
+
+`arrays.npz`または`manifest.json`が変更されています。元データからartifactを再生成してください。
+
+### episodeを開始できない
+
+データ期間が短い可能性があります。バー数を増やすか、次を短くしてください。
+
+- `environment.episode_hours`
+- `trend.fast_hours`
+- `trend.base_hours`
+- `trend.slow_hours`
+- rewardのbaseline window
+
+### CUDA関連で失敗する
+
+`training.device`を`cpu`へ戻し、まずCPUで学習パイプラインを確認してください。
+
+### 学習途中で失敗した
+
+```bash
+find var/quickstart/artifacts/failed -maxdepth 3 -type f | sort
+```
+
+失敗したstaging runは`failed/<run-id>`へ隔離されます。正常publish済みrunと`latest.json`は保持されます。
+
+## 10. 次の段階
+
+単一runの動作確認後は、nested walk-forwardを使用します。
+
+```bash
+uv run trade-rl walk-forward run \
+  --config configs/walk-forward.json \
+  --dataset artifacts/datasets/btc-usdt \
+  --output artifacts/research \
+  --run-id btc-usdt-wf-001
+```
+
+最終判断には、手数料・spread・impact・funding・borrowを含むsealed out-of-sample評価と、別期間・複数seed・複数AUMでの再現性確認が必要です。

--- a/docs/superpowers/plans/2026-07-14-training-quickstart.md
+++ b/docs/superpowers/plans/2026-07-14-training-quickstart.md
@@ -1,0 +1,80 @@
+# Training Quickstart Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a copy-paste training quickstart that generates a valid demo market dataset, runs the maintained `trade-rl train run` command, and explains how to replace the demo with real data.
+
+**Architecture:** Keep the existing training pipeline unchanged. Add one deterministic example dataset builder, one minimal validated training configuration, a root `START.md`, and a focused integration test that executes the builder and parses the configuration through production code.
+
+**Tech Stack:** Python 3.12, NumPy, `trade_rl.data.MarketDataset`, `write_market_dataset_files`, JSON, pytest, Stable-Baselines3 CLI.
+
+## Global Constraints
+
+- The authoritative training entry point remains `trade-rl train run --config CONFIG --dataset DATASET --output STORE`.
+- Example training must use the real artifact writer and real `TrainingRunConfig` parser.
+- The example must remain CPU-compatible and small enough for a first smoke run.
+- Documentation must state that training success does not authorize production trading.
+- No synthetic performance or profitability claims.
+
+---
+
+### Task 1: Deterministic demo dataset builder
+
+**Files:**
+- Create: `examples/quickstart/create_demo_dataset.py`
+- Test: `tests/examples/test_training_quickstart.py`
+
+**Interfaces:**
+- Consumes: `trade_rl.data.MarketDataset`, `trade_rl.data.write_market_dataset_files`
+- Produces: `build_demo_dataset(n_bars: int = 1024) -> MarketDataset` and CLI output directory containing `manifest.json` plus `arrays.npz`
+
+- [ ] Create a deterministic one-symbol, hourly, continuous market dataset with causal momentum/volatility features and realistic OHLCV shapes.
+- [ ] Add argument parsing for `--output` and `--bars`.
+- [ ] Write the artifact through `write_market_dataset_files` and print a compact JSON result.
+- [ ] Add tests for deterministic identity, successful artifact round-trip, and expected symbols/features.
+
+### Task 2: Minimal maintained training configuration
+
+**Files:**
+- Create: `examples/quickstart/training.json`
+- Test: `tests/examples/test_training_quickstart.py`
+
+**Interfaces:**
+- Consumes: `TrainingRunConfig.from_json(Path)`
+- Produces: a CPU-friendly PPO configuration with no alpha/factor artifacts and a three-dimensional dynamic residual action
+
+- [ ] Configure 512 requested timesteps, 64-step PPO rollouts, batch size 32, one seed, 1-hour decisions, 168-hour episodes, time-series trend, and explicit initial capital.
+- [ ] Keep exports disabled for the first-run path.
+- [ ] Test that production parsing succeeds and the action layout is exactly `fast_tilt`, `slow_tilt`, `risk_tilt`.
+
+### Task 3: Root quickstart documentation
+
+**Files:**
+- Create: `START.md`
+- Modify: `README.md`
+
+**Interfaces:**
+- Consumes: the example builder and config from Tasks 1–2
+- Produces: a three-command first run and a real-data migration guide
+
+- [ ] Document prerequisites and installation.
+- [ ] Provide exact commands to generate data, train, and inspect `latest.json` and the published run directory.
+- [ ] Explain output files, rerunning with a unique `--run-id`, GPU selection, larger training, and real dataset artifact requirements.
+- [ ] Document common failures and the `failed/<run-id>` isolation behavior.
+- [ ] Link `START.md` prominently from `README.md`.
+
+### Task 4: Verification
+
+**Files:**
+- Test: `tests/examples/test_training_quickstart.py`
+
+**Interfaces:**
+- Produces: evidence that documentation commands reference real paths and example assets are production-parseable
+
+- [ ] Run `uv run ruff check .`.
+- [ ] Run `uv run ruff format --check .`.
+- [ ] Run `uv run mypy trade_rl`.
+- [ ] Run `uv run lint-imports`.
+- [ ] Run `uv run pytest tests/examples/test_training_quickstart.py -q`.
+- [ ] Run the standard full pytest command with branch coverage.
+- [ ] Run `uv run trade-rl --version`.

--- a/examples/quickstart/create_demo_dataset.py
+++ b/examples/quickstart/create_demo_dataset.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+import numpy as np
+
+from trade_rl.data import MarketDataset, write_market_dataset_files
+
+
+def _rolling_mean(values: np.ndarray, window: int) -> np.ndarray:
+    result = np.empty_like(values, dtype=np.float64)
+    for index in range(values.size):
+        start = max(0, index - window + 1)
+        result[index] = float(np.mean(values[start : index + 1]))
+    return result
+
+
+def _rolling_std(values: np.ndarray, window: int) -> np.ndarray:
+    result = np.empty_like(values, dtype=np.float64)
+    for index in range(values.size):
+        start = max(0, index - window + 1)
+        result[index] = float(np.std(values[start : index + 1]))
+    return result
+
+
+def build_demo_dataset(n_bars: int = 1_024) -> MarketDataset:
+    """Build a deterministic hourly BTC-like dataset for a training smoke run."""
+
+    if isinstance(n_bars, bool) or not isinstance(n_bars, int) or n_bars < 512:
+        raise ValueError("n_bars must be an integer of at least 512")
+
+    rng = np.random.default_rng(20260714)
+    timestamps = np.datetime64("2024-01-01T00:00:00", "ns") + np.arange(
+        n_bars
+    ) * np.timedelta64(1, "h")
+
+    cycle = 0.00035 * np.sin(np.arange(n_bars, dtype=np.float64) / 36.0)
+    innovations = rng.normal(loc=0.0, scale=0.0035, size=n_bars)
+    log_returns = 0.00005 + cycle + innovations
+    close = 30_000.0 * np.exp(np.cumsum(log_returns))
+    open_price = np.concatenate(([close[0]], close[:-1]))
+    intrabar_range = 0.0015 + np.abs(rng.normal(0.0, 0.001, size=n_bars))
+    high = np.maximum(open_price, close) * (1.0 + intrabar_range)
+    low = np.minimum(open_price, close) * (1.0 - intrabar_range)
+    volume = 750.0 + 180.0 * np.abs(rng.normal(size=n_bars))
+
+    observed_returns = np.zeros(n_bars, dtype=np.float64)
+    observed_returns[1:] = np.log(close[1:] / close[:-1])
+    volatility_24h = _rolling_std(observed_returns, 24)
+    market_trend_24h = _rolling_mean(observed_returns, 24)
+
+    features = np.stack((observed_returns, volatility_24h), axis=-1).astype(
+        np.float32
+    )[:, None, :]
+    global_features = market_trend_24h.astype(np.float32)[:, None]
+    prices = {
+        "open": open_price[:, None],
+        "high": high[:, None],
+        "low": low[:, None],
+        "close": close[:, None],
+        "volume": volume[:, None],
+    }
+    feature_available = np.ones(features.shape, dtype=np.bool_)
+    tradable = np.ones((n_bars, 1), dtype=np.bool_)
+    funding_rate = np.zeros((n_bars, 1), dtype=np.float64)
+
+    identity = hashlib.sha256()
+    identity.update(b"trade-rl-quickstart-dataset-v1")
+    for array in (
+        timestamps.astype("datetime64[ns]").astype(np.int64),
+        features,
+        global_features,
+        *prices.values(),
+    ):
+        identity.update(np.ascontiguousarray(array).tobytes(order="C"))
+
+    return MarketDataset(
+        dataset_id=identity.hexdigest(),
+        symbols=("BTCUSDT",),
+        timestamps=timestamps,
+        features=features,
+        global_features=global_features,
+        open=prices["open"],
+        high=prices["high"],
+        low=prices["low"],
+        close=prices["close"],
+        volume=prices["volume"],
+        funding_rate=funding_rate,
+        tradable=tradable,
+        feature_available=feature_available,
+        feature_names=("log_return_1h", "volatility_24h"),
+        global_feature_names=("market_trend_24h",),
+        periods_per_year=8_760,
+        fee_rate=np.full((n_bars, 1), 0.0005, dtype=np.float64),
+        spread_rate=np.full((n_bars, 1), 0.0002, dtype=np.float64),
+        max_participation_rate=np.full((n_bars, 1), 0.05, dtype=np.float64),
+        borrow_available=np.ones((n_bars, 1), dtype=np.bool_),
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Create a deterministic market dataset artifact for START.md."
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("var/quickstart/dataset"),
+        help="directory that receives manifest.json and arrays.npz",
+    )
+    parser.add_argument(
+        "--bars",
+        type=int,
+        default=1_024,
+        help="number of hourly bars; must be at least 512",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    dataset = build_demo_dataset(args.bars)
+    result = write_market_dataset_files(args.output, dataset)
+    print(
+        json.dumps(
+            {
+                "arrays_path": str(result.arrays_path),
+                "artifact_digest": result.artifact_digest,
+                "dataset_id": dataset.dataset_id,
+                "manifest_path": str(result.manifest_path),
+                "n_bars": dataset.n_bars,
+                "symbols": list(dataset.symbols),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/quickstart/create_demo_dataset.py
+++ b/examples/quickstart/create_demo_dataset.py
@@ -52,9 +52,9 @@ def build_demo_dataset(n_bars: int = 1_024) -> MarketDataset:
     volatility_24h = _rolling_std(observed_returns, 24)
     market_trend_24h = _rolling_mean(observed_returns, 24)
 
-    features = np.stack((observed_returns, volatility_24h), axis=-1).astype(
-        np.float32
-    )[:, None, :]
+    features = np.stack((observed_returns, volatility_24h), axis=-1).astype(np.float32)[
+        :, None, :
+    ]
     global_features = market_trend_24h.astype(np.float32)[:, None]
     prices = {
         "open": open_price[:, None],

--- a/examples/quickstart/training.json
+++ b/examples/quickstart/training.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": "training_run_config_v1",
+  "training": {
+    "timesteps": 512,
+    "gamma": 0.9958826236582974,
+    "seeds": [0],
+    "n_steps": 64,
+    "batch_size": 32,
+    "n_epochs": 2,
+    "device": "cpu",
+    "decision_hours": 1.0,
+    "discount_half_life_hours": 168.0,
+    "policy_net_arch": [64, 64],
+    "asset_embedding_dim": 32,
+    "global_embedding_dim": 32,
+    "algorithm": "ppo"
+  },
+  "environment": {
+    "episode_hours": 168.0,
+    "decision_hours": 1.0,
+    "initial_capital": 100000.0,
+    "finite_horizon_observation": true,
+    "initial_state_modes": ["cash"]
+  },
+  "risk": {
+    "max_gross": 1.0,
+    "max_abs_weight": 1.0,
+    "max_turnover": 1.0,
+    "drawdown_start": 0.1,
+    "drawdown_stop": 0.2
+  },
+  "reward": {},
+  "trend": {
+    "fast_hours": 24.0,
+    "base_hours": 48.0,
+    "slow_hours": 96.0,
+    "mode": "time_series",
+    "signal_scale": 0.05
+  },
+  "action": {
+    "alpha_enabled": false,
+    "n_factors": 0,
+    "validation_mode": "clip"
+  },
+  "alpha_contract": {
+    "kind": "target_weight",
+    "expected_return_scale": 0.01,
+    "max_gross": 1.0
+  },
+  "execution": {
+    "fee_rate": 0.0005,
+    "spread_rate": 0.0002,
+    "impact_rate": 0.0001,
+    "max_participation_rate": 0.05,
+    "allow_short": true,
+    "max_leverage": 1.0,
+    "margin_mode": "cross",
+    "order_type": "market"
+  },
+  "exports": {
+    "onnx": false,
+    "torchscript": false,
+    "tolerance": 0.00001
+  }
+}

--- a/tests/examples/test_training_quickstart.py
+++ b/tests/examples/test_training_quickstart.py
@@ -57,9 +57,10 @@ def test_quickstart_config_builds_a_compatible_environment() -> None:
 
     environment = _environment_factory(dataset, config)()
     try:
-        observation, info = environment.reset(seed=0)
+        observation, reset_info = environment.reset(seed=0)
         assert observation.shape == environment.observation_space.shape
-        assert info["dataset_id"] == dataset.dataset_id
+        assert environment.dataset_id == dataset.dataset_id
+        assert reset_info["reward_history_steps"] > 0
         action = np.zeros(environment.action_space.shape, dtype=np.float32)
         next_observation, reward, terminated, truncated, step_info = environment.step(
             action
@@ -67,7 +68,7 @@ def test_quickstart_config_builds_a_compatible_environment() -> None:
         assert next_observation.shape == environment.observation_space.shape
         assert np.isfinite(reward)
         assert not (terminated and truncated)
-        assert step_info["dataset_id"] == dataset.dataset_id
+        assert "termination_reason" in step_info
     finally:
         environment.close()
 

--- a/tests/examples/test_training_quickstart.py
+++ b/tests/examples/test_training_quickstart.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import numpy as np
+
+from trade_rl.data import load_market_dataset_artifact, write_market_dataset_files
+from trade_rl.workflows.training_run import TrainingRunConfig, _environment_factory
+
+ROOT = Path(__file__).resolve().parents[2]
+QUICKSTART = ROOT / "examples" / "quickstart"
+
+
+def _load_dataset_builder() -> ModuleType:
+    path = QUICKSTART / "create_demo_dataset.py"
+    spec = importlib.util.spec_from_file_location("quickstart_dataset_builder", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("could not load quickstart dataset builder")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_demo_dataset_is_deterministic_and_round_trips(tmp_path: Path) -> None:
+    module = _load_dataset_builder()
+    first = module.build_demo_dataset(512)
+    second = module.build_demo_dataset(512)
+
+    assert first.dataset_id == second.dataset_id
+    assert first.symbols == ("BTCUSDT",)
+    assert first.feature_names == ("log_return_1h", "volatility_24h")
+    assert first.global_feature_names == ("market_trend_24h",)
+    np.testing.assert_array_equal(first.close, second.close)
+    np.testing.assert_array_equal(first.features, second.features)
+
+    result = write_market_dataset_files(tmp_path, first)
+    restored = load_market_dataset_artifact(tmp_path)
+
+    assert result.manifest_path == tmp_path / "manifest.json"
+    assert result.arrays_path == tmp_path / "arrays.npz"
+    assert restored.dataset_id == first.dataset_id
+    np.testing.assert_array_equal(restored.close, first.close)
+
+
+def test_quickstart_config_builds_a_compatible_environment() -> None:
+    module = _load_dataset_builder()
+    dataset = module.build_demo_dataset(1_024)
+    config = TrainingRunConfig.from_json(QUICKSTART / "training.json")
+
+    assert config.training.timesteps == 512
+    assert config.training.device == "cpu"
+    assert config.training.seeds == (0,)
+    assert config.action.names == ("fast_tilt", "slow_tilt", "risk_tilt")
+    assert config.environment.initial_capital == 100_000.0
+
+    environment = _environment_factory(dataset, config)()
+    try:
+        observation, info = environment.reset(seed=0)
+        assert observation.shape == environment.observation_space.shape
+        assert info["dataset_id"] == dataset.dataset_id
+        action = np.zeros(environment.action_space.shape, dtype=np.float32)
+        next_observation, reward, terminated, truncated, step_info = environment.step(
+            action
+        )
+        assert next_observation.shape == environment.observation_space.shape
+        assert np.isfinite(reward)
+        assert not (terminated and truncated)
+        assert step_info["dataset_id"] == dataset.dataset_id
+    finally:
+        environment.close()
+
+
+def test_start_document_references_existing_quickstart_assets() -> None:
+    start = (ROOT / "START.md").read_text(encoding="utf-8")
+
+    assert "examples/quickstart/create_demo_dataset.py" in start
+    assert "examples/quickstart/training.json" in start
+    assert "trade-rl train run" in start
+    assert "production_status" in start
+    assert (QUICKSTART / "create_demo_dataset.py").is_file()
+    assert (QUICKSTART / "training.json").is_file()


### PR DESCRIPTION
## Summary

- add root `START.md` with a three-command first training run
- add deterministic demo market-data artifact generation
- add a CPU-friendly maintained PPO configuration for `trade-rl train run`
- document artifact inspection, reruns, GPU settings, larger training, real data, alpha/factor setup and failure isolation
- add integration tests for dataset round-trip, production config parsing and environment reset/step compatibility
- link the quickstart from README

## Safety

The demo data is explicitly limited to pipeline verification. The documentation keeps production status `NO-GO` and makes no profitability claim.

## Verification

Standard CI passed on head `ba0232cf081b0a6cb1e1e2aa3939c346106980f3`:

- dependency installation: passed
- Ruff: passed
- Ruff format check: passed
- mypy: passed
- import-linter: passed
- dead-code report: passed
- full pytest with branch coverage: passed
- critical branch coverage: passed
- CLI smoke test: passed

The quickstart-specific tests verify deterministic dataset identity, artifact round-trip, production `TrainingRunConfig` parsing and a real environment reset/step.