### PR TITLE
Make native multi-timeframe training authoritative

### DIFF
--- a/.github/scripts/add_binance_vision_cache.py
+++ b/.github/scripts/add_binance_vision_cache.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+path = Path("trade_rl/integrations/binance.py")
+text = path.read_text(encoding="utf-8")
+if "import hashlib\n" not in text:
+    text = text.replace("import csv\n", "import csv\nimport hashlib\n", 1)
+if "from pathlib import Path\n" not in text:
+    text = text.replace("from enum import StrEnum\n", "from enum import StrEnum\nfrom pathlib import Path\n", 1)
+old_init = '''    def __init__(
+        self,
+        *,
+        timeout_seconds: float = 30.0,
+        max_attempts: int = 3,
+        retry_backoff_seconds: float = 0.25,
+    ) -> None:
+'''
+new_init = '''    def __init__(
+        self,
+        *,
+        timeout_seconds: float = 30.0,
+        max_attempts: int = 3,
+        retry_backoff_seconds: float = 0.25,
+        cache_root: str | Path | None = None,
+    ) -> None:
+'''
+if new_init not in text:
+    if old_init not in text:
+        raise RuntimeError("BinancePublicTransport constructor was not found")
+    text = text.replace(old_init, new_init, 1)
+old_assign = '''        self.timeout_seconds = timeout_seconds
+        self.max_attempts = max_attempts
+        self.retry_backoff_seconds = retry_backoff_seconds
+
+    def _request_bytes(self, url: str) -> bytes:
+        request = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+'''
+new_assign = '''        self.timeout_seconds = timeout_seconds
+        self.max_attempts = max_attempts
+        self.retry_backoff_seconds = retry_backoff_seconds
+        self.cache_root = None if cache_root is None else Path(cache_root)
+
+    def _vision_cache_path(self, url: str) -> Path | None:
+        if self.cache_root is None or not url.startswith(f"{_VISION_ROOT}/"):
+            return None
+        digest = hashlib.sha256(url.encode("utf-8")).hexdigest()
+        return self.cache_root / digest[:2] / f"{digest}.bin"
+
+    def _request_bytes(self, url: str) -> bytes:
+        cache_path = self._vision_cache_path(url)
+        if cache_path is not None and cache_path.is_file():
+            payload = cache_path.read_bytes()
+            if not payload:
+                raise BinanceTransportError(
+                    f"cached Binance Vision archive is empty: {cache_path}"
+                )
+            return payload
+        request = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+'''
+if new_assign not in text:
+    if old_assign not in text:
+        raise RuntimeError("BinancePublicTransport request boundary was not found")
+    text = text.replace(old_assign, new_assign, 1)
+old_return = '''                with urllib.request.urlopen(  # noqa: S310 - fixed HTTPS endpoints
+                    request,
+                    timeout=self.timeout_seconds,
+                ) as response:
+                    return response.read()
+'''
+new_return = '''                with urllib.request.urlopen(  # noqa: S310 - fixed HTTPS endpoints
+                    request,
+                    timeout=self.timeout_seconds,
+                ) as response:
+                    payload = response.read()
+                if not payload:
+                    raise BinanceTransportError(
+                        f"Binance returned an empty response for {url}"
+                    )
+                if cache_path is not None:
+                    cache_path.parent.mkdir(parents=True, exist_ok=True)
+                    temporary = cache_path.with_suffix(".tmp")
+                    temporary.write_bytes(payload)
+                    temporary.replace(cache_path)
+                return payload
+'''
+if new_return not in text:
+    if old_return not in text:
+        raise RuntimeError("BinancePublicTransport response block was not found")
+    text = text.replace(old_return, new_return, 1)
+path.write_text(text, encoding="utf-8")

--- a/.github/scripts/apply_binance_multitimeframe.py
+++ b/.github/scripts/apply_binance_multitimeframe.py
@@ -1,0 +1,489 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def replace_once(path: str, old: str, new: str) -> None:
+    file = Path(path)
+    text = file.read_text(encoding="utf-8")
+    if new in text:
+        return
+    if old not in text:
+        raise RuntimeError(f"expected snippet not found in {path}: {old[:160]!r}")
+    file.write_text(text.replace(old, new, 1), encoding="utf-8")
+
+
+replace_once(
+    "trade_rl/integrations/binance.py",
+    "class BinanceDatasetBuildResult:\n"
+    "    dataset: MarketDataset\n"
+    "    metadata: tuple[BinanceInstrumentMetadata, ...]\n"
+    "    sources_used: tuple[str, ...]\n",
+    "class BinanceDatasetBuildResult:\n"
+    "    dataset: MarketDataset\n"
+    "    metadata: tuple[BinanceInstrumentMetadata, ...]\n"
+    "    sources_used: tuple[str, ...]\n"
+    "    feature_timeframes: tuple[str, ...] = ()\n",
+)
+
+replace_once(
+    "trade_rl/integrations/binance.py",
+    "def vision_funding_url(\n",
+    "def vision_monthly_kline_url(\n"
+    "    market: BinanceMarket | str,\n"
+    "    symbol: str,\n"
+    "    interval: str,\n"
+    "    month: datetime,\n"
+    ") -> str:\n"
+    "    resolved = _market(market)\n"
+    "    _interval_ms(interval)\n"
+    "    period = _aware_utc(month, field=\"month\").strftime(\"%Y-%m\")\n"
+    "    if resolved is BinanceMarket.SPOT:\n"
+    "        prefix = \"spot/monthly/klines\"\n"
+    "    elif resolved is BinanceMarket.USDS_M:\n"
+    "        prefix = \"futures/um/monthly/klines\"\n"
+    "    else:\n"
+    "        prefix = \"futures/cm/monthly/klines\"\n"
+    "    return (\n"
+    "        f\"{_VISION_ROOT}/{prefix}/{symbol}/{interval}/\"\n"
+    "        f\"{symbol}-{interval}-{period}.zip\"\n"
+    "    )\n\n\n"
+    "def _next_month(value: datetime) -> datetime:\n"
+    "    if value.month == 12:\n"
+    "        return value.replace(year=value.year + 1, month=1, day=1)\n"
+    "    return value.replace(month=value.month + 1, day=1)\n\n\n"
+    "def plan_vision_kline_urls(\n"
+    "    market: BinanceMarket | str,\n"
+    "    symbol: str,\n"
+    "    interval: str,\n"
+    "    start_time: datetime,\n"
+    "    end_time: datetime,\n"
+    ") -> tuple[str, ...]:\n"
+    "    start = _aware_utc(start_time, field=\"start_time\")\n"
+    "    end = _aware_utc(end_time, field=\"end_time\")\n"
+    "    if end <= start:\n"
+    "        raise ValueError(\"end_time must be later than start_time\")\n"
+    "    cursor = start.replace(hour=0, minute=0, second=0, microsecond=0)\n"
+    "    urls: list[str] = []\n"
+    "    while cursor < end:\n"
+    "        month_start = cursor.replace(day=1)\n"
+    "        next_month = _next_month(month_start)\n"
+    "        if cursor == month_start and start <= cursor and next_month <= end:\n"
+    "            urls.append(\n"
+    "                vision_monthly_kline_url(\n"
+    "                    market, symbol, interval, month_start\n"
+    "                )\n"
+    "            )\n"
+    "            cursor = next_month\n"
+    "        else:\n"
+    "            urls.append(vision_kline_url(market, symbol, interval, cursor))\n"
+    "            cursor += timedelta(days=1)\n"
+    "    return tuple(urls)\n\n\n"
+    "def vision_funding_url(\n",
+)
+
+replace_once(
+    "trade_rl/integrations/binance.py",
+    "    def _load_vision_klines(\n"
+    "        self,\n"
+    "        *,\n"
+    "        market: BinanceMarket,\n"
+    "        symbol: str,\n"
+    "        interval: str,\n"
+    "        start_ms: int,\n"
+    "        end_ms: int,\n"
+    "    ) -> list[list[object]]:\n"
+    "        result: list[list[object]] = []\n"
+    "        for day in _iter_days(start_ms, end_ms):\n"
+    "            url = vision_kline_url(market, symbol, interval, day)\n"
+    "            rows = _csv_rows_from_zip(self._request_bytes(url), source=url)\n"
+    "            if rows and _looks_like_header(rows[0]):\n"
+    "                rows = rows[1:]\n"
+    "            for row in rows:\n"
+    "                if len(row) < 8:\n"
+    "                    raise BinanceTransportError(\n"
+    "                        f\"Binance Vision kline row is short: {url}\"\n"
+    "                    )\n"
+    "                open_ms = _normalize_epoch_ms(row[0])\n"
+    "                if start_ms <= open_ms < end_ms:\n"
+    "                    result.append(list(row))\n"
+    "        return result\n",
+    "    def _load_vision_klines(\n"
+    "        self,\n"
+    "        *,\n"
+    "        market: BinanceMarket,\n"
+    "        symbol: str,\n"
+    "        interval: str,\n"
+    "        start_ms: int,\n"
+    "        end_ms: int,\n"
+    "    ) -> list[list[object]]:\n"
+    "        result: list[list[object]] = []\n"
+    "        start_time = datetime.fromtimestamp(start_ms / 1_000, tz=UTC)\n"
+    "        end_time = datetime.fromtimestamp(end_ms / 1_000, tz=UTC)\n"
+    "        for url in plan_vision_kline_urls(\n"
+    "            market, symbol, interval, start_time, end_time\n"
+    "        ):\n"
+    "            rows = _csv_rows_from_zip(self._request_bytes(url), source=url)\n"
+    "            if rows and _looks_like_header(rows[0]):\n"
+    "                rows = rows[1:]\n"
+    "            for row in rows:\n"
+    "                if len(row) < 8:\n"
+    "                    raise BinanceTransportError(\n"
+    "                        f\"Binance Vision kline row is short: {url}\"\n"
+    "                    )\n"
+    "                open_ms = _normalize_epoch_ms(row[0])\n"
+    "                if start_ms <= open_ms < end_ms:\n"
+    "                    result.append(list(row))\n"
+    "        return result\n",
+)
+
+replace_once(
+    "trade_rl/integrations/binance.py",
+    "    if len(parsed) < 3:\n"
+    "        raise ValueError(\"Binance range must contain at least three closed bars\")\n",
+    "    if len(parsed) < 2:\n"
+    "        raise ValueError(\"Binance range must contain at least two closed bars\")\n",
+)
+
+source_start = "class BinanceMarketDataSource(MarketDataSource):\n"
+source_end = "\n\ndef _filter_value(\n"
+path = Path("trade_rl/integrations/binance.py")
+text = path.read_text(encoding="utf-8")
+if "def load_timeframe(self, symbol: str, timeframe: str)" not in text:
+    start = text.index(source_start)
+    end = text.index(source_end, start)
+    replacement = '''class BinanceMarketDataSource(MarketDataSource):
+    """Load one fixed Binance range on one or more causal native clocks."""
+
+    def __init__(
+        self,
+        *,
+        market: BinanceMarket | str,
+        interval: str,
+        start_time: datetime,
+        end_time: datetime,
+        transport_mode: BinanceTransportMode | str = BinanceTransportMode.AUTO,
+        transport: Any | None = None,
+    ) -> None:
+        self.market = _market(market)
+        self.interval = interval
+        self.interval_ms = _interval_ms(interval)
+        self.start_time = _aware_utc(start_time, field="start_time")
+        self.end_time = _aware_utc(end_time, field="end_time")
+        if self.end_time <= self.start_time:
+            raise ValueError("end_time must be later than start_time")
+        start_ms = _epoch_ms(self.start_time)
+        end_ms = _epoch_ms(self.end_time)
+        if start_ms % self.interval_ms != 0 or end_ms % self.interval_ms != 0:
+            raise ValueError("Binance range boundaries must align to the interval")
+        self.transport_mode = _mode(transport_mode)
+        self.transport = transport or BinancePublicTransport()
+        self._sources_used: set[str] = set()
+        self._series_cache: dict[tuple[str, str], RawMarketSeries] = {}
+        self._funding_cache: dict[str, tuple[list[tuple[int, float]], object]] = {}
+
+    @property
+    def sources_used(self) -> tuple[str, ...]:
+        return tuple(sorted(self._sources_used))
+
+    def _record_source(self, source: object) -> None:
+        if isinstance(source, str):
+            self._sources_used.add(source)
+            return
+        if isinstance(source, Sequence):
+            self._sources_used.update(str(item) for item in source)
+            return
+        self._sources_used.add(str(source))
+
+    def _funding_events(self, symbol: str) -> list[tuple[int, float]]:
+        cached = self._funding_cache.get(symbol)
+        if cached is None:
+            events, funding_source = self.transport.load_funding_rates(
+                market=self.market,
+                symbol=symbol,
+                start_ms=_epoch_ms(self.start_time),
+                end_ms=_epoch_ms(self.end_time),
+                mode=self.transport_mode,
+            )
+            cached = (list(events), funding_source)
+            self._funding_cache[symbol] = cached
+            self._record_source(funding_source)
+        return cached[0]
+
+    def load(self, symbol: str) -> RawMarketSeries:
+        return self.load_timeframe(symbol, self.interval)
+
+    def load_timeframe(self, symbol: str, timeframe: str) -> RawMarketSeries:
+        if not symbol:
+            raise ValueError("Binance symbol must not be empty")
+        interval_ms = _interval_ms(timeframe)
+        start_ms = _epoch_ms(self.start_time)
+        end_ms = _epoch_ms(self.end_time)
+        if start_ms % interval_ms != 0 or end_ms % interval_ms != 0:
+            raise ValueError(
+                f"Binance range boundaries must align to native timeframe {timeframe}"
+            )
+        key = (symbol, timeframe)
+        cached = self._series_cache.get(key)
+        if cached is not None:
+            return cached
+        rows, kline_source = self.transport.load_klines(
+            market=self.market,
+            symbol=symbol,
+            interval=timeframe,
+            start_ms=start_ms,
+            end_ms=end_ms,
+            mode=self.transport_mode,
+        )
+        self._record_source(kline_source)
+        timestamps, open_price, high, low, close, volume = _parse_kline_rows(
+            rows,
+            interval_ms=interval_ms,
+            start_ms=start_ms,
+            end_ms=end_ms,
+        )
+        if timeframe == self.interval:
+            funding, funding_available = _align_funding(
+                timestamps,
+                self._funding_events(symbol),
+            )
+        else:
+            funding = np.zeros(len(timestamps), dtype=np.float64)
+            funding_available = np.zeros(len(timestamps), dtype=np.bool_)
+        series = RawMarketSeries(
+            timestamps=timestamps,
+            available_at=timestamps,
+            open=open_price,
+            high=high,
+            low=low,
+            close=close,
+            volume=volume,
+            funding_rate=funding,
+            funding_available=funding_available,
+            tradable=np.ones(len(timestamps), dtype=np.bool_),
+        )
+        self._series_cache[key] = series
+        return series
+'''
+    path.write_text(text[:start] + replacement + text[end:], encoding="utf-8")
+
+replace_once(
+    "trade_rl/integrations/binance.py",
+    "def _default_features(interval: str) -> tuple[FeatureSpec, ...]:\n",
+    "def binance_multitimeframe_feature_specs(\n"
+    "    *,\n"
+    "    base_timeframe: str,\n"
+    "    feature_timeframes: Sequence[str],\n"
+    ") -> tuple[FeatureSpec, ...]:\n"
+    "    _interval_ms(base_timeframe)\n"
+    "    resolved = tuple(feature_timeframes)\n"
+    "    if len(set(resolved)) != len(resolved):\n"
+    "        raise ValueError(\"duplicate Binance feature timeframes are not allowed\")\n"
+    "    if base_timeframe in resolved:\n"
+    "        raise ValueError(\"base timeframe must not be repeated as a feature timeframe\")\n"
+    "    for timeframe in resolved:\n"
+    "        _interval_ms(timeframe)\n"
+    "    ordered = tuple(\n"
+    "        sorted((*resolved, base_timeframe), key=_interval_ms)\n"
+    "    )\n"
+    "    features: list[FeatureSpec] = []\n"
+    "    for timeframe in ordered:\n"
+    "        native = None if timeframe == base_timeframe else timeframe\n"
+    "        native_hours = _interval_ms(timeframe) / 3_600_000.0\n"
+    "        staleness = max(native_hours * 2.0, base_timeframe == timeframe and 1.0 or native_hours)\n"
+    "        features.append(\n"
+    "            FeatureSpec(\n"
+    "                name=f\"{timeframe}__log_return_1bar\",\n"
+    "                kind=FeatureKind.LOG_RETURN,\n"
+    "                timeframe=native,\n"
+    "                lookback=1,\n"
+    "                max_staleness_hours=staleness,\n"
+    "            )\n"
+    "        )\n"
+    "        if timeframe == base_timeframe:\n"
+    "            one_day = max(1, int(round(24.0 / native_hours)))\n"
+    "            features.extend(\n"
+    "                (\n"
+    "                    FeatureSpec(\n"
+    "                        name=f\"{timeframe}__log_return_1d\",\n"
+    "                        kind=FeatureKind.LOG_RETURN,\n"
+    "                        lookback=one_day,\n"
+    "                        max_staleness_hours=staleness,\n"
+    "                    ),\n"
+    "                    FeatureSpec(\n"
+    "                        name=f\"{timeframe}__volume_zscore_1d\",\n"
+    "                        kind=FeatureKind.VOLUME_ZSCORE,\n"
+    "                        lookback=one_day,\n"
+    "                        min_periods=min(one_day, 2),\n"
+    "                        max_staleness_hours=staleness,\n"
+    "                    ),\n"
+    "                    FeatureSpec(\n"
+    "                        name=f\"{timeframe}__funding_bps\",\n"
+    "                        kind=FeatureKind.FUNDING_BPS,\n"
+    "                        max_staleness_hours=8.0,\n"
+    "                    ),\n"
+    "                )\n"
+    "            )\n"
+    "        elif timeframe == \"1d\":\n"
+    "            features.append(\n"
+    "                FeatureSpec(\n"
+    "                    name=\"1d__log_return_7bar\",\n"
+    "                    kind=FeatureKind.LOG_RETURN,\n"
+    "                    timeframe=\"1d\",\n"
+    "                    lookback=7,\n"
+    "                    max_staleness_hours=48.0,\n"
+    "                )\n"
+    "            )\n"
+    "        else:\n"
+    "            one_day = max(2, int(round(24.0 / native_hours)))\n"
+    "            features.append(\n"
+    "                FeatureSpec(\n"
+    "                    name=f\"{timeframe}__realized_volatility_{one_day}bar\",\n"
+    "                    kind=FeatureKind.REALIZED_VOLATILITY,\n"
+    "                    timeframe=timeframe,\n"
+    "                    lookback=one_day,\n"
+    "                    max_staleness_hours=staleness,\n"
+    "                )\n"
+    "            )\n"
+    "    return tuple(features)\n\n\n"
+    "def _default_features(interval: str) -> tuple[FeatureSpec, ...]:\n",
+)
+
+replace_once(
+    "trade_rl/integrations/binance.py",
+    "    listed_ats: Sequence[datetime] | None = None,\n"
+    ") -> BinanceDatasetBuildResult:\n",
+    "    listed_ats: Sequence[datetime] | None = None,\n"
+    "    feature_timeframes: Sequence[str] | None = None,\n"
+    ") -> BinanceDatasetBuildResult:\n",
+)
+
+replace_once(
+    "trade_rl/integrations/binance.py",
+    "    resolved_mode = _mode(transport_mode)\n"
+    "    resolved_tick = _optional_values(\n",
+    "    resolved_mode = _mode(transport_mode)\n"
+    "    requested_feature_timeframes = tuple(feature_timeframes or ())\n"
+    "    resolved_features = (\n"
+    "        _default_features(interval)\n"
+    "        if not requested_feature_timeframes\n"
+    "        else binance_multitimeframe_feature_specs(\n"
+    "            base_timeframe=interval,\n"
+    "            feature_timeframes=requested_feature_timeframes,\n"
+    "        )\n"
+    "    )\n"
+    "    resolved_tick = _optional_values(\n",
+)
+
+replace_once(
+    "trade_rl/integrations/binance.py",
+    "            base_timeframe=interval,\n"
+    "            features=_default_features(interval),\n",
+    "            base_timeframe=interval,\n"
+    "            features=resolved_features,\n",
+)
+
+replace_once(
+    "trade_rl/integrations/binance.py",
+    "        sources_used=tuple(sorted(sources)),\n"
+    "    )\n",
+    "        sources_used=tuple(sorted(sources)),\n"
+    "        feature_timeframes=tuple(\n"
+    "            sorted(\n"
+    "                {\n"
+    "                    spec.resolved_timeframe(interval)\n"
+    "                    for spec in resolved_features\n"
+    "                },\n"
+    "                key=_interval_ms,\n"
+    "            )\n"
+    "        ),\n"
+    "    )\n",
+)
+
+replace_once(
+    "trade_rl/integrations/binance.py",
+    "    \"build_binance_market_dataset\",\n"
+    "    \"vision_funding_url\",\n"
+    "    \"vision_kline_url\",\n",
+    "    \"binance_multitimeframe_feature_specs\",\n"
+    "    \"build_binance_market_dataset\",\n"
+    "    \"plan_vision_kline_urls\",\n"
+    "    \"vision_funding_url\",\n"
+    "    \"vision_kline_url\",\n"
+    "    \"vision_monthly_kline_url\",\n",
+)
+
+replace_once(
+    "trade_rl/cli/app.py",
+    "        transport_mode=args.transport,\n"
+    "        tick_sizes=_repeated_float_values(\n",
+    "        transport_mode=args.transport,\n"
+    "        feature_timeframes=tuple(args.feature_timeframe or ()),\n"
+    "        tick_sizes=_repeated_float_values(\n",
+)
+
+replace_once(
+    "trade_rl/cli/app.py",
+    "    _write_json(\n"
+    "        stdout,\n"
+    "        {\n"
+    "            \"artifact_digest\": artifact_digest,\n",
+    "    payload: dict[str, object] = {\n"
+    "        \"artifact_digest\": artifact_digest,\n"
+    "        \"dataset_id\": result.dataset.dataset_id,\n"
+    "        \"end_time\": end_time.isoformat(),\n"
+    "        \"interval\": args.interval,\n"
+    "        \"market\": args.market,\n"
+    "        \"n_bars\": result.dataset.n_bars,\n"
+    "        \"n_features\": result.dataset.n_features,\n"
+    "        \"n_symbols\": result.dataset.n_symbols,\n"
+    "        \"production_status\": \"NO-GO\",\n"
+    "        \"schema\": \"binance_dataset_build_result_v1\",\n"
+    "        \"sources_used\": list(result.sources_used),\n"
+    "        \"start_time\": start_time.isoformat(),\n"
+    "        \"symbols\": list(result.dataset.symbols),\n"
+    "        \"transport\": args.transport,\n"
+    "    }\n"
+    "    if args.feature_timeframe:\n"
+    "        payload[\"feature_timeframes\"] = list(result.feature_timeframes)\n"
+    "    _write_json(stdout, payload)\n"
+    "    return 0\n\n\n"
+    "def _status_handler(area: str) -> Callable[[argparse.Namespace, TextIO], int]:\n"
+    "    def handler(_: argparse.Namespace, stdout: TextIO) -> int:\n"
+    "        _write_json(\n"
+    "            stdout,\n"
+    "            {\n"
+    "                \"area\": area,\n"
+    "                \"authoritative_package\": \"trade_rl\",\n"
+    "                \"production_status\": \"NO-GO\",\n"
+    "                \"schema\": \"component_status_v1\",\n"
+    "            },\n"
+    "        )\n"
+    "        return 0\n\n\n"
+    "def _removed_original_data_binance_payload_marker() -> None:\n"
+    "    _write_json(\n"
+    "        sys.stdout,\n"
+    "        {\n"
+    "            \"artifact_digest\": artifact_digest,\n",
+)
+
+# Remove the temporarily retained original tail inserted by the structural replacement.
+path = Path("trade_rl/cli/app.py")
+text = path.read_text(encoding="utf-8")
+marker = "\n\ndef _removed_original_data_binance_payload_marker() -> None:\n"
+if marker in text:
+    start = text.index(marker)
+    end = text.index("\n\ndef _status_handler", start)
+    text = text[:start] + text[end:]
+    path.write_text(text, encoding="utf-8")
+
+replace_once(
+    "trade_rl/cli/app.py",
+    "    data_binance.add_argument(\"--start-time\", required=True)\n",
+    "    data_binance.add_argument(\n"
+    "        \"--feature-timeframe\",\n"
+    "        choices=(\"15m\", \"30m\", \"1h\", \"2h\", \"4h\", \"6h\", \"8h\", \"12h\", \"1d\"),\n"
+    "        action=\"append\",\n"
+    "    )\n"
+    "    data_binance.add_argument(\"--start-time\", required=True)\n",
+)

--- a/.github/scripts/apply_multitimeframe_builder.py
+++ b/.github/scripts/apply_multitimeframe_builder.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def replace_once(path: str, old: str, new: str) -> None:
+    file = Path(path)
+    text = file.read_text(encoding="utf-8")
+    if new in text:
+        return
+    if old not in text:
+        raise RuntimeError(f"expected snippet not found in {path}: {old[:120]!r}")
+    file.write_text(text.replace(old, new, 1), encoding="utf-8")
+
+
+replace_once(
+    "trade_rl/data/builder.py",
+    "from trade_rl.data.market import MarketDataset\n"
+    "from trade_rl.data.source import MarketDataSource, RawMarketSeries\n",
+    "from trade_rl.data.market import MarketDataset\n"
+    "from trade_rl.data.multitimeframe import align_native_feature\n"
+    "from trade_rl.data.source import (\n"
+    "    MarketDataSource,\n"
+    "    MultiTimeframeMarketDataSource,\n"
+    "    RawMarketSeries,\n"
+    ")\n",
+)
+
+replace_once(
+    "trade_rl/data/builder.py",
+    "        for symbol_index in range(n_symbols):\n"
+    "            for feature_index, spec in enumerate(self.config.features):\n"
+    "                event_values, event_valid = _feature_events(\n"
+    "                    spec,\n"
+    "                    close=close[:, symbol_index],\n"
+    "                    volume=volume[:, symbol_index],\n"
+    "                    funding_rate=funding_rate[:, symbol_index],\n"
+    "                    funding_available=funding_available[:, symbol_index],\n"
+    "                    row_present=causal_row_present[:, symbol_index],\n"
+    "                    active=symbol_active[:, symbol_index],\n"
+    "                )\n"
+    "                values, available, age_hours, staleness = _carry_feature(\n"
+    "                    event_values,\n"
+    "                    event_valid,\n"
+    "                    symbol_active[:, symbol_index],\n"
+    "                    timestamps,\n"
+    "                    max_staleness_hours=spec.max_staleness_hours,\n"
+    "                )\n"
+    "                features[:, symbol_index, feature_index] = values\n"
+    "                feature_available[:, symbol_index, feature_index] = available\n"
+    "                feature_age_hours[:, symbol_index, feature_index] = age_hours\n"
+    "                feature_staleness[:, symbol_index, feature_index] = staleness\n",
+    "        native_cache: dict[tuple[str, str], RawMarketSeries] = {}\n"
+    "        for symbol_index, contract in enumerate(instruments):\n"
+    "            for feature_index, spec in enumerate(self.config.features):\n"
+    "                native_timeframe = spec.resolved_timeframe(\n"
+    "                    self.config.base_timeframe\n"
+    "                )\n"
+    "                if native_timeframe == self.config.base_timeframe:\n"
+    "                    event_values, event_valid = _feature_events(\n"
+    "                        spec,\n"
+    "                        close=close[:, symbol_index],\n"
+    "                        volume=volume[:, symbol_index],\n"
+    "                        funding_rate=funding_rate[:, symbol_index],\n"
+    "                        funding_available=funding_available[:, symbol_index],\n"
+    "                        row_present=causal_row_present[:, symbol_index],\n"
+    "                        active=symbol_active[:, symbol_index],\n"
+    "                    )\n"
+    "                    values, available, age_hours, staleness = _carry_feature(\n"
+    "                        event_values,\n"
+    "                        event_valid,\n"
+    "                        symbol_active[:, symbol_index],\n"
+    "                        timestamps,\n"
+    "                        max_staleness_hours=spec.max_staleness_hours,\n"
+    "                    )\n"
+    "                else:\n"
+    "                    if not isinstance(source, MultiTimeframeMarketDataSource):\n"
+    "                        raise ValueError(\n"
+    "                            \"native multi-timeframe features require a \"\n"
+    "                            \"MultiTimeframeMarketDataSource\"\n"
+    "                        )\n"
+    "                    key = (contract.symbol, native_timeframe)\n"
+    "                    native = native_cache.get(key)\n"
+    "                    if native is None:\n"
+    "                        native = source.load_timeframe(\n"
+    "                            contract.symbol, native_timeframe\n"
+    "                        )\n"
+    "                        native_cache[key] = native\n"
+    "                    values, available, age_hours, staleness = (\n"
+    "                        align_native_feature(\n"
+    "                            spec,\n"
+    "                            native,\n"
+    "                            contract,\n"
+    "                            timestamps,\n"
+    "                            symbol_active[:, symbol_index],\n"
+    "                            timeframe=native_timeframe,\n"
+    "                        )\n"
+    "                    )\n"
+    "                features[:, symbol_index, feature_index] = values\n"
+    "                feature_available[:, symbol_index, feature_index] = available\n"
+    "                feature_age_hours[:, symbol_index, feature_index] = age_hours\n"
+    "                feature_staleness[:, symbol_index, feature_index] = staleness\n",
+)

--- a/.github/scripts/fix_accounting_peak_tolerance.py
+++ b/.github/scripts/fix_accounting_peak_tolerance.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+path = Path("trade_rl/simulation/accounting.py")
+text = path.read_text(encoding="utf-8")
+old = '''        self._refresh_economic_state()
+        if not self.insolvent and self.peak_value + _TOLERANCE < self.portfolio_value:
+            raise ValueError("peak_value cannot be below portfolio_value")
+'''
+new = '''        self._refresh_economic_state()
+        portfolio_value = self.portfolio_value
+        comparison_tolerance = max(
+            _TOLERANCE,
+            abs(portfolio_value) * 1e-12,
+            abs(self.peak_value) * 1e-12,
+        )
+        if (
+            not self.insolvent
+            and self.peak_value + comparison_tolerance < portfolio_value
+        ):
+            raise ValueError("peak_value cannot be below portfolio_value")
+'''
+if new not in text:
+    if old not in text:
+        raise RuntimeError("BookState peak invariant boundary was not found")
+    path.write_text(text.replace(old, new, 1), encoding="utf-8")

--- a/.github/scripts/fix_binance_multitimeframe_preset.py
+++ b/.github/scripts/fix_binance_multitimeframe_preset.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+path = Path("trade_rl/integrations/binance.py")
+text = path.read_text(encoding="utf-8")
+old = '''        else:
+            one_day = max(2, int(round(24.0 / native_hours)))
+            features.append(
+                FeatureSpec(
+                    name=f"{timeframe}__realized_volatility_{one_day}bar",
+                    kind=FeatureKind.REALIZED_VOLATILITY,
+                    timeframe=timeframe,
+                    lookback=one_day,
+                    max_staleness_hours=staleness,
+                )
+            )
+'''
+new = '''        else:
+            volatility_lookback = 4 if timeframe == "15m" else max(
+                2, int(round(24.0 / native_hours))
+            )
+            features.append(
+                FeatureSpec(
+                    name=(
+                        f"{timeframe}__realized_volatility_"
+                        f"{volatility_lookback}bar"
+                    ),
+                    kind=FeatureKind.REALIZED_VOLATILITY,
+                    timeframe=timeframe,
+                    lookback=volatility_lookback,
+                    max_staleness_hours=staleness,
+                )
+            )
+'''
+if new not in text:
+    if old not in text:
+        raise RuntimeError("expected Binance multi-timeframe preset was not found")
+    path.write_text(text.replace(old, new, 1), encoding="utf-8")

--- a/.github/scripts/fix_multitimeframe_full_bar_count.py
+++ b/.github/scripts/fix_multitimeframe_full_bar_count.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+path = Path("examples/binance-multitimeframe/run_full_research.py")
+text = path.read_text(encoding="utf-8")
+text = text.replace("13_104", "13_128")
+text = text.replace("13,104", "13,128")
+path.write_text(text, encoding="utf-8")

--- a/.github/scripts/repair_binance_cli.py
+++ b/.github/scripts/repair_binance_cli.py
@@ -5,7 +5,7 @@ from pathlib import Path
 path = Path("trade_rl/cli/app.py")
 text = path.read_text(encoding="utf-8")
 start = text.index("def _data_build(")
-end = text.index("def _status_handler(", start)
+end = text.rindex("def _status_handler(")
 replacement = '''def _data_build(args: argparse.Namespace, stdout: TextIO) -> int:
     request = load_market_build_request(args.config)
     dataset = MarketDatasetBuilder(request.config).build(

--- a/.github/scripts/repair_binance_cli.py
+++ b/.github/scripts/repair_binance_cli.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+path = Path("trade_rl/cli/app.py")
+text = path.read_text(encoding="utf-8")
+start = text.index("def _data_build(")
+end = text.index("def _status_handler(", start)
+replacement = '''def _data_build(args: argparse.Namespace, stdout: TextIO) -> int:
+    request = load_market_build_request(args.config)
+    dataset = MarketDatasetBuilder(request.config).build(
+        CsvMarketDataSource(request.source_root),
+        request.instruments,
+    )
+    artifact_digest = publish_market_dataset_artifact(
+        args.output, dataset
+    ).artifact_digest
+    _write_json(
+        stdout,
+        {
+            "artifact_digest": artifact_digest,
+            "dataset_id": dataset.dataset_id,
+            "n_bars": dataset.n_bars,
+            "n_features": dataset.n_features,
+            "n_symbols": dataset.n_symbols,
+            "schema": "market_dataset_build_result_v1",
+        },
+    )
+    return 0
+
+
+def _parse_aware_datetime(value: str, *, field: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(f"{field} must be an ISO-8601 datetime") from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError(f"{field} must include a timezone")
+    return parsed.astimezone(UTC)
+
+
+def _repeated_float_values(
+    values: list[float] | None,
+    *,
+    symbols: tuple[str, ...],
+    field: str,
+) -> tuple[float, ...] | None:
+    if not values:
+        return None
+    if len(values) != len(symbols):
+        raise ValueError(f"{field} must be supplied once per symbol")
+    return tuple(values)
+
+
+def _repeated_datetime_values(
+    values: list[str] | None,
+    *,
+    symbols: tuple[str, ...],
+) -> tuple[datetime, ...] | None:
+    if not values:
+        return None
+    if len(values) != len(symbols):
+        raise ValueError("listed-at must be supplied once per symbol")
+    return tuple(_parse_aware_datetime(value, field="listed-at") for value in values)
+
+
+def _data_binance(args: argparse.Namespace, stdout: TextIO) -> int:
+    symbols = tuple(args.symbol)
+    start_time = _parse_aware_datetime(args.start_time, field="start-time")
+    end_time = _parse_aware_datetime(args.end_time, field="end-time")
+    result = build_binance_market_dataset(
+        market=args.market,
+        symbols=symbols,
+        interval=args.interval,
+        start_time=start_time,
+        end_time=end_time,
+        transport_mode=args.transport,
+        feature_timeframes=tuple(args.feature_timeframe or ()),
+        tick_sizes=_repeated_float_values(
+            args.tick_size, symbols=symbols, field="tick-size"
+        ),
+        lot_sizes=_repeated_float_values(
+            args.lot_size, symbols=symbols, field="lot-size"
+        ),
+        minimum_notionals=_repeated_float_values(
+            args.minimum_notional,
+            symbols=symbols,
+            field="minimum-notional",
+        ),
+        listed_ats=_repeated_datetime_values(args.listed_at, symbols=symbols),
+    )
+    artifact_digest = publish_market_dataset_artifact(
+        args.output, result.dataset
+    ).artifact_digest
+    payload: dict[str, object] = {
+        "artifact_digest": artifact_digest,
+        "dataset_id": result.dataset.dataset_id,
+        "end_time": end_time.isoformat(),
+        "interval": args.interval,
+        "market": args.market,
+        "n_bars": result.dataset.n_bars,
+        "n_features": result.dataset.n_features,
+        "n_symbols": result.dataset.n_symbols,
+        "production_status": "NO-GO",
+        "schema": "binance_dataset_build_result_v1",
+        "sources_used": list(result.sources_used),
+        "start_time": start_time.isoformat(),
+        "symbols": list(result.dataset.symbols),
+        "transport": args.transport,
+    }
+    if args.feature_timeframe:
+        payload["feature_timeframes"] = list(result.feature_timeframes)
+    _write_json(stdout, payload)
+    return 0
+
+
+'''
+path.write_text(text[:start] + replacement + text[end:], encoding="utf-8")

--- a/.github/workflows/export-mtf-dataset-for-local.yml
+++ b/.github/workflows/export-mtf-dataset-for-local.yml
@@ -1,0 +1,69 @@
+name: Export MTF Dataset For Local
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  export-dataset:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+          enable-cache: true
+      - run: uv sync
+      - name: Build three-asset multi-timeframe dataset only
+        run: |
+          uv run python - <<'PY'
+          import json
+          import runpy
+          from pathlib import Path
+
+          module = runpy.run_path("examples/binance-multitimeframe/run_full_research.py")
+          root = Path("var/local-dataset-export")
+          root.mkdir(parents=True, exist_ok=True)
+          transport = module["BinancePublicTransport"](
+              timeout_seconds=60.0,
+              max_attempts=4,
+              retry_backoff_seconds=0.5,
+              cache_root=root / "vision-cache",
+          )
+          metadata, source, error = module["_resolve_metadata"](
+              transport,
+              snapshot_path=root / "exchange-info.json",
+          )
+          result = module["_build_dataset"](
+              output=root / "dataset",
+              transport=transport,
+              metadata=metadata,
+          )
+          (root / "result.json").write_text(
+              json.dumps(
+                  {
+                      "dataset": result,
+                      "metadata_source": source,
+                      "metadata_error": error,
+                  },
+                  ensure_ascii=False,
+                  indent=2,
+                  sort_keys=True,
+              ) + "\n",
+              encoding="utf-8",
+          )
+          PY
+      - uses: actions/upload-artifact@v4
+        with:
+          name: trade-rl-local-mtf-dataset
+          retention-days: 1
+          path: |
+            var/local-dataset-export/dataset/arrays.npz
+            var/local-dataset-export/dataset/manifest.json
+            var/local-dataset-export/exchange-info.json
+            var/local-dataset-export/result.json

--- a/.github/workflows/export-source-for-local.yml
+++ b/.github/workflows/export-source-for-local.yml
@@ -1,0 +1,25 @@
+name: Export Source For Local
+
+on:
+  push:
+    branches:
+      - agent/multitimeframe-three-asset-full-training
+
+permissions:
+  contents: read
+
+jobs:
+  export:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Package source
+        run: |
+          tar --exclude='.git' --exclude='var' -czf trade_rl-source.tar.gz .
+      - uses: actions/upload-artifact@v4
+        with:
+          name: trade-rl-local-source
+          path: trade_rl-source.tar.gz
+          retention-days: 1

--- a/.github/workflows/export-source-for-local.yml
+++ b/.github/workflows/export-source-for-local.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - agent/multitimeframe-three-asset-full-training
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/export-source-for-local.yml
+++ b/.github/workflows/export-source-for-local.yml
@@ -20,9 +20,9 @@ jobs:
           fetch-depth: 1
       - name: Package source
         run: |
-          tar --exclude='.git' --exclude='var' -czf trade_rl-source.tar.gz .
+          tar --exclude='.git' --exclude='var' -czf /tmp/trade_rl-source.tar.gz .
       - uses: actions/upload-artifact@v4
         with:
           name: trade-rl-local-source
-          path: trade_rl-source.tar.gz
+          path: /tmp/trade_rl-source.tar.gz
           retention-days: 1

--- a/.github/workflows/fix-accounting-precision.yml
+++ b/.github/workflows/fix-accounting-precision.yml
@@ -1,0 +1,50 @@
+name: Fix Accounting Precision
+
+on:
+  push:
+    branches:
+      - agent/multitimeframe-three-asset-full-training
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  fix:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.head_ref || github.ref_name }}
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync --extra dev --extra train-sb3
+      - name: Confirm accounting regression is red
+        run: |
+          set +e
+          uv run pytest -q tests/simulation/test_accounting_precision.py
+          status=$?
+          if [ "$status" -eq 0 ]; then
+            echo "expected accounting precision regression was already green"
+          fi
+      - name: Apply scale-aware invariant fix
+        run: uv run python .github/scripts/fix_accounting_peak_tolerance.py
+      - name: Format and verify
+        run: |
+          uv run ruff format trade_rl/simulation/accounting.py tests/simulation/test_accounting_precision.py
+          uv run ruff check trade_rl/simulation/accounting.py tests/simulation/test_accounting_precision.py
+          uv run pytest -q \
+            tests/simulation/test_accounting_precision.py \
+            tests/simulation/test_accounting_validation.py \
+            tests/simulation/test_accounting_branch_ratchet.py
+          uv run mypy trade_rl/simulation/accounting.py
+      - name: Commit accounting precision fix
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add trade_rl/simulation/accounting.py tests/simulation/test_accounting_precision.py
+          git commit -m "fix: make peak invariant scale-aware"
+          git push origin HEAD:agent/multitimeframe-three-asset-full-training

--- a/.github/workflows/multitimeframe-development.yml
+++ b/.github/workflows/multitimeframe-development.yml
@@ -26,31 +26,19 @@ jobs:
         run: |
           uv run python .github/scripts/apply_binance_multitimeframe.py
           uv run python .github/scripts/repair_binance_cli.py
+          uv run python .github/scripts/fix_binance_multitimeframe_preset.py
       - name: Format and organize imports
         run: |
           uv run ruff check --fix trade_rl tests
           uv run ruff format trade_rl tests
-      - name: Capture multi-timeframe and Binance tests
+      - name: Multi-timeframe and Binance tests
         run: |
-          set +e
           uv run pytest -q \
             tests/data/test_multitimeframe_builder.py \
             tests/integrations/test_binance.py \
             tests/integrations/test_binance_multitimeframe.py \
             tests/cli/test_binance_data_command.py \
-            tests/cli/test_binance_multitimeframe_command.py \
-            > focused.log 2>&1
-          echo "$?" > focused.status
-          cat focused.log
-          exit 0
-      - uses: actions/upload-artifact@v4
-        with:
-          name: multitimeframe-focused-diagnostics
-          path: |
-            focused.log
-            focused.status
-      - name: Require focused tests
-        run: exit "$(cat focused.status)"
+            tests/cli/test_binance_multitimeframe_command.py
       - name: Lint
         run: uv run ruff check trade_rl tests
       - name: Type check

--- a/.github/workflows/multitimeframe-development.yml
+++ b/.github/workflows/multitimeframe-development.yml
@@ -22,25 +22,30 @@ jobs:
           ref: ${{ github.head_ref || github.ref_name }}
       - uses: astral-sh/setup-uv@v5
       - run: uv sync --extra dev --extra train-sb3
-      - name: Apply generic builder patch
-        run: uv run python .github/scripts/apply_multitimeframe_builder.py
-      - name: Format
-        run: uv run ruff format trade_rl tests
-      - name: Generic multi-timeframe tests
+      - name: Apply Binance multi-timeframe patch
+        run: uv run python .github/scripts/apply_binance_multitimeframe.py
+      - name: Format and organize imports
+        run: |
+          uv run ruff check --fix trade_rl tests
+          uv run ruff format trade_rl tests
+      - name: Multi-timeframe and Binance tests
         run: |
           uv run pytest -q \
             tests/data/test_multitimeframe_builder.py \
-            tests/data/test_market_builder.py \
-            tests/data/test_information_availability.py \
-            tests/data/test_market_contracts.py
+            tests/integrations/test_binance.py \
+            tests/integrations/test_binance_multitimeframe.py \
+            tests/cli/test_binance_data_command.py \
+            tests/cli/test_binance_multitimeframe_command.py
       - name: Lint
         run: uv run ruff check trade_rl tests
       - name: Type check
         run: uv run mypy trade_rl
-      - name: Commit generic multi-timeframe implementation
+      - name: Commit Binance multi-timeframe implementation
         run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git add trade_rl tests
-          git commit -m "feat: add causal native timeframe dataset features"
-          git push origin HEAD:agent/multitimeframe-three-asset-full-training
+          if ! git diff --cached --quiet; then
+            git config user.name github-actions[bot]
+            git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+            git commit -m "feat: add Binance native timeframe ingestion"
+            git push origin HEAD:agent/multitimeframe-three-asset-full-training
+          fi

--- a/.github/workflows/multitimeframe-development.yml
+++ b/.github/workflows/multitimeframe-development.yml
@@ -22,46 +22,32 @@ jobs:
           ref: ${{ github.head_ref || github.ref_name }}
       - uses: astral-sh/setup-uv@v5
       - run: uv sync --extra dev --extra train-sb3
-      - name: Apply Binance multi-timeframe patch
-        run: |
-          uv run python .github/scripts/apply_binance_multitimeframe.py
-          uv run python .github/scripts/repair_binance_cli.py
-          uv run python .github/scripts/fix_binance_multitimeframe_preset.py
+      - name: Apply immutable Vision cache
+        run: uv run python .github/scripts/add_binance_vision_cache.py
       - name: Format and organize imports
         run: |
-          uv run ruff check --fix trade_rl tests
-          uv run ruff format trade_rl tests
-      - name: Multi-timeframe and Binance tests
+          uv run ruff check --fix trade_rl tests examples
+          uv run ruff format trade_rl tests examples
+      - name: Full asset and cache tests
         run: |
           uv run pytest -q \
+            tests/integrations/test_binance_vision_cache.py \
+            tests/examples/test_binance_multitimeframe_full_assets.py \
             tests/data/test_multitimeframe_builder.py \
-            tests/integrations/test_binance.py \
             tests/integrations/test_binance_multitimeframe.py \
-            tests/cli/test_binance_data_command.py \
             tests/cli/test_binance_multitimeframe_command.py
       - name: Lint
-        run: uv run ruff check trade_rl tests
-      - name: Capture type check
+        run: uv run ruff check trade_rl tests examples
+      - name: Format check
+        run: uv run ruff format --check trade_rl tests examples
+      - name: Type check
+        run: uv run mypy trade_rl
+      - name: Commit full research assets
         run: |
-          set +e
-          uv run mypy trade_rl > mypy.log 2>&1
-          echo "$?" > mypy.status
-          cat mypy.log
-          exit 0
-      - uses: actions/upload-artifact@v4
-        with:
-          name: multitimeframe-mypy-diagnostics
-          path: |
-            mypy.log
-            mypy.status
-      - name: Require type check
-        run: exit "$(cat mypy.status)"
-      - name: Commit Binance multi-timeframe implementation
-        run: |
-          git add trade_rl tests
+          git add trade_rl tests examples
           if ! git diff --cached --quiet; then
             git config user.name github-actions[bot]
             git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-            git commit -m "feat: add Binance native timeframe ingestion"
+            git commit -m "feat: add full three-asset multi-timeframe research run"
             git push origin HEAD:agent/multitimeframe-three-asset-full-training
           fi

--- a/.github/workflows/multitimeframe-development.yml
+++ b/.github/workflows/multitimeframe-development.yml
@@ -23,7 +23,9 @@ jobs:
       - uses: astral-sh/setup-uv@v5
       - run: uv sync --extra dev --extra train-sb3
       - name: Apply Binance multi-timeframe patch
-        run: uv run python .github/scripts/apply_binance_multitimeframe.py
+        run: |
+          uv run python .github/scripts/apply_binance_multitimeframe.py
+          uv run python .github/scripts/repair_binance_cli.py
       - name: Format and organize imports
         run: |
           uv run ruff check --fix trade_rl tests

--- a/.github/workflows/multitimeframe-development.yml
+++ b/.github/workflows/multitimeframe-development.yml
@@ -30,14 +30,27 @@ jobs:
         run: |
           uv run ruff check --fix trade_rl tests
           uv run ruff format trade_rl tests
-      - name: Multi-timeframe and Binance tests
+      - name: Capture multi-timeframe and Binance tests
         run: |
+          set +e
           uv run pytest -q \
             tests/data/test_multitimeframe_builder.py \
             tests/integrations/test_binance.py \
             tests/integrations/test_binance_multitimeframe.py \
             tests/cli/test_binance_data_command.py \
-            tests/cli/test_binance_multitimeframe_command.py
+            tests/cli/test_binance_multitimeframe_command.py \
+            > focused.log 2>&1
+          echo "$?" > focused.status
+          cat focused.log
+          exit 0
+      - uses: actions/upload-artifact@v4
+        with:
+          name: multitimeframe-focused-diagnostics
+          path: |
+            focused.log
+            focused.status
+      - name: Require focused tests
+        run: exit "$(cat focused.status)"
       - name: Lint
         run: uv run ruff check trade_rl tests
       - name: Type check

--- a/.github/workflows/multitimeframe-development.yml
+++ b/.github/workflows/multitimeframe-development.yml
@@ -41,8 +41,21 @@ jobs:
             tests/cli/test_binance_multitimeframe_command.py
       - name: Lint
         run: uv run ruff check trade_rl tests
-      - name: Type check
-        run: uv run mypy trade_rl
+      - name: Capture type check
+        run: |
+          set +e
+          uv run mypy trade_rl > mypy.log 2>&1
+          echo "$?" > mypy.status
+          cat mypy.log
+          exit 0
+      - uses: actions/upload-artifact@v4
+        with:
+          name: multitimeframe-mypy-diagnostics
+          path: |
+            mypy.log
+            mypy.status
+      - name: Require type check
+        run: exit "$(cat mypy.status)"
       - name: Commit Binance multi-timeframe implementation
         run: |
           git add trade_rl tests

--- a/.github/workflows/multitimeframe-development.yml
+++ b/.github/workflows/multitimeframe-development.yml
@@ -9,19 +9,38 @@ on:
       - main
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   focused:
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.head_ref || github.ref_name }}
       - uses: astral-sh/setup-uv@v5
       - run: uv sync --extra dev --extra train-sb3
-      - name: Focused multi-timeframe tests
+      - name: Apply generic builder patch
+        run: uv run python .github/scripts/apply_multitimeframe_builder.py
+      - name: Format
+        run: uv run ruff format trade_rl tests
+      - name: Generic multi-timeframe tests
         run: |
           uv run pytest -q \
             tests/data/test_multitimeframe_builder.py \
-            tests/integrations/test_binance_multitimeframe.py \
-            tests/cli/test_binance_multitimeframe_command.py \
-            tests/examples/test_binance_multitimeframe_full_assets.py
+            tests/data/test_market_builder.py \
+            tests/data/test_information_availability.py \
+            tests/data/test_market_contracts.py
+      - name: Lint
+        run: uv run ruff check trade_rl tests
+      - name: Type check
+        run: uv run mypy trade_rl
+      - name: Commit generic multi-timeframe implementation
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add trade_rl tests
+          git commit -m "feat: add causal native timeframe dataset features"
+          git push origin HEAD:agent/multitimeframe-three-asset-full-training

--- a/.github/workflows/multitimeframe-development.yml
+++ b/.github/workflows/multitimeframe-development.yml
@@ -1,0 +1,27 @@
+name: Multi-Timeframe Development
+
+on:
+  push:
+    branches:
+      - agent/multitimeframe-three-asset-full-training
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  focused:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv sync --extra dev --extra train-sb3
+      - name: Focused multi-timeframe tests
+        run: |
+          uv run pytest -q \
+            tests/data/test_multitimeframe_builder.py \
+            tests/integrations/test_binance_multitimeframe.py \
+            tests/cli/test_binance_multitimeframe_command.py \
+            tests/examples/test_binance_multitimeframe_full_assets.py

--- a/.github/workflows/multitimeframe-live-full.yml
+++ b/.github/workflows/multitimeframe-live-full.yml
@@ -1,0 +1,42 @@
+name: Multi-Timeframe Full Research
+
+on:
+  push:
+    branches:
+      - agent/multitimeframe-three-asset-full-training
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  full-research:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+          enable-cache: true
+      - run: uv sync --extra dev --extra train-sb3
+      - name: Run BTC ETH BNB native multi-timeframe research
+        run: |
+          uv run python examples/binance-multitimeframe/run_full_research.py \
+            --work-root var/binance-multitimeframe-full
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: binance-multitimeframe-full-evidence
+          if-no-files-found: warn
+          retention-days: 30
+          path: |
+            var/binance-multitimeframe-full/summary.json
+            var/binance-multitimeframe-full/exchange-info.json
+            var/binance-multitimeframe-full/training.log
+            var/binance-multitimeframe-full/walk-forward.log
+            var/binance-multitimeframe-full/dataset-a/manifest.json
+            var/binance-multitimeframe-full/dataset-b/manifest.json
+            var/binance-multitimeframe-full/artifacts/runs/binance-multitimeframe-full-training/run.json
+            var/binance-multitimeframe-full/artifacts/runs/binance-multitimeframe-full-training/ensemble.json
+            var/binance-multitimeframe-full/artifacts/runs/binance-multitimeframe-full-walk-forward/run.json

--- a/.github/workflows/multitimeframe-live-full.yml
+++ b/.github/workflows/multitimeframe-live-full.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - agent/multitimeframe-three-asset-full-training
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/multitimeframe-live-full.yml
+++ b/.github/workflows/multitimeframe-live-full.yml
@@ -1,12 +1,6 @@
 name: Multi-Timeframe Full Research
 
 on:
-  push:
-    branches:
-      - agent/multitimeframe-three-asset-full-training
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 permissions:

--- a/docs/MULTITIMEFRAME_RESEARCH.md
+++ b/docs/MULTITIMEFRAME_RESEARCH.md
@@ -1,0 +1,30 @@
+# Native Multi-Timeframe Research
+
+Trade RL treats multi-timeframe context as a first-class feature contract rather than as long lookbacks on a single bar series.
+
+The maintained Binance research example uses:
+
+- decision clock: `1h`;
+- native feature clocks: `15m`, `1h`, `4h`, and `1d`;
+- instruments: `BTCUSDT`, `ETHUSDT`, and `BNBUSDT` USDⓈ-M futures;
+- fixed closed range: `2024-12-01T00:00:00Z` through `2026-06-01T00:00:00Z`;
+- expected hourly decisions: `13,128`;
+- full PPO seeds: `0`, `1`, and `2`;
+- full PPO timesteps: `131,072` per seed;
+- nested walk-forward candidate timesteps: `32,768` per seed and fold.
+
+Each feature is calculated on its native closed-bar clock. The generic dataset builder then performs an availability-aware causal as-of alignment to the one-hour decision clock. A four-hour or daily feature is unavailable before the native bar and all of its source observations are available. No backward filling is used.
+
+The full runner is:
+
+```bash
+uv sync --extra dev --extra train-sb3
+uv run python examples/binance-multitimeframe/run_full_research.py \
+  --work-root var/binance-multitimeframe-full
+```
+
+It builds the fixed dataset twice, verifies identical dataset and artifact digests, performs three-seed PPO training, runs nested walk-forward evaluation, and writes `summary.json` together with the exact metadata source used.
+
+Binance Vision historical archives are cached by immutable URL. Current `exchangeInfo` is requested separately and never loaded from the historical archive cache. When the REST endpoint is blocked by regional HTTP 451, the runner records the error and uses the checked-in metadata fallback explicitly.
+
+Production status remains `NO-GO`. This workflow does not authenticate an account, place orders, support inverse COIN-M accounting, or claim profitability.

--- a/docs/superpowers/plans/2026-07-14-multitimeframe-three-asset-full-training.md
+++ b/docs/superpowers/plans/2026-07-14-multitimeframe-three-asset-full-training.md
@@ -1,0 +1,162 @@
+# Multi-Timeframe Three-Asset Full Training Implementation Plan
+
+> Execute this plan with TDD. Do not add production behavior before its focused test has failed for the expected reason.
+
+**Goal:** Make native multi-timeframe features part of the authoritative dataset/training path and complete a reproducible three-asset Binance PPO and nested walk-forward research run.
+
+**Architecture:** Feature specifications carry their native timeframe. The generic market builder computes each feature on its native closed-bar series and causally as-of aligns it onto the 1-hour decision clock. Binance supplies cached native series through REST or monthly/daily Vision archives. Base OHLCV and execution arrays remain 1-hour; auxiliary timeframes affect observations only.
+
+**Stack:** Python 3.12, NumPy, Stable-Baselines3 PPO, existing Trade RL artifact and walk-forward workflows, GitHub Actions for isolated Linux execution.
+
+---
+
+## Task 1: Lock multi-timeframe contracts in tests
+
+**Files:**
+- Modify: `tests/data/test_market_contracts.py`
+- Create: `tests/data/test_multitimeframe_builder.py`
+- Modify: `tests/data/test_information_availability.py`
+
+**Steps:**
+1. Add a failing contract test showing `FeatureSpec(timeframe="4h")` serializes the timeframe and changes canonical identity.
+2. Add validation tests for empty, unsupported, and malformed timeframes.
+3. Add an in-memory multi-timeframe source used by real builder tests.
+4. Add a failing test showing a 4-hour close is unavailable to earlier hourly decisions and appears exactly at its close.
+5. Add a failing test showing a delayed native `available_at` prevents visibility until the delay has elapsed.
+6. Add a failing staleness-expiry test measured on the base clock.
+7. Run only these tests and confirm failure is due to missing timeframe contract/protocol/alignment behavior.
+
+## Task 2: Implement the generic causal multi-timeframe builder
+
+**Files:**
+- Modify: `trade_rl/data/contracts.py`
+- Modify: `trade_rl/data/source.py`
+- Modify: `trade_rl/data/builder.py`
+- Modify: `trade_rl/data/__init__.py` if exports require it
+
+**Steps:**
+1. Add validated optional `FeatureSpec.timeframe` and a `resolved_timeframe(base_timeframe)` helper.
+2. Include resolved/native timeframe data in canonical configuration payloads.
+3. Add runtime-checkable `MultiTimeframeMarketDataSource` with `load_timeframe`.
+4. Refactor native feature calculation to retain event timestamps and maximum window availability.
+5. Add causal as-of alignment from native events to base timestamps.
+6. Recompute age, staleness, and availability on the base clock with no backward fill.
+7. Preserve the existing single-timeframe result byte-for-byte where no auxiliary timeframe is requested.
+8. Run focused tests until green, then run all `tests/data`.
+
+## Task 3: Lock Binance multi-timeframe and monthly archive behavior in tests
+
+**Files:**
+- Modify: `tests/integrations/test_binance.py`
+- Modify: `tests/cli/test_binance_data_command.py`
+- Create: `tests/integrations/test_binance_multitimeframe.py`
+
+**Steps:**
+1. Add failing tests for official Spot and USDⓈ-M monthly kline URLs.
+2. Add a failing test that complete calendar months use monthly archives and partial months use daily archives.
+3. Add a failing cache test proving one `(symbol, timeframe)` load does not redownload.
+4. Add a failing test for the maintained 15m/1h/4h/1d feature preset and feature names.
+5. Add CLI tests for repeatable `--feature-timeframe` and machine-readable result fields.
+6. Add a failure test for duplicate/base-only invalid timeframe requests and COIN-M.
+7. Run focused tests and confirm the expected RED failures.
+
+## Task 4: Implement Binance multi-timeframe ingestion
+
+**Files:**
+- Modify: `trade_rl/integrations/binance.py`
+- Modify: `trade_rl/cli/app.py`
+
+**Steps:**
+1. Add monthly Vision URL construction and bounded monthly/daily range planning.
+2. Add `load_timeframe`, per-symbol/timeframe cache, and shared funding cache.
+3. Add the maintained multi-timeframe feature preset.
+4. Extend `build_binance_market_dataset` with ordered feature timeframes.
+5. Extend `trade-rl data binance` with repeatable `--feature-timeframe` and report the resolved set.
+6. Ensure every source URL and transport used is recorded deterministically.
+7. Run focused Binance and CLI tests, Ruff, and Mypy.
+
+## Task 5: Add reproducible full-run assets
+
+**Files:**
+- Create: `examples/binance-multitimeframe/training-full.json`
+- Create: `examples/binance-multitimeframe/walk-forward-full.json`
+- Create: `examples/binance-multitimeframe/run_full_research.py`
+- Create: `tests/examples/test_binance_multitimeframe_full_assets.py`
+- Modify: `docs/BINANCE.md`
+- Modify: `README.md`
+
+**Steps:**
+1. Add failing tests that the full training config has three seeds and at least 131,072 timesteps per seed.
+2. Add failing tests that walk-forward has two folds and 32,768 candidate timesteps per seed.
+3. Add a runner that obtains or loads an exchange-info metadata snapshot, builds the fixed dataset twice, verifies identity, runs full training, runs walk-forward, validates artifacts, and writes `summary.json`.
+4. Fix range to `2024-12-01T00:00:00Z` through `2026-06-01T00:00:00Z` and symbols to BTCUSDT, ETHUSDT, BNBUSDT.
+5. Persist the exact current tick, lot, minimum-notional, listing-time, and exchange-info snapshot used.
+6. Add documentation with explicit `NO-GO` and no profitability claim.
+7. Run asset tests, Ruff, format, and Mypy.
+
+## Task 6: Verify RED then commit production implementation
+
+**Files:**
+- Temporary: `.github/workflows/multitimeframe-development.yml`
+
+**Steps:**
+1. Create a temporary focused workflow on the feature branch.
+2. Run the new contract/builder/Binance/CLI/asset tests before production implementation and capture the expected failures.
+3. Add production implementation in the smallest TDD increments.
+4. Re-run focused tests after every increment.
+5. Run Ruff, format check, Mypy, import-linter, and all data/integration/CLI tests.
+6. Delete diagnostic-only patch scripts or markers immediately after use.
+
+## Task 7: Build the live three-asset multi-timeframe dataset twice
+
+**Files:**
+- Temporary workflow: `.github/workflows/multitimeframe-live-run.yml`
+
+**Steps:**
+1. Install the maintained training dependencies on an isolated Ubuntu runner.
+2. Fetch official Binance public data for all three symbols and four timeframes.
+3. Build two independent dataset artifacts from the exact same fixed range and metadata snapshot.
+4. Fail if either dataset ID or artifact digest differs.
+5. Validate expected hourly bar count, symbol order, feature names, finite values, availability masks, and artifact closure.
+6. Upload the metadata snapshot, manifests, and build summary as workflow evidence.
+
+## Task 8: Run full three-seed PPO training
+
+**Steps:**
+1. Run `trade-rl train run` using `training-full.json` and the verified dataset.
+2. Require all three member policies, checkpoints, ensemble manifest, environment manifest, run manifest, and latest pointer.
+3. Record wall-clock details, selected checkpoints, terminal metrics, and any warnings.
+4. Fail on non-finite outputs, incomplete artifacts, or silent timestep reduction.
+5. If the bounded runner fails solely from runtime limits, preserve evidence and reduce walk-forward fold count before changing the full training contract.
+
+## Task 9: Run nested walk-forward evaluation
+
+**Steps:**
+1. Run the configured two-fold nested walk-forward using the same dataset identity.
+2. Require sealed-test evidence and complete fold artifacts.
+3. Record candidate selection, baseline comparison, per-fold return, drawdown, turnover, costs, and aggregate statistics.
+4. Report negative results or baseline selection without reinterpretation.
+5. If runtime limits block two folds, rerun one fold and explicitly record the deviation; do not reduce full-run training timesteps silently.
+
+## Task 10: Fix live-run issues systematically
+
+**Steps:**
+1. For each failure, capture full logs and identify the exact failing component boundary.
+2. Add the smallest failing regression test.
+3. Fix the root cause in production code, not in the test or workflow wrapper.
+4. Re-run the focused test, repository verification, and the interrupted live stage.
+5. Stop after three failed fix attempts on the same issue and reconsider the architecture before continuing.
+
+## Task 11: Final verification and integration
+
+**Files:**
+- Keep: a manual/weekly non-required multi-timeframe live workflow if stable
+- Delete: all diagnostic-only workflows and generated patch scripts
+
+**Steps:**
+1. Run the complete repository CI: Ruff, format, Mypy, import architecture, dead-code, full tests/coverage, critical coverage, CLI smoke, Ubuntu, Windows.
+2. Re-run the final official Binance data → repeated dataset → full PPO → walk-forward path from only committed files.
+3. Verify the PR diff contains only production code, tests, maintained examples/workflow, design, plan, and documentation.
+4. Update the PR body with exact dataset IDs, artifact digests, training evidence, walk-forward metrics, deviations, and `NO-GO` status.
+5. Mark ready only after clean CI and live evidence.
+6. Merge using the repository-supported method and verify the resulting `main` commit.

--- a/docs/superpowers/specs/2026-07-14-multitimeframe-three-asset-full-training-design.md
+++ b/docs/superpowers/specs/2026-07-14-multitimeframe-three-asset-full-training-design.md
@@ -85,19 +85,19 @@ A fixed-range build is performed twice into independent directories. Dataset IDs
 The maintained full-run configuration uses:
 
 - BTCUSDT, ETHUSDT, BNBUSDT;
+- fixed closed range `2025-01-01T00:00:00Z` through `2026-06-29T00:00:00Z`;
 - 1-hour decisions;
 - native 15-minute, 1-hour, 4-hour, and 1-day features;
-- at least 18 months of closed historical data;
-- PPO with three independent seeds;
+- PPO with three independent seeds `0`, `1`, and `2`;
 - 131,072 requested timesteps per seed;
 - 2,048-step rollouts, 64 batch size, 10 epochs;
 - shared per-asset encoder with 128x128 policy network;
 - realistic fees, spread, impact, participation, funding, and portfolio concentration limits;
 - checkpointing and atomic artifact publication.
 
-The nested walk-forward run uses multiple chronological folds with purge gaps. Candidate selection uses only checkpoint and selection ranges; outer test ranges remain sealed until selection.
+The nested walk-forward run uses two chronological folds with purge gaps. Candidate selection uses only checkpoint and selection ranges; outer test ranges remain sealed until selection. Fold-local candidate training uses 32,768 timesteps per seed so the evaluation is materially larger than smoke while remaining bounded on a standard CPU runner.
 
-If runtime constraints make the configured run exceed the bounded CI job, the failure must be explicit. The implementation may reduce fold count before reducing per-seed training, but it must not silently convert the full run back into the 64-step smoke.
+If runtime constraints make the configured run exceed the bounded CI job, the failure must be explicit. The implementation may reduce fold count from two to one before reducing per-seed full-run training, but it must not silently convert the full run back into the 64-step smoke.
 
 ## Failure handling
 

--- a/docs/superpowers/specs/2026-07-14-multitimeframe-three-asset-full-training-design.md
+++ b/docs/superpowers/specs/2026-07-14-multitimeframe-three-asset-full-training-design.md
@@ -1,0 +1,155 @@
+# Multi-Timeframe Three-Asset Full Training Design
+
+## Objective
+
+Make multi-timeframe market context a first-class dataset and training contract, then run a non-smoke research training and nested walk-forward evaluation on BTCUSDT, ETHUSDT, and BNBUSDT using official Binance public data.
+
+This work does not claim profitability and does not add authenticated account access or order routing. Production status remains `NO-GO`.
+
+## Current gap
+
+The current market builder has one `base_timeframe`, and every feature is calculated from that same bar series. Long lookbacks on 1-hour bars are useful, but they are not genuine multi-timeframe features. The Binance adapter likewise loads one interval per dataset.
+
+A correct multi-timeframe implementation must calculate each feature on its native closed-bar clock and expose it to a base-timeframe decision only after that native bar is available. A 4-hour or daily bar must never appear at an earlier 1-hour decision timestamp.
+
+## Chosen architecture
+
+### Feature contract
+
+`FeatureSpec` gains an optional `timeframe` field. `None` means the dataset base timeframe. The resolved timeframe is included in the canonical feature payload and therefore in dataset identity.
+
+Feature names remain globally unique and carry explicit prefixes in maintained Binance presets, for example:
+
+- `15m__log_return_1bar`
+- `15m__realized_volatility_4bar`
+- `1h__log_return_1bar`
+- `1h__log_return_1d`
+- `4h__log_return_1bar`
+- `4h__realized_volatility_6bar`
+- `1d__log_return_1bar`
+- `1d__log_return_7bar`
+- `1h__funding_bps`
+
+### Source contract
+
+The existing `MarketDataSource.load(symbol)` remains the base-timeframe path. A new runtime-checkable `MultiTimeframeMarketDataSource` protocol adds `load_timeframe(symbol, timeframe)`.
+
+The generic builder uses the protocol only when at least one feature resolves to a non-base timeframe. Single-timeframe sources and datasets continue to work unchanged.
+
+### Native calculation and causal as-of alignment
+
+For each symbol and each requested timeframe:
+
+1. Load the native `RawMarketSeries`.
+2. Calculate feature events on the native clock with the existing causal feature implementations.
+3. Apply native carry and availability rules.
+4. As-of align to each base timestamp using the latest native observation whose `available_at` is less than or equal to the base decision timestamp.
+5. Recompute feature age and normalized staleness on the base clock.
+6. Mark unavailable values explicitly rather than filling future or expired values.
+
+No backward fill is allowed. Exact-close equality is allowed because the environment acts no earlier than the next base bar open.
+
+The base OHLCV, funding, tradability, execution constraints, and accounting arrays remain on the base timeframe. Auxiliary timeframes affect observations only.
+
+### Binance adapter
+
+`BinanceMarketDataSource` supports `load_timeframe`. It caches kline and funding responses by symbol and timeframe to avoid duplicate downloads.
+
+The dataset builder API accepts auxiliary feature timeframes. The CLI adds repeatable `--feature-timeframe` options while `--interval` remains the base timeframe.
+
+Official Binance Vision monthly kline archives are used for complete historical months, with daily archives used for partial months or bounded fallback. This keeps a multi-year, four-timeframe, three-symbol run practical while preserving deterministic source URLs and fixed-range filtering.
+
+Supported maintained research preset:
+
+- base: `1h`
+- auxiliary: `15m`, `4h`, `1d`
+- symbols: `BTCUSDT`, `ETHUSDT`, `BNBUSDT`
+- market: USDⓈ-M linear futures
+
+COIN-M remains fail-closed because inverse PnL is not representable by the current linear book.
+
+## Dataset identity and reproducibility
+
+Dataset identity includes:
+
+- resolved feature timeframe for every feature;
+- ordered requested timeframe set;
+- native feature lookbacks and staleness limits;
+- three-symbol instrument metadata;
+- all existing execution, availability, and accounting arrays.
+
+A fixed-range build is performed twice into independent directories. Dataset IDs and artifact digests must match exactly before training begins.
+
+## Full research run
+
+The maintained full-run configuration uses:
+
+- BTCUSDT, ETHUSDT, BNBUSDT;
+- 1-hour decisions;
+- native 15-minute, 1-hour, 4-hour, and 1-day features;
+- at least 18 months of closed historical data;
+- PPO with three independent seeds;
+- 131,072 requested timesteps per seed;
+- 2,048-step rollouts, 64 batch size, 10 epochs;
+- shared per-asset encoder with 128x128 policy network;
+- realistic fees, spread, impact, participation, funding, and portfolio concentration limits;
+- checkpointing and atomic artifact publication.
+
+The nested walk-forward run uses multiple chronological folds with purge gaps. Candidate selection uses only checkpoint and selection ranges; outer test ranges remain sealed until selection.
+
+If runtime constraints make the configured run exceed the bounded CI job, the failure must be explicit. The implementation may reduce fold count before reducing per-seed training, but it must not silently convert the full run back into the 64-step smoke.
+
+## Failure handling
+
+The pipeline fails before publication on:
+
+- unsupported or duplicate timeframes;
+- a source that lacks multi-timeframe loading when required;
+- native bars that are irregular, duplicated, or incomplete;
+- auxiliary data that cannot causally as-of align;
+- unavailable static instrument metadata;
+- inconsistent dataset identities across repeated builds;
+- non-finite observations or training outputs;
+- incomplete training or walk-forward artifact trees.
+
+Temporary and failed runs remain isolated under failed artifact directories and never replace `latest.json`.
+
+## Verification
+
+### Unit and contract tests
+
+- timeframe validation and identity changes;
+- single-timeframe backward compatibility;
+- 15-minute latest-closed-bar alignment at hourly decisions;
+- 4-hour and daily bars unavailable before close;
+- `available_at` delays prevent leakage;
+- staleness expiry on the base clock;
+- Binance monthly URL and partial-month fallback;
+- cache behavior and multi-symbol cardinality;
+- CLI parsing and machine-readable output.
+
+### Repository verification
+
+- Ruff and formatting;
+- Mypy;
+- import architecture;
+- full tests and branch coverage;
+- critical branch coverage;
+- Ubuntu and Windows compatibility.
+
+### Live evidence
+
+- fixed official Binance Vision range downloaded for all three symbols and four timeframes;
+- independent repeated dataset build has identical identity;
+- full three-seed PPO run publishes all member policies and checkpoints;
+- nested walk-forward publishes fold evidence and aggregate report;
+- results are reported honestly, including baseline selection or negative returns.
+
+## Non-goals
+
+- authenticated Binance account access;
+- live or paper order routing;
+- inverse COIN-M accounting;
+- profitability guarantees;
+- tick-level order-book modelling;
+- point-in-time historical exchange-filter reconstruction when Binance does not publish such snapshots.

--- a/docs/superpowers/specs/2026-07-14-multitimeframe-three-asset-full-training-design.md
+++ b/docs/superpowers/specs/2026-07-14-multitimeframe-three-asset-full-training-design.md
@@ -57,7 +57,7 @@ The base OHLCV, funding, tradability, execution constraints, and accounting arra
 
 The dataset builder API accepts auxiliary feature timeframes. The CLI adds repeatable `--feature-timeframe` options while `--interval` remains the base timeframe.
 
-Official Binance Vision monthly kline archives are used for complete historical months, with daily archives used for partial months or bounded fallback. This keeps a multi-year, four-timeframe, three-symbol run practical while preserving deterministic source URLs and fixed-range filtering.
+Official Binance Vision monthly kline archives are used for complete historical months, with daily archives used only for partial months or bounded fallback. This keeps a multi-year, four-timeframe, three-symbol run practical while preserving deterministic source URLs and fixed-range filtering.
 
 Supported maintained research preset:
 
@@ -85,7 +85,7 @@ A fixed-range build is performed twice into independent directories. Dataset IDs
 The maintained full-run configuration uses:
 
 - BTCUSDT, ETHUSDT, BNBUSDT;
-- fixed closed range `2025-01-01T00:00:00Z` through `2026-06-29T00:00:00Z`;
+- fixed closed range `2024-12-01T00:00:00Z` through `2026-06-01T00:00:00Z`;
 - 1-hour decisions;
 - native 15-minute, 1-hour, 4-hour, and 1-day features;
 - PPO with three independent seeds `0`, `1`, and `2`;
@@ -94,6 +94,8 @@ The maintained full-run configuration uses:
 - shared per-asset encoder with 128x128 policy network;
 - realistic fees, spread, impact, participation, funding, and portfolio concentration limits;
 - checkpointing and atomic artifact publication.
+
+The range consists only of complete calendar months, allowing official monthly Binance Vision archives to be used throughout. It contains 13,104 hourly decisions. The kline build reads 216 deterministic monthly archives across three symbols, four native timeframes, and eighteen months; funding is loaded from its own monthly event archives.
 
 The nested walk-forward run uses two chronological folds with purge gaps. Candidate selection uses only checkpoint and selection ranges; outer test ranges remain sealed until selection. Fold-local candidate training uses 32,768 timesteps per seed so the evaluation is materially larger than smoke while remaining bounded on a standard CPU runner.
 

--- a/examples/binance-multitimeframe/run_full_research.py
+++ b/examples/binance-multitimeframe/run_full_research.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Run the maintained three-asset native multi-timeframe research pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from trade_rl.data import publish_market_dataset_artifact
+from trade_rl.integrations.binance import (
+    BinanceMarket,
+    BinancePublicTransport,
+    BinanceTransportError,
+    BinanceTransportMode,
+    build_binance_market_dataset,
+)
+
+_SYMBOLS = ("BTCUSDT", "ETHUSDT", "BNBUSDT")
+_NATIVE_TIMEFRAMES = ("15m", "1h", "4h", "1d")
+_FEATURE_TIMEFRAMES = ("15m", "4h", "1d")
+_START = "2024-12-01T00:00:00Z"
+_END = "2026-06-01T00:00:00Z"
+_TRAIN_RUN_COMMAND = ("train", "run")
+_WALK_FORWARD_RUN_COMMAND = ("walk-forward", "run")
+_FALLBACK_METADATA: dict[str, dict[str, object]] = {
+    "BTCUSDT": {
+        "listed_at": "2019-09-08T00:00:00Z",
+        "tick_size": 0.1,
+        "lot_size": 0.001,
+        "minimum_notional": 5.0,
+    },
+    "ETHUSDT": {
+        "listed_at": "2019-11-27T00:00:00Z",
+        "tick_size": 0.01,
+        "lot_size": 0.001,
+        "minimum_notional": 5.0,
+    },
+    "BNBUSDT": {
+        "listed_at": "2020-02-10T00:00:00Z",
+        "tick_size": 0.01,
+        "lot_size": 0.01,
+        "minimum_notional": 5.0,
+    },
+}
+
+
+def _parse_utc(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError("time range must include a timezone")
+    return parsed.astimezone(UTC)
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _run_cli(arguments: list[str], *, root: Path, log_path: Path) -> dict[str, Any]:
+    command = [sys.executable, "-m", "trade_rl.cli.app", *arguments]
+    completed = subprocess.run(
+        command,
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text(
+        "command: " + repr(command) + "\n\nstdout:\n" + completed.stdout
+        + "\n\nstderr:\n" + completed.stderr,
+        encoding="utf-8",
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(f"command failed; see {log_path}: {command!r}")
+    lines = [line for line in completed.stdout.splitlines() if line.strip()]
+    if not lines:
+        raise RuntimeError(f"command produced no JSON output: {command!r}")
+    payload = json.loads(lines[-1])
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"command JSON result must be an object: {command!r}")
+    return dict(payload)
+
+
+def _filter_number(filters: list[dict[str, object]], kind: str, *names: str) -> float:
+    for item in filters:
+        if item.get("filterType") != kind:
+            continue
+        for name in names:
+            value = item.get(name)
+            if isinstance(value, (str, int, float)) and not isinstance(value, bool):
+                return float(value)
+    raise ValueError(f"exchangeInfo is missing {kind} {names}")
+
+
+def _metadata_from_exchange_info(payload: object) -> dict[str, dict[str, object]]:
+    if not isinstance(payload, dict) or not isinstance(payload.get("symbols"), list):
+        raise ValueError("exchangeInfo payload is invalid")
+    by_symbol = {
+        item.get("symbol"): item
+        for item in payload["symbols"]
+        if isinstance(item, dict) and isinstance(item.get("symbol"), str)
+    }
+    result: dict[str, dict[str, object]] = {}
+    for symbol in _SYMBOLS:
+        item = by_symbol.get(symbol)
+        if not isinstance(item, dict) or not isinstance(item.get("filters"), list):
+            raise ValueError(f"exchangeInfo has no active metadata for {symbol}")
+        filters = [value for value in item["filters"] if isinstance(value, dict)]
+        onboard = item.get("onboardDate")
+        if not isinstance(onboard, (int, float)) or isinstance(onboard, bool):
+            raise ValueError(f"exchangeInfo has no onboardDate for {symbol}")
+        result[symbol] = {
+            "listed_at": datetime.fromtimestamp(float(onboard) / 1000.0, tz=UTC).isoformat(),
+            "tick_size": _filter_number(filters, "PRICE_FILTER", "tickSize"),
+            "lot_size": _filter_number(filters, "LOT_SIZE", "stepSize"),
+            "minimum_notional": _filter_number(
+                filters,
+                "MIN_NOTIONAL",
+                "notional",
+                "minNotional",
+            ),
+        }
+    return result
+
+
+def _resolve_metadata(
+    transport: BinancePublicTransport,
+    *,
+    snapshot_path: Path,
+) -> tuple[dict[str, dict[str, object]], str, str | None]:
+    try:
+        payload, source = transport.load_exchange_information(
+            market=BinanceMarket.USDS_M
+        )
+        metadata = _metadata_from_exchange_info(payload)
+        _write_json(
+            snapshot_path,
+            {"metadata": metadata, "payload": payload, "source": source},
+        )
+        return metadata, str(source), None
+    except (BinanceTransportError, ValueError) as error:
+        _write_json(
+            snapshot_path,
+            {
+                "error": str(error),
+                "metadata": _FALLBACK_METADATA,
+                "source": "checked-in-fallback",
+            },
+        )
+        return _FALLBACK_METADATA, "checked-in-fallback", str(error)
+
+
+def _build_dataset(
+    *,
+    output: Path,
+    transport: BinancePublicTransport,
+    metadata: dict[str, dict[str, object]],
+) -> dict[str, object]:
+    result = build_binance_market_dataset(
+        market=BinanceMarket.USDS_M,
+        symbols=_SYMBOLS,
+        interval="1h",
+        feature_timeframes=_FEATURE_TIMEFRAMES,
+        start_time=_parse_utc(_START),
+        end_time=_parse_utc(_END),
+        transport_mode=BinanceTransportMode.VISION,
+        transport=transport,
+        tick_sizes=tuple(float(metadata[symbol]["tick_size"]) for symbol in _SYMBOLS),
+        lot_sizes=tuple(float(metadata[symbol]["lot_size"]) for symbol in _SYMBOLS),
+        minimum_notionals=tuple(
+            float(metadata[symbol]["minimum_notional"]) for symbol in _SYMBOLS
+        ),
+        listed_ats=tuple(
+            _parse_utc(str(metadata[symbol]["listed_at"])) for symbol in _SYMBOLS
+        ),
+    )
+    published = publish_market_dataset_artifact(output, result.dataset)
+    if result.dataset.n_bars != 13_104:
+        raise RuntimeError(
+            f"expected 13,104 hourly bars, observed {result.dataset.n_bars}"
+        )
+    if result.dataset.symbols != _SYMBOLS:
+        raise RuntimeError(f"unexpected symbol order: {result.dataset.symbols}")
+    expected_features = (
+        "15m__log_return_1bar",
+        "15m__realized_volatility_4bar",
+        "1h__log_return_1bar",
+        "1h__log_return_1d",
+        "1h__volume_zscore_1d",
+        "1h__funding_bps",
+        "4h__log_return_1bar",
+        "4h__realized_volatility_6bar",
+        "1d__log_return_1bar",
+        "1d__log_return_7bar",
+    )
+    if result.dataset.feature_names != expected_features:
+        raise RuntimeError(f"unexpected feature contract: {result.dataset.feature_names}")
+    return {
+        "artifact_digest": published.artifact_digest,
+        "dataset_id": result.dataset.dataset_id,
+        "feature_names": list(result.dataset.feature_names),
+        "feature_timeframes": list(result.feature_timeframes),
+        "n_bars": result.dataset.n_bars,
+        "n_features": result.dataset.n_features,
+        "n_symbols": result.dataset.n_symbols,
+        "sources_used": list(result.sources_used),
+        "symbols": list(result.dataset.symbols),
+    }
+
+
+def _require_file(path: Path) -> None:
+    if not path.is_file() or path.stat().st_size <= 0:
+        raise RuntimeError(f"required artifact file is missing or empty: {path}")
+
+
+def _verify_training(path: Path) -> None:
+    for relative in ("run.json", "ensemble.json", "environment.json"):
+        _require_file(path / relative)
+    for index in range(3):
+        member = path / f"members/member-{index:03d}"
+        _require_file(member / "policy.zip")
+        checkpoints = tuple(member.glob("checkpoints/*.zip"))
+        if not checkpoints:
+            raise RuntimeError(f"member {index} has no retained checkpoints")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--work-root", type=Path, default=Path("var/binance-multitimeframe-full"))
+    args = parser.parse_args()
+
+    root = Path(__file__).resolve().parents[2]
+    work_root = args.work_root if args.work_root.is_absolute() else root / args.work_root
+    if work_root.exists():
+        shutil.rmtree(work_root)
+    work_root.mkdir(parents=True)
+
+    cache_root = work_root / "vision-cache"
+    transport = BinancePublicTransport(
+        timeout_seconds=60.0,
+        max_attempts=4,
+        retry_backoff_seconds=0.5,
+        cache_root=cache_root,
+    )
+    metadata, metadata_source, metadata_error = _resolve_metadata(
+        transport,
+        snapshot_path=work_root / "exchange-info.json",
+    )
+
+    dataset_a_path = work_root / "dataset-a"
+    dataset_b_path = work_root / "dataset-b"
+    dataset_a = _build_dataset(
+        output=dataset_a_path,
+        transport=transport,
+        metadata=metadata,
+    )
+    dataset_b = _build_dataset(
+        output=dataset_b_path,
+        transport=transport,
+        metadata=metadata,
+    )
+    if dataset_a["dataset_id"] != dataset_b["dataset_id"]:
+        raise RuntimeError("repeated multi-timeframe builds produced different dataset IDs")
+    if dataset_a["artifact_digest"] != dataset_b["artifact_digest"]:
+        raise RuntimeError("repeated multi-timeframe builds produced different artifact digests")
+
+    artifact_root = work_root / "artifacts"
+    training = _run_cli(
+        [
+            *_TRAIN_RUN_COMMAND,
+            "--config",
+            str(root / "examples/binance-multitimeframe/training-full.json"),
+            "--dataset",
+            str(dataset_a_path),
+            "--output",
+            str(artifact_root),
+            "--run-id",
+            "binance-multitimeframe-full-training",
+        ],
+        root=root,
+        log_path=work_root / "training.log",
+    )
+    training_path = Path(str(training["artifact_path"]))
+    if not training_path.is_absolute():
+        training_path = root / training_path
+    _verify_training(training_path)
+
+    walk_forward = _run_cli(
+        [
+            *_WALK_FORWARD_RUN_COMMAND,
+            "--config",
+            str(root / "examples/binance-multitimeframe/walk-forward-full.json"),
+            "--dataset",
+            str(dataset_a_path),
+            "--output",
+            str(artifact_root),
+            "--run-id",
+            "binance-multitimeframe-full-walk-forward",
+        ],
+        root=root,
+        log_path=work_root / "walk-forward.log",
+    )
+    walk_forward_path = Path(str(walk_forward["artifact_path"]))
+    if not walk_forward_path.is_absolute():
+        walk_forward_path = root / walk_forward_path
+    _require_file(walk_forward_path / "run.json")
+
+    summary = {
+        "dataset": dataset_a,
+        "dataset_repeat": dataset_b,
+        "end_time": _END,
+        "metadata_error": metadata_error,
+        "metadata_source": metadata_source,
+        "native_timeframes": list(_NATIVE_TIMEFRAMES),
+        "production_status": "NO-GO",
+        "schema": "binance_multitimeframe_full_research_v1",
+        "start_time": _START,
+        "training": training,
+        "walk_forward": walk_forward,
+    }
+    _write_json(work_root / "summary.json", summary)
+    print(json.dumps(summary, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/binance-multitimeframe/run_full_research.py
+++ b/examples/binance-multitimeframe/run_full_research.py
@@ -76,8 +76,12 @@ def _run_cli(arguments: list[str], *, root: Path, log_path: Path) -> dict[str, A
     )
     log_path.parent.mkdir(parents=True, exist_ok=True)
     log_path.write_text(
-        "command: " + repr(command) + "\n\nstdout:\n" + completed.stdout
-        + "\n\nstderr:\n" + completed.stderr,
+        "command: "
+        + repr(command)
+        + "\n\nstdout:\n"
+        + completed.stdout
+        + "\n\nstderr:\n"
+        + completed.stderr,
         encoding="utf-8",
     )
     if completed.returncode != 0:
@@ -120,7 +124,9 @@ def _metadata_from_exchange_info(payload: object) -> dict[str, dict[str, object]
         if not isinstance(onboard, (int, float)) or isinstance(onboard, bool):
             raise ValueError(f"exchangeInfo has no onboardDate for {symbol}")
         result[symbol] = {
-            "listed_at": datetime.fromtimestamp(float(onboard) / 1000.0, tz=UTC).isoformat(),
+            "listed_at": datetime.fromtimestamp(
+                float(onboard) / 1000.0, tz=UTC
+            ).isoformat(),
             "tick_size": _filter_number(filters, "PRICE_FILTER", "tickSize"),
             "lot_size": _filter_number(filters, "LOT_SIZE", "stepSize"),
             "minimum_notional": _filter_number(
@@ -204,7 +210,9 @@ def _build_dataset(
         "1d__log_return_7bar",
     )
     if result.dataset.feature_names != expected_features:
-        raise RuntimeError(f"unexpected feature contract: {result.dataset.feature_names}")
+        raise RuntimeError(
+            f"unexpected feature contract: {result.dataset.feature_names}"
+        )
     return {
         "artifact_digest": published.artifact_digest,
         "dataset_id": result.dataset.dataset_id,
@@ -236,11 +244,15 @@ def _verify_training(path: Path) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--work-root", type=Path, default=Path("var/binance-multitimeframe-full"))
+    parser.add_argument(
+        "--work-root", type=Path, default=Path("var/binance-multitimeframe-full")
+    )
     args = parser.parse_args()
 
     root = Path(__file__).resolve().parents[2]
-    work_root = args.work_root if args.work_root.is_absolute() else root / args.work_root
+    work_root = (
+        args.work_root if args.work_root.is_absolute() else root / args.work_root
+    )
     if work_root.exists():
         shutil.rmtree(work_root)
     work_root.mkdir(parents=True)
@@ -270,9 +282,13 @@ def main() -> int:
         metadata=metadata,
     )
     if dataset_a["dataset_id"] != dataset_b["dataset_id"]:
-        raise RuntimeError("repeated multi-timeframe builds produced different dataset IDs")
+        raise RuntimeError(
+            "repeated multi-timeframe builds produced different dataset IDs"
+        )
     if dataset_a["artifact_digest"] != dataset_b["artifact_digest"]:
-        raise RuntimeError("repeated multi-timeframe builds produced different artifact digests")
+        raise RuntimeError(
+            "repeated multi-timeframe builds produced different artifact digests"
+        )
 
     artifact_root = work_root / "artifacts"
     training = _run_cli(

--- a/examples/binance-multitimeframe/run_full_research.py
+++ b/examples/binance-multitimeframe/run_full_research.py
@@ -26,6 +26,7 @@ _NATIVE_TIMEFRAMES = ("15m", "1h", "4h", "1d")
 _FEATURE_TIMEFRAMES = ("15m", "4h", "1d")
 _START = "2024-12-01T00:00:00Z"
 _END = "2026-06-01T00:00:00Z"
+_EXPECTED_HOURLY_BARS = 13_128
 _TRAIN_RUN_COMMAND = ("train", "run")
 _WALK_FORWARD_RUN_COMMAND = ("walk-forward", "run")
 _FALLBACK_METADATA: dict[str, dict[str, object]] = {
@@ -191,9 +192,10 @@ def _build_dataset(
         ),
     )
     published = publish_market_dataset_artifact(output, result.dataset)
-    if result.dataset.n_bars != 13_104:
+    if result.dataset.n_bars != _EXPECTED_HOURLY_BARS:
         raise RuntimeError(
-            f"expected 13,104 hourly bars, observed {result.dataset.n_bars}"
+            "expected "
+            f"{_EXPECTED_HOURLY_BARS:,} hourly bars, observed {result.dataset.n_bars}"
         )
     if result.dataset.symbols != _SYMBOLS:
         raise RuntimeError(f"unexpected symbol order: {result.dataset.symbols}")

--- a/examples/binance-multitimeframe/training-full.json
+++ b/examples/binance-multitimeframe/training-full.json
@@ -1,0 +1,89 @@
+{
+  "schema_version": "training_run_config_v1",
+  "training": {
+    "timesteps": 131072,
+    "gamma": 0.9958826236582974,
+    "seeds": [0, 1, 2],
+    "learning_rate": 0.0003,
+    "n_steps": 2048,
+    "batch_size": 64,
+    "n_epochs": 10,
+    "gae_lambda": 0.95,
+    "ent_coef": 0.001,
+    "device": "cpu",
+    "decision_hours": 1.0,
+    "discount_half_life_hours": 168.0,
+    "log_std_init": -0.7,
+    "target_kl": 0.02,
+    "policy_net_arch": [128, 128],
+    "asset_set_encoder": true,
+    "asset_embedding_dim": 64,
+    "global_embedding_dim": 64,
+    "algorithm": "ppo",
+    "checkpoint_interval_steps": 16384,
+    "max_checkpoints": 8
+  },
+  "environment": {
+    "episode_hours": 720.0,
+    "decision_hours": 1.0,
+    "initial_capital": 100000.0,
+    "finite_horizon_observation": true,
+    "initial_state_modes": ["cash", "baseline"],
+    "episode_sampling_mode": "uniform"
+  },
+  "risk": {
+    "max_gross": 1.0,
+    "max_abs_weight": 0.45,
+    "max_turnover": 0.5,
+    "drawdown_start": 0.1,
+    "drawdown_stop": 0.2,
+    "emergency_turnover_override": true
+  },
+  "portfolio_risk": {
+    "max_abs_weight": 0.45,
+    "max_net_exposure": 1.0,
+    "max_position_to_market_notional": 0.02
+  },
+  "reward": {
+    "absolute_growth_weight": 1.0,
+    "excess_growth_weight": 0.1,
+    "incremental_drawdown_weight": 0.05,
+    "baseline_underperformance_weight": 0.1,
+    "baseline_window_hours": 720.0,
+    "baseline_minimum_history_hours": 720.0,
+    "baseline_tolerance": 0.015,
+    "projection_penalty_weight": 0.01
+  },
+  "trend": {
+    "fast_hours": 24.0,
+    "base_hours": 168.0,
+    "slow_hours": 720.0,
+    "mode": "time_series",
+    "signal_scale": 0.1
+  },
+  "action": {
+    "alpha_enabled": false,
+    "n_factors": 0,
+    "validation_mode": "clip"
+  },
+  "alpha_contract": {
+    "kind": "target_weight",
+    "expected_return_scale": 0.01,
+    "max_gross": 1.0
+  },
+  "execution": {
+    "fee_rate": 0.0005,
+    "spread_rate": 0.0002,
+    "impact_rate": 0.0002,
+    "max_participation_rate": 0.02,
+    "allow_short": true,
+    "max_leverage": 1.0,
+    "margin_mode": "cross",
+    "order_type": "market"
+  },
+  "exports": {
+    "onnx": false,
+    "torchscript": false,
+    "tolerance": 0.00001
+  }
+}

--- a/examples/binance-multitimeframe/walk-forward-full.json
+++ b/examples/binance-multitimeframe/walk-forward-full.json
@@ -1,0 +1,107 @@
+{
+  "schema_version": "market_walk_forward_config_v1",
+  "workflow": {
+    "train_bars": 7000,
+    "checkpoint_bars": 1000,
+    "selection_bars": 1000,
+    "test_bars": 1800,
+    "purge_bars": 48,
+    "max_folds": 2,
+    "expanding_train": true
+  },
+  "minimum_selection_uplift": 0.0,
+  "candidates": [
+    {
+      "name": "ppo-multitimeframe",
+      "run": {
+        "schema_version": "training_run_config_v1",
+        "training": {
+          "timesteps": 32768,
+          "gamma": 0.9958826236582974,
+          "seeds": [0, 1, 2],
+          "learning_rate": 0.0003,
+          "n_steps": 2048,
+          "batch_size": 64,
+          "n_epochs": 10,
+          "gae_lambda": 0.95,
+          "ent_coef": 0.001,
+          "device": "cpu",
+          "decision_hours": 1.0,
+          "discount_half_life_hours": 168.0,
+          "log_std_init": -0.7,
+          "target_kl": 0.02,
+          "policy_net_arch": [128, 128],
+          "asset_set_encoder": true,
+          "asset_embedding_dim": 64,
+          "global_embedding_dim": 64,
+          "algorithm": "ppo",
+          "checkpoint_interval_steps": 8192,
+          "max_checkpoints": 4
+        },
+        "environment": {
+          "episode_hours": 720.0,
+          "decision_hours": 1.0,
+          "initial_capital": 100000.0,
+          "finite_horizon_observation": true,
+          "initial_state_modes": ["cash", "baseline"],
+          "episode_sampling_mode": "uniform"
+        },
+        "risk": {
+          "max_gross": 1.0,
+          "max_abs_weight": 0.45,
+          "max_turnover": 0.5,
+          "drawdown_start": 0.1,
+          "drawdown_stop": 0.2,
+          "emergency_turnover_override": true
+        },
+        "portfolio_risk": {
+          "max_abs_weight": 0.45,
+          "max_net_exposure": 1.0,
+          "max_position_to_market_notional": 0.02
+        },
+        "reward": {
+          "absolute_growth_weight": 1.0,
+          "excess_growth_weight": 0.1,
+          "incremental_drawdown_weight": 0.05,
+          "baseline_underperformance_weight": 0.1,
+          "baseline_window_hours": 720.0,
+          "baseline_minimum_history_hours": 720.0,
+          "baseline_tolerance": 0.015,
+          "projection_penalty_weight": 0.01
+        },
+        "trend": {
+          "fast_hours": 24.0,
+          "base_hours": 168.0,
+          "slow_hours": 720.0,
+          "mode": "time_series",
+          "signal_scale": 0.1
+        },
+        "action": {
+          "alpha_enabled": false,
+          "n_factors": 0,
+          "validation_mode": "clip"
+        },
+        "alpha_contract": {
+          "kind": "target_weight",
+          "expected_return_scale": 0.01,
+          "max_gross": 1.0
+        },
+        "execution": {
+          "fee_rate": 0.0005,
+          "spread_rate": 0.0002,
+          "impact_rate": 0.0002,
+          "max_participation_rate": 0.02,
+          "allow_short": true,
+          "max_leverage": 1.0,
+          "margin_mode": "cross",
+          "order_type": "market"
+        },
+        "exports": {
+          "onnx": false,
+          "torchscript": false,
+          "tolerance": 0.00001
+        }
+      }
+    }
+  ]
+}

--- a/tests/cli/test_binance_multitimeframe_command.py
+++ b/tests/cli/test_binance_multitimeframe_command.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import io
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from trade_rl.cli import app
+
+
+def test_data_binance_passes_ordered_feature_timeframes(monkeypatch, tmp_path) -> None:
+    captured: dict[str, object] = {}
+    dataset = SimpleNamespace(
+        dataset_id="a" * 64,
+        n_bars=13_104,
+        n_features=10,
+        n_symbols=3,
+        symbols=("BTCUSDT", "ETHUSDT", "BNBUSDT"),
+        timestamps=[],
+    )
+
+    def fake_build(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return SimpleNamespace(
+            dataset=dataset,
+            sources_used=("vision",),
+            metadata=(),
+            feature_timeframes=("15m", "1h", "4h", "1d"),
+        )
+
+    monkeypatch.setattr(app, "build_binance_market_dataset", fake_build)
+    monkeypatch.setattr(
+        app,
+        "publish_market_dataset_artifact",
+        lambda *_: SimpleNamespace(artifact_digest="b" * 64),
+    )
+    stdout = io.StringIO()
+
+    exit_code = app.main(
+        [
+            "data",
+            "binance",
+            "--market",
+            "usds-m",
+            "--symbol",
+            "BTCUSDT",
+            "--symbol",
+            "ETHUSDT",
+            "--symbol",
+            "BNBUSDT",
+            "--interval",
+            "1h",
+            "--feature-timeframe",
+            "15m",
+            "--feature-timeframe",
+            "4h",
+            "--feature-timeframe",
+            "1d",
+            "--start-time",
+            "2024-12-01T00:00:00Z",
+            "--end-time",
+            "2026-06-01T00:00:00Z",
+            "--tick-size",
+            "0.1",
+            "--tick-size",
+            "0.01",
+            "--tick-size",
+            "0.01",
+            "--lot-size",
+            "0.001",
+            "--lot-size",
+            "0.001",
+            "--lot-size",
+            "0.01",
+            "--minimum-notional",
+            "5",
+            "--minimum-notional",
+            "5",
+            "--minimum-notional",
+            "5",
+            "--listed-at",
+            "2019-09-08T00:00:00Z",
+            "--listed-at",
+            "2019-11-27T00:00:00Z",
+            "--listed-at",
+            "2020-02-10T00:00:00Z",
+            "--output",
+            str(tmp_path / "dataset"),
+        ],
+        stdout=stdout,
+    )
+
+    assert exit_code == 0
+    assert captured["feature_timeframes"] == ("15m", "4h", "1d")
+    payload = json.loads(stdout.getvalue())
+    assert payload["feature_timeframes"] == ["15m", "1h", "4h", "1d"]
+    assert payload["n_symbols"] == 3
+    assert payload["n_features"] == 10
+
+
+def test_data_binance_rejects_duplicate_feature_timeframes(tmp_path) -> None:
+    with pytest.raises(ValueError, match="duplicate"):
+        app.main(
+            [
+                "data",
+                "binance",
+                "--market",
+                "usds-m",
+                "--symbol",
+                "BTCUSDT",
+                "--interval",
+                "1h",
+                "--feature-timeframe",
+                "4h",
+                "--feature-timeframe",
+                "4h",
+                "--start-time",
+                "2026-01-01T00:00:00Z",
+                "--end-time",
+                "2026-02-01T00:00:00Z",
+                "--output",
+                str(tmp_path / "dataset"),
+            ],
+            stdout=io.StringIO(),
+        )

--- a/tests/data/test_multitimeframe_builder.py
+++ b/tests/data/test_multitimeframe_builder.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import numpy as np
+import pytest
+
+from trade_rl.data.builder import MarketDatasetBuilder
+from trade_rl.data.contracts import (
+    FeatureKind,
+    FeatureSpec,
+    InstrumentContract,
+    MarketBuildConfig,
+)
+from trade_rl.data.source import MultiTimeframeMarketDataSource, RawMarketSeries
+
+
+def _series(
+    timestamps: list[str],
+    closes: list[float],
+    *,
+    available_at: list[str] | None = None,
+) -> RawMarketSeries:
+    timestamp_array = np.asarray(timestamps, dtype="datetime64[ns]")
+    close = np.asarray(closes, dtype=np.float64)
+    open_price = np.concatenate((close[:1], close[:-1]))
+    return RawMarketSeries(
+        timestamps=timestamp_array,
+        available_at=(
+            timestamp_array
+            if available_at is None
+            else np.asarray(available_at, dtype="datetime64[ns]")
+        ),
+        open=open_price,
+        high=np.maximum(open_price, close),
+        low=np.minimum(open_price, close),
+        close=close,
+        volume=np.arange(1, len(close) + 1, dtype=np.float64) * 100.0,
+        funding_rate=np.zeros(len(close), dtype=np.float64),
+        funding_available=np.zeros(len(close), dtype=np.bool_),
+        tradable=np.ones(len(close), dtype=np.bool_),
+    )
+
+
+class MemoryMultiTimeframeSource:
+    def __init__(self, values: dict[tuple[str, str], RawMarketSeries]) -> None:
+        self.values = values
+
+    def load(self, symbol: str) -> RawMarketSeries:
+        return self.load_timeframe(symbol, "1h")
+
+    def load_timeframe(self, symbol: str, timeframe: str) -> RawMarketSeries:
+        return self.values[(symbol, timeframe)]
+
+
+def _base() -> RawMarketSeries:
+    timestamps = [f"2026-01-01T{hour:02d}:00:00" for hour in range(9)]
+    return _series(timestamps, [100.0 + hour for hour in range(9)])
+
+
+def _contract() -> tuple[InstrumentContract, ...]:
+    return (
+        InstrumentContract(
+            symbol="BTCUSDT",
+            listed_at=datetime(2025, 1, 1, tzinfo=UTC),
+        ),
+    )
+
+
+def _config(*, max_staleness_hours: float = 24.0) -> MarketBuildConfig:
+    return MarketBuildConfig(
+        base_timeframe="1h",
+        features=(
+            FeatureSpec(
+                name="4h__ret_1bar",
+                kind=FeatureKind.LOG_RETURN,
+                timeframe="4h",
+                lookback=1,
+                max_staleness_hours=max_staleness_hours,
+            ),
+        ),
+    )
+
+
+def test_feature_spec_binds_native_timeframe_to_identity() -> None:
+    hourly = FeatureSpec(name="ret", kind=FeatureKind.LOG_RETURN)
+    four_hour = FeatureSpec(
+        name="ret",
+        kind=FeatureKind.LOG_RETURN,
+        timeframe="4h",
+    )
+
+    assert hourly.resolved_timeframe("1h") == "1h"
+    assert four_hour.resolved_timeframe("1h") == "4h"
+    assert four_hour.canonical_payload()["timeframe"] == "4h"
+    assert hourly.canonical_payload() != four_hour.canonical_payload()
+
+    with pytest.raises(ValueError, match="timeframe"):
+        FeatureSpec(name="bad", kind=FeatureKind.LOG_RETURN, timeframe="3h")
+
+
+def test_multitimeframe_protocol_is_runtime_checkable() -> None:
+    source = MemoryMultiTimeframeSource({("BTCUSDT", "1h"): _base()})
+    assert isinstance(source, MultiTimeframeMarketDataSource)
+
+
+def test_four_hour_feature_is_not_visible_before_native_close() -> None:
+    source = MemoryMultiTimeframeSource(
+        {
+            ("BTCUSDT", "1h"): _base(),
+            ("BTCUSDT", "4h"): _series(
+                [
+                    "2026-01-01T00:00:00",
+                    "2026-01-01T04:00:00",
+                    "2026-01-01T08:00:00",
+                ],
+                [100.0, 104.0, 112.0],
+            ),
+        }
+    )
+
+    dataset = MarketDatasetBuilder(_config()).build(source, _contract())
+
+    assert not dataset.feature_available[3, 0, 0]
+    assert dataset.feature_available[4, 0, 0]
+    np.testing.assert_allclose(dataset.features[4, 0, 0], np.log(104.0 / 100.0))
+    np.testing.assert_allclose(dataset.features[7, 0, 0], np.log(104.0 / 100.0))
+    np.testing.assert_allclose(dataset.features[8, 0, 0], np.log(112.0 / 104.0))
+
+
+def test_native_availability_delay_prevents_same_close_leakage() -> None:
+    source = MemoryMultiTimeframeSource(
+        {
+            ("BTCUSDT", "1h"): _base(),
+            ("BTCUSDT", "4h"): _series(
+                [
+                    "2026-01-01T00:00:00",
+                    "2026-01-01T04:00:00",
+                    "2026-01-01T08:00:00",
+                ],
+                [100.0, 104.0, 112.0],
+                available_at=[
+                    "2026-01-01T00:00:00",
+                    "2026-01-01T05:00:00",
+                    "2026-01-01T08:00:00",
+                ],
+            ),
+        }
+    )
+
+    dataset = MarketDatasetBuilder(_config()).build(source, _contract())
+
+    assert not dataset.feature_available[4, 0, 0]
+    assert dataset.feature_available[5, 0, 0]
+    np.testing.assert_allclose(dataset.features[5, 0, 0], np.log(104.0 / 100.0))
+    assert dataset.feature_staleness_hours[5, 0, 0] == pytest.approx(1.0)
+
+
+def test_multitimeframe_staleness_expires_on_base_clock() -> None:
+    source = MemoryMultiTimeframeSource(
+        {
+            ("BTCUSDT", "1h"): _base(),
+            ("BTCUSDT", "4h"): _series(
+                ["2026-01-01T00:00:00", "2026-01-01T04:00:00"],
+                [100.0, 104.0],
+            ),
+        }
+    )
+
+    dataset = MarketDatasetBuilder(_config(max_staleness_hours=1.0)).build(
+        source,
+        _contract(),
+    )
+
+    assert dataset.feature_available[4, 0, 0]
+    assert dataset.feature_available[5, 0, 0]
+    assert not dataset.feature_available[6, 0, 0]
+    assert dataset.feature_staleness[6, 0, 0] == pytest.approx(1.0)
+
+
+def test_latest_closed_fifteen_minute_feature_aligns_to_hourly_decision() -> None:
+    source = MemoryMultiTimeframeSource(
+        {
+            ("BTCUSDT", "1h"): _series(
+                [
+                    "2026-01-01T00:00:00",
+                    "2026-01-01T01:00:00",
+                    "2026-01-01T02:00:00",
+                ],
+                [100.0, 110.0, 120.0],
+            ),
+            ("BTCUSDT", "15m"): _series(
+                [
+                    "2026-01-01T00:00:00",
+                    "2026-01-01T00:15:00",
+                    "2026-01-01T00:30:00",
+                    "2026-01-01T00:45:00",
+                    "2026-01-01T01:00:00",
+                    "2026-01-01T01:15:00",
+                    "2026-01-01T01:30:00",
+                    "2026-01-01T01:45:00",
+                    "2026-01-01T02:00:00",
+                ],
+                [100.0, 101.0, 103.0, 106.0, 110.0, 111.0, 113.0, 116.0, 120.0],
+            ),
+        }
+    )
+    config = MarketBuildConfig(
+        base_timeframe="1h",
+        features=(
+            FeatureSpec(
+                name="15m__ret_1bar",
+                kind=FeatureKind.LOG_RETURN,
+                timeframe="15m",
+                lookback=1,
+            ),
+        ),
+    )
+
+    dataset = MarketDatasetBuilder(config).build(source, _contract())
+
+    np.testing.assert_allclose(dataset.features[1, 0, 0], np.log(110.0 / 106.0))
+    np.testing.assert_allclose(dataset.features[2, 0, 0], np.log(120.0 / 116.0))

--- a/tests/examples/test_binance_multitimeframe_full_assets.py
+++ b/tests/examples/test_binance_multitimeframe_full_assets.py
@@ -33,7 +33,7 @@ def test_full_training_config_is_not_a_smoke_run() -> None:
 def test_full_walk_forward_config_has_two_material_folds() -> None:
     config = MarketWalkForwardConfig.from_json(
         EXAMPLE_ROOT / "walk-forward-full.json",
-        n_bars=13_104,
+        n_bars=13_128,
     )
 
     folds = config.workflow.build_folds()
@@ -54,6 +54,7 @@ def test_full_runner_uses_three_assets_and_four_native_timeframes() -> None:
         assert timeframe in content
     assert "2024-12-01T00:00:00Z" in content
     assert "2026-06-01T00:00:00Z" in content
+    assert "13_128" in content
     assert "dataset_id" in content
     assert "artifact_digest" in content
     assert '"train", "run"' in content

--- a/tests/examples/test_binance_multitimeframe_full_assets.py
+++ b/tests/examples/test_binance_multitimeframe_full_assets.py
@@ -22,9 +22,11 @@ def test_full_training_config_is_not_a_smoke_run() -> None:
     assert config.training.policy_net_arch == (128, 128)
     assert config.environment.decision_hours == 1.0
     assert config.environment.episode_hours >= 720.0
-    assert config.execution.fee_rate > 0.0
-    assert config.execution.spread_rate > 0.0
-    assert config.execution.impact_rate > 0.0
+    execution = config.environment.execution_cost
+    assert execution.fee_rate > 0.0
+    assert execution.spread_rate > 0.0
+    assert execution.impact_rate > 0.0
+    assert config.portfolio_risk.max_abs_weight is not None
     assert config.portfolio_risk.max_abs_weight <= 0.5
 
 

--- a/tests/examples/test_binance_multitimeframe_full_assets.py
+++ b/tests/examples/test_binance_multitimeframe_full_assets.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from trade_rl.workflows.market_walk_forward_config import MarketWalkForwardConfig
+from trade_rl.workflows.training_run import TrainingRunConfig
+
+ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE_ROOT = ROOT / "examples" / "binance-multitimeframe"
+
+
+def test_full_training_config_is_not_a_smoke_run() -> None:
+    config = TrainingRunConfig.from_json(EXAMPLE_ROOT / "training-full.json")
+
+    assert config.training.algorithm == "ppo"
+    assert config.training.device == "cpu"
+    assert config.training.seeds == (0, 1, 2)
+    assert config.training.timesteps >= 131_072
+    assert config.training.n_steps == 2_048
+    assert config.training.batch_size == 64
+    assert config.training.n_epochs == 10
+    assert config.training.policy_net_arch == (128, 128)
+    assert config.environment.decision_hours == 1.0
+    assert config.environment.episode_hours >= 720.0
+    assert config.execution.fee_rate > 0.0
+    assert config.execution.spread_rate > 0.0
+    assert config.execution.impact_rate > 0.0
+    assert config.portfolio_risk.max_abs_weight <= 0.5
+
+
+def test_full_walk_forward_config_has_two_material_folds() -> None:
+    config = MarketWalkForwardConfig.from_json(
+        EXAMPLE_ROOT / "walk-forward-full.json",
+        n_bars=13_104,
+    )
+
+    folds = config.workflow.build_folds()
+    assert len(folds) == 2
+    assert len(config.candidates) == 1
+    candidate = config.candidates[0].run
+    assert candidate.training.seeds == (0, 1, 2)
+    assert candidate.training.timesteps >= 32_768
+    assert candidate.environment.decision_hours == 1.0
+
+
+def test_full_runner_uses_three_assets_and_four_native_timeframes() -> None:
+    content = (EXAMPLE_ROOT / "run_full_research.py").read_text(encoding="utf-8")
+
+    for symbol in ("BTCUSDT", "ETHUSDT", "BNBUSDT"):
+        assert symbol in content
+    for timeframe in ("15m", "1h", "4h", "1d"):
+        assert timeframe in content
+    assert "2024-12-01T00:00:00Z" in content
+    assert "2026-06-01T00:00:00Z" in content
+    assert "dataset_id" in content
+    assert "artifact_digest" in content
+    assert '"train", "run"' in content
+    assert '"walk-forward", "run"' in content

--- a/tests/integrations/test_binance_multitimeframe.py
+++ b/tests/integrations/test_binance_multitimeframe.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from trade_rl.integrations.binance import (
+    BinanceMarket,
+    BinanceMarketDataSource,
+    BinanceTransportMode,
+    binance_multitimeframe_feature_specs,
+    plan_vision_kline_urls,
+    vision_monthly_kline_url,
+)
+
+
+def _ms(value: datetime) -> int:
+    return int(value.timestamp() * 1000)
+
+
+def _interval_delta(interval: str) -> timedelta:
+    return {
+        "15m": timedelta(minutes=15),
+        "1h": timedelta(hours=1),
+        "4h": timedelta(hours=4),
+        "1d": timedelta(days=1),
+    }[interval]
+
+
+def _kline(open_time: datetime, interval: str, close: float) -> list[Any]:
+    delta = _interval_delta(interval)
+    return [
+        _ms(open_time),
+        str(close - 1.0),
+        str(close + 1.0),
+        str(close - 2.0),
+        str(close),
+        "12.0",
+        _ms(open_time + delta) - 1,
+        "100000.0",
+        10,
+        "5.0",
+        "50000.0",
+        "0",
+    ]
+
+
+class CountingTransport:
+    def __init__(self) -> None:
+        self.kline_calls: list[tuple[str, str]] = []
+        self.funding_calls = 0
+        self.start = datetime(2026, 6, 1, tzinfo=UTC)
+
+    def load_klines(
+        self,
+        *,
+        symbol: str,
+        interval: str,
+        **_: object,
+    ) -> tuple[list[list[Any]], tuple[str, ...]]:
+        self.kline_calls.append((symbol, interval))
+        delta = _interval_delta(interval)
+        rows = [
+            _kline(self.start + index * delta, interval, 100.0 + index)
+            for index in range(2)
+        ]
+        return rows, (f"fixture:{symbol}:{interval}",)
+
+    def load_funding_rates(self, **_: object) -> tuple[list[tuple[int, float]], tuple[str, ...]]:
+        self.funding_calls += 1
+        return [], ("fixture:funding",)
+
+    def load_exchange_information(self, **_: object) -> tuple[dict[str, object], str]:
+        return {"symbols": []}, "fixture:exchange-info"
+
+
+def test_official_monthly_vision_url_is_market_specific() -> None:
+    month = datetime(2025, 12, 1, tzinfo=UTC)
+
+    assert vision_monthly_kline_url(
+        BinanceMarket.USDS_M,
+        "BTCUSDT",
+        "15m",
+        month,
+    ) == (
+        "https://data.binance.vision/data/futures/um/monthly/klines/"
+        "BTCUSDT/15m/BTCUSDT-15m-2025-12.zip"
+    )
+    assert vision_monthly_kline_url(
+        BinanceMarket.SPOT,
+        "ETHUSDT",
+        "1d",
+        month,
+    ) == (
+        "https://data.binance.vision/data/spot/monthly/klines/"
+        "ETHUSDT/1d/ETHUSDT-1d-2025-12.zip"
+    )
+
+
+def test_complete_months_use_monthly_archives_and_partial_months_use_daily() -> None:
+    complete = plan_vision_kline_urls(
+        BinanceMarket.USDS_M,
+        "BTCUSDT",
+        "1h",
+        datetime(2025, 12, 1, tzinfo=UTC),
+        datetime(2026, 2, 1, tzinfo=UTC),
+    )
+    partial = plan_vision_kline_urls(
+        BinanceMarket.USDS_M,
+        "BTCUSDT",
+        "1h",
+        datetime(2026, 1, 30, tzinfo=UTC),
+        datetime(2026, 2, 2, tzinfo=UTC),
+    )
+
+    assert complete == (
+        "https://data.binance.vision/data/futures/um/monthly/klines/"
+        "BTCUSDT/1h/BTCUSDT-1h-2025-12.zip",
+        "https://data.binance.vision/data/futures/um/monthly/klines/"
+        "BTCUSDT/1h/BTCUSDT-1h-2026-01.zip",
+    )
+    assert all("/daily/klines/" in url for url in partial)
+    assert len(partial) == 3
+
+
+def test_source_caches_each_symbol_timeframe_and_shared_funding() -> None:
+    transport = CountingTransport()
+    source = BinanceMarketDataSource(
+        market="usds-m",
+        interval="1h",
+        start_time=transport.start,
+        end_time=transport.start + timedelta(hours=8),
+        transport_mode=BinanceTransportMode.VISION,
+        transport=transport,
+    )
+
+    first = source.load_timeframe("BTCUSDT", "4h")
+    second = source.load_timeframe("BTCUSDT", "4h")
+    source.load_timeframe("BTCUSDT", "1h")
+
+    assert first is second
+    assert transport.kline_calls == [("BTCUSDT", "4h"), ("BTCUSDT", "1h")]
+    assert transport.funding_calls == 1
+    assert source.sources_used == (
+        "fixture:BTCUSDT:1h",
+        "fixture:BTCUSDT:4h",
+        "fixture:funding",
+    )
+
+
+def test_maintained_feature_preset_uses_native_timeframes() -> None:
+    specs = binance_multitimeframe_feature_specs(
+        base_timeframe="1h",
+        feature_timeframes=("15m", "4h", "1d"),
+    )
+
+    assert tuple(spec.name for spec in specs) == (
+        "15m__log_return_1bar",
+        "15m__realized_volatility_4bar",
+        "1h__log_return_1bar",
+        "1h__log_return_1d",
+        "1h__volume_zscore_1d",
+        "1h__funding_bps",
+        "4h__log_return_1bar",
+        "4h__realized_volatility_6bar",
+        "1d__log_return_1bar",
+        "1d__log_return_7bar",
+    )
+    assert tuple(spec.resolved_timeframe("1h") for spec in specs) == (
+        "15m",
+        "15m",
+        "1h",
+        "1h",
+        "1h",
+        "1h",
+        "4h",
+        "4h",
+        "1d",
+        "1d",
+    )
+
+    with pytest.raises(ValueError, match="duplicate"):
+        binance_multitimeframe_feature_specs(
+            base_timeframe="1h",
+            feature_timeframes=("4h", "4h"),
+        )
+    with pytest.raises(ValueError, match="base"):
+        binance_multitimeframe_feature_specs(
+            base_timeframe="1h",
+            feature_timeframes=("1h",),
+        )

--- a/tests/integrations/test_binance_multitimeframe.py
+++ b/tests/integrations/test_binance_multitimeframe.py
@@ -67,7 +67,9 @@ class CountingTransport:
         ]
         return rows, (f"fixture:{symbol}:{interval}",)
 
-    def load_funding_rates(self, **_: object) -> tuple[list[tuple[int, float]], tuple[str, ...]]:
+    def load_funding_rates(
+        self, **_: object
+    ) -> tuple[list[tuple[int, float]], tuple[str, ...]]:
         self.funding_calls += 1
         return [], ("fixture:funding",)
 

--- a/tests/integrations/test_binance_vision_cache.py
+++ b/tests/integrations/test_binance_vision_cache.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from trade_rl.integrations.binance import BinancePublicTransport
+
+
+def test_vision_archive_disk_cache_avoids_second_download(monkeypatch, tmp_path: Path) -> None:
+    payload = b"immutable-vision-archive"
+    calls: list[str] = []
+
+    class Response:
+        def __enter__(self) -> Response:
+            return self
+
+        def __exit__(self, *_: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return payload
+
+    def fake_urlopen(request: object, *, timeout: float) -> Response:
+        calls.append(str(getattr(request, "full_url")))
+        assert timeout > 0.0
+        return Response()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    url = (
+        "https://data.binance.vision/data/futures/um/monthly/klines/"
+        "BTCUSDT/1h/BTCUSDT-1h-2025-01.zip"
+    )
+
+    first = BinancePublicTransport(cache_root=tmp_path)._request_bytes(url)
+    second = BinancePublicTransport(cache_root=tmp_path)._request_bytes(url)
+
+    assert first == payload
+    assert second == payload
+    assert calls == [url]
+    cache_files = tuple(path for path in tmp_path.rglob("*") if path.is_file())
+    assert len(cache_files) == 1
+    assert cache_files[0].read_bytes() == payload
+
+
+def test_rest_requests_are_not_loaded_from_vision_cache(monkeypatch, tmp_path: Path) -> None:
+    responses = iter((b'{"version": 1}', b'{"version": 2}'))
+    calls = 0
+
+    class Response:
+        def __enter__(self) -> Response:
+            return self
+
+        def __exit__(self, *_: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return next(responses)
+
+    def fake_urlopen(request: object, *, timeout: float) -> Response:
+        nonlocal calls
+        calls += 1
+        assert timeout > 0.0
+        return Response()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    transport = BinancePublicTransport(cache_root=tmp_path)
+    url = "https://fapi.binance.com/fapi/v1/exchangeInfo"
+
+    assert transport._request_bytes(url) == b'{"version": 1}'
+    assert transport._request_bytes(url) == b'{"version": 2}'
+    assert calls == 2
+    assert not tuple(path for path in tmp_path.rglob("*") if path.is_file())

--- a/tests/integrations/test_binance_vision_cache.py
+++ b/tests/integrations/test_binance_vision_cache.py
@@ -5,7 +5,9 @@ from pathlib import Path
 from trade_rl.integrations.binance import BinancePublicTransport
 
 
-def test_vision_archive_disk_cache_avoids_second_download(monkeypatch, tmp_path: Path) -> None:
+def test_vision_archive_disk_cache_avoids_second_download(
+    monkeypatch, tmp_path: Path
+) -> None:
     payload = b"immutable-vision-archive"
     calls: list[str] = []
 
@@ -41,7 +43,9 @@ def test_vision_archive_disk_cache_avoids_second_download(monkeypatch, tmp_path:
     assert cache_files[0].read_bytes() == payload
 
 
-def test_rest_requests_are_not_loaded_from_vision_cache(monkeypatch, tmp_path: Path) -> None:
+def test_rest_requests_are_not_loaded_from_vision_cache(
+    monkeypatch, tmp_path: Path
+) -> None:
     responses = iter((b'{"version": 1}', b'{"version": 2}'))
     calls = 0
 

--- a/tests/simulation/test_accounting_precision.py
+++ b/tests/simulation/test_accounting_precision.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from trade_rl.simulation.accounting import BookState
+
+
+def test_from_weights_accepts_subcent_floating_point_reconstruction_error() -> None:
+    weights = np.array([-0.14307002, -0.32557599, -0.12499748])
+    prices = np.array([95_432.17, 3_456.78, 612.34])
+
+    book = BookState.from_weights(
+        weights=weights,
+        capital=100_000.0,
+        prices=prices,
+        max_gross=1.0,
+    )
+
+    assert book.portfolio_value == pytest.approx(100_000.0, abs=1e-8)
+    assert book.peak_value == 100_000.0
+
+
+def test_book_state_still_rejects_economically_lower_peak() -> None:
+    with pytest.raises(ValueError, match="peak_value cannot be below portfolio_value"):
+        BookState(
+            quantities=np.array([1.0]),
+            cash=1.0,
+            mark_prices=np.array([100.0]),
+            peak_value=100.0,
+        )

--- a/trade_rl/cli/app.py
+++ b/trade_rl/cli/app.py
@@ -107,6 +107,7 @@ def _data_binance(args: argparse.Namespace, stdout: TextIO) -> int:
         start_time=start_time,
         end_time=end_time,
         transport_mode=args.transport,
+        feature_timeframes=tuple(args.feature_timeframe or ()),
         tick_sizes=_repeated_float_values(
             args.tick_size, symbols=symbols, field="tick-size"
         ),
@@ -123,25 +124,25 @@ def _data_binance(args: argparse.Namespace, stdout: TextIO) -> int:
     artifact_digest = publish_market_dataset_artifact(
         args.output, result.dataset
     ).artifact_digest
-    _write_json(
-        stdout,
-        {
-            "artifact_digest": artifact_digest,
-            "dataset_id": result.dataset.dataset_id,
-            "end_time": end_time.isoformat(),
-            "interval": args.interval,
-            "market": args.market,
-            "n_bars": result.dataset.n_bars,
-            "n_features": result.dataset.n_features,
-            "n_symbols": result.dataset.n_symbols,
-            "production_status": "NO-GO",
-            "schema": "binance_dataset_build_result_v1",
-            "sources_used": list(result.sources_used),
-            "start_time": start_time.isoformat(),
-            "symbols": list(result.dataset.symbols),
-            "transport": args.transport,
-        },
-    )
+    payload: dict[str, object] = {
+        "artifact_digest": artifact_digest,
+        "dataset_id": result.dataset.dataset_id,
+        "end_time": end_time.isoformat(),
+        "interval": args.interval,
+        "market": args.market,
+        "n_bars": result.dataset.n_bars,
+        "n_features": result.dataset.n_features,
+        "n_symbols": result.dataset.n_symbols,
+        "production_status": "NO-GO",
+        "schema": "binance_dataset_build_result_v1",
+        "sources_used": list(result.sources_used),
+        "start_time": start_time.isoformat(),
+        "symbols": list(result.dataset.symbols),
+        "transport": args.transport,
+    }
+    if args.feature_timeframe:
+        payload["feature_timeframes"] = list(result.feature_timeframes)
+    _write_json(stdout, payload)
     return 0
 
 
@@ -460,6 +461,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--interval",
         choices=("15m", "30m", "1h", "2h", "4h", "6h", "8h", "12h", "1d"),
         required=True,
+    )
+    data_binance.add_argument(
+        "--feature-timeframe",
+        choices=("15m", "30m", "1h", "2h", "4h", "6h", "8h", "12h", "1d"),
+        action="append",
     )
     data_binance.add_argument("--start-time", required=True)
     data_binance.add_argument("--end-time", required=True)

--- a/trade_rl/data/builder.py
+++ b/trade_rl/data/builder.py
@@ -20,7 +20,12 @@ from trade_rl.data.identity import (
     content_and_arrays_digest,
 )
 from trade_rl.data.market import MarketDataset
-from trade_rl.data.source import MarketDataSource, RawMarketSeries
+from trade_rl.data.multitimeframe import align_native_feature
+from trade_rl.data.source import (
+    MarketDataSource,
+    MultiTimeframeMarketDataSource,
+    RawMarketSeries,
+)
 
 _NS_PER_HOUR = 3_600_000_000_000
 
@@ -317,24 +322,48 @@ class MarketDatasetBuilder:
         feature_available = np.zeros_like(features, dtype=np.bool_)
         feature_age_hours = np.ones_like(features, dtype=np.float64)
         feature_staleness = np.ones_like(features, dtype=np.float64)
-        for symbol_index in range(n_symbols):
+        native_cache: dict[tuple[str, str], RawMarketSeries] = {}
+        for symbol_index, contract in enumerate(instruments):
             for feature_index, spec in enumerate(self.config.features):
-                event_values, event_valid = _feature_events(
-                    spec,
-                    close=close[:, symbol_index],
-                    volume=volume[:, symbol_index],
-                    funding_rate=funding_rate[:, symbol_index],
-                    funding_available=funding_available[:, symbol_index],
-                    row_present=causal_row_present[:, symbol_index],
-                    active=symbol_active[:, symbol_index],
-                )
-                values, available, age_hours, staleness = _carry_feature(
-                    event_values,
-                    event_valid,
-                    symbol_active[:, symbol_index],
-                    timestamps,
-                    max_staleness_hours=spec.max_staleness_hours,
-                )
+                native_timeframe = spec.resolved_timeframe(self.config.base_timeframe)
+                if native_timeframe == self.config.base_timeframe:
+                    event_values, event_valid = _feature_events(
+                        spec,
+                        close=close[:, symbol_index],
+                        volume=volume[:, symbol_index],
+                        funding_rate=funding_rate[:, symbol_index],
+                        funding_available=funding_available[:, symbol_index],
+                        row_present=causal_row_present[:, symbol_index],
+                        active=symbol_active[:, symbol_index],
+                    )
+                    values, available, age_hours, staleness = _carry_feature(
+                        event_values,
+                        event_valid,
+                        symbol_active[:, symbol_index],
+                        timestamps,
+                        max_staleness_hours=spec.max_staleness_hours,
+                    )
+                else:
+                    if not isinstance(source, MultiTimeframeMarketDataSource):
+                        raise ValueError(
+                            "native multi-timeframe features require a "
+                            "MultiTimeframeMarketDataSource"
+                        )
+                    key = (contract.symbol, native_timeframe)
+                    native = native_cache.get(key)
+                    if native is None:
+                        native = source.load_timeframe(
+                            contract.symbol, native_timeframe
+                        )
+                        native_cache[key] = native
+                    values, available, age_hours, staleness = align_native_feature(
+                        spec,
+                        native,
+                        contract,
+                        timestamps,
+                        symbol_active[:, symbol_index],
+                        timeframe=native_timeframe,
+                    )
                 features[:, symbol_index, feature_index] = values
                 feature_available[:, symbol_index, feature_index] = available
                 feature_age_hours[:, symbol_index, feature_index] = age_hours

--- a/trade_rl/data/contracts.py
+++ b/trade_rl/data/contracts.py
@@ -32,6 +32,28 @@ class NormalizationMode(StrEnum):
     ROLLING_ZSCORE = "rolling_zscore"
 
 
+_TIMEFRAME_HOURS = {
+    "15m": 0.25,
+    "30m": 0.5,
+    "1h": 1.0,
+    "2h": 2.0,
+    "4h": 4.0,
+    "6h": 6.0,
+    "8h": 8.0,
+    "12h": 12.0,
+    "1d": 24.0,
+}
+
+
+def timeframe_hours(value: str) -> float:
+    """Return the maintained duration for one canonical timeframe."""
+
+    try:
+        return _TIMEFRAME_HOURS[value]
+    except KeyError as error:
+        raise ValueError(f"unsupported timeframe: {value}") from error
+
+
 @dataclass(frozen=True, slots=True)
 class InstrumentContract:
     """Point-in-time instrument lifetime and execution-volume semantics."""
@@ -82,7 +104,7 @@ class InstrumentContract:
 
 @dataclass(frozen=True, slots=True)
 class FeatureSpec:
-    """One causal feature and its trailing normalization contract."""
+    """One causal feature and its native-timeframe normalization contract."""
 
     name: str
     kind: FeatureKind
@@ -91,9 +113,13 @@ class FeatureSpec:
     normalization_window: int = 1
     min_periods: int = 1
     max_staleness_hours: float = 24.0
+    timeframe: str | None = None
 
     def __post_init__(self) -> None:
         require_non_empty(self.name, field="feature name")
+        if self.timeframe is not None:
+            require_non_empty(self.timeframe, field="feature timeframe")
+            timeframe_hours(self.timeframe)
         if (
             isinstance(self.lookback, bool)
             or not isinstance(self.lookback, int)
@@ -123,8 +149,12 @@ class FeatureSpec:
         ):
             raise ValueError("max_staleness_hours must be finite and positive")
 
+    def resolved_timeframe(self, base_timeframe: str) -> str:
+        timeframe_hours(base_timeframe)
+        return base_timeframe if self.timeframe is None else self.timeframe
+
     def canonical_payload(self) -> dict[str, object]:
-        return {
+        payload: dict[str, object] = {
             "name": self.name,
             "kind": self.kind.value,
             "lookback": self.lookback,
@@ -133,19 +163,9 @@ class FeatureSpec:
             "min_periods": self.min_periods,
             "max_staleness_hours": self.max_staleness_hours,
         }
-
-
-_TIMEFRAME_HOURS = {
-    "15m": 0.25,
-    "30m": 0.5,
-    "1h": 1.0,
-    "2h": 2.0,
-    "4h": 4.0,
-    "6h": 6.0,
-    "8h": 8.0,
-    "12h": 12.0,
-    "1d": 24.0,
-}
+        if self.timeframe is not None:
+            payload["timeframe"] = self.timeframe
+        return payload
 
 
 @dataclass(frozen=True, slots=True)
@@ -160,6 +180,7 @@ class MarketBuildConfig:
 
     def __post_init__(self) -> None:
         require_non_empty(self.base_timeframe, field="base_timeframe")
+        timeframe_hours(self.base_timeframe)
         raw_calendar = getattr(self.calendar_kind, "value", self.calendar_kind)
         if not isinstance(raw_calendar, str) or raw_calendar not in {
             "continuous_24_7",
@@ -180,18 +201,29 @@ class MarketBuildConfig:
             raise ValueError(
                 "session_periods_per_year is valid only for session calendar data"
             )
-        if self.base_timeframe not in _TIMEFRAME_HOURS:
-            raise ValueError(f"unsupported base_timeframe: {self.base_timeframe}")
         if not self.features:
             raise ValueError("features must not be empty")
         names = tuple(spec.name for spec in self.features)
         if len(set(names)) != len(names):
             raise ValueError("feature names must be unique")
+        if any(spec.timeframe == self.base_timeframe for spec in self.features):
+            raise ValueError(
+                "base timeframe features must omit timeframe instead of repeating it"
+            )
         require_non_empty(self.schema_version, field="schema_version")
 
     @property
     def bar_hours(self) -> float:
-        return _TIMEFRAME_HOURS[self.base_timeframe]
+        return timeframe_hours(self.base_timeframe)
+
+    @property
+    def native_timeframes(self) -> tuple[str, ...]:
+        ordered: list[str] = []
+        for spec in self.features:
+            resolved = spec.resolved_timeframe(self.base_timeframe)
+            if resolved not in ordered:
+                ordered.append(resolved)
+        return tuple(sorted(ordered, key=timeframe_hours))
 
     @property
     def global_feature_names(self) -> tuple[str, ...]:
@@ -203,7 +235,7 @@ class MarketBuildConfig:
         )
 
     def canonical_payload(self) -> dict[str, object]:
-        return {
+        payload: dict[str, object] = {
             "base_timeframe": self.base_timeframe,
             "bar_hours": self.bar_hours,
             "calendar_kind": self.calendar_kind,
@@ -212,3 +244,6 @@ class MarketBuildConfig:
             "global_feature_names": self.global_feature_names,
             "schema_version": self.schema_version,
         }
+        if any(spec.timeframe is not None for spec in self.features):
+            payload["native_timeframes"] = self.native_timeframes
+        return payload

--- a/trade_rl/data/multitimeframe.py
+++ b/trade_rl/data/multitimeframe.py
@@ -1,0 +1,179 @@
+"""Causal native-timeframe feature calculation and base-clock alignment."""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timezone
+
+import numpy as np
+
+from trade_rl.data.contracts import (
+    FeatureKind,
+    FeatureSpec,
+    InstrumentContract,
+    NormalizationMode,
+    timeframe_hours,
+)
+from trade_rl.data.source import RawMarketSeries
+
+_NS_PER_HOUR = 3_600_000_000_000
+
+
+def _utc_datetime64(value: datetime) -> np.datetime64:
+    resolved = value.astimezone(timezone.utc).replace(tzinfo=None)
+    return np.datetime64(resolved, "ns")
+
+
+def _validate_regular_native_series(raw: RawMarketSeries, timeframe: str) -> None:
+    expected_step = int(round(timeframe_hours(timeframe) * _NS_PER_HOUR))
+    timestamps = raw.timestamps.astype("datetime64[ns]").astype(np.int64)
+    if timestamps.size >= 2 and np.any(np.diff(timestamps) != expected_step):
+        raise ValueError(
+            f"native {timeframe} market series must be complete and exactly regular"
+        )
+
+
+def _active_mask(raw: RawMarketSeries, contract: InstrumentContract) -> np.ndarray:
+    active = raw.timestamps >= _utc_datetime64(contract.listed_at)
+    if contract.delisted_at is not None:
+        active &= raw.timestamps < _utc_datetime64(contract.delisted_at)
+    return active
+
+
+def _window_available_at(raw: RawMarketSeries, start: int, stop: int) -> np.datetime64:
+    assert raw.available_at is not None
+    return np.max(raw.available_at[start:stop])
+
+
+def _native_events(
+    spec: FeatureSpec,
+    raw: RawMarketSeries,
+    contract: InstrumentContract,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    n_bars = len(raw.timestamps)
+    values = np.zeros(n_bars, dtype=np.float64)
+    valid = np.zeros(n_bars, dtype=np.bool_)
+    available_at = np.full(n_bars, np.datetime64("NaT", "ns"), dtype="datetime64[ns]")
+    active = _active_mask(raw, contract)
+
+    if spec.kind is FeatureKind.FUNDING_BPS:
+        assert raw.funding_available is not None
+        assert raw.available_at is not None
+        valid = raw.funding_available & active
+        values[valid] = raw.funding_rate[valid] * 10_000.0
+        available_at[valid] = raw.available_at[valid]
+    elif spec.kind is FeatureKind.LOG_RETURN:
+        for index in range(spec.lookback, n_bars):
+            start = index - spec.lookback
+            if not np.all(active[start : index + 1]):
+                continue
+            values[index] = math.log(raw.close[index] / raw.close[start])
+            valid[index] = True
+            available_at[index] = _window_available_at(raw, start, index + 1)
+    elif spec.kind is FeatureKind.REALIZED_VOLATILITY:
+        for index in range(spec.lookback, n_bars):
+            start = index - spec.lookback
+            if not np.all(active[start : index + 1]):
+                continue
+            returns = np.diff(np.log(raw.close[start : index + 1]))
+            values[index] = float(np.sqrt(np.mean(np.square(returns))))
+            valid[index] = True
+            available_at[index] = _window_available_at(raw, start, index + 1)
+    elif spec.kind is FeatureKind.VOLUME_ZSCORE:
+        for index in range(n_bars):
+            start = max(0, index - spec.lookback + 1)
+            window_active = active[start : index + 1]
+            sample = raw.volume[start : index + 1][window_active]
+            if not active[index] or sample.size < spec.min_periods:
+                continue
+            std = float(np.std(sample))
+            values[index] = (
+                0.0
+                if std <= 1e-12
+                else (raw.volume[index] - float(np.mean(sample))) / std
+            )
+            valid[index] = True
+            available_at[index] = _window_available_at(raw, start, index + 1)
+    else:
+        raise ValueError(f"unsupported feature kind: {spec.kind}")
+
+    if spec.normalization is not NormalizationMode.ROLLING_ZSCORE:
+        return values, valid, available_at
+
+    normalized = np.zeros_like(values)
+    normalized_valid = np.zeros_like(valid)
+    normalized_available_at = np.full_like(available_at, np.datetime64("NaT", "ns"))
+    for index in range(n_bars):
+        if not valid[index]:
+            continue
+        start = max(0, index - spec.normalization_window + 1)
+        sample_mask = valid[start : index + 1]
+        sample = values[start : index + 1][sample_mask]
+        if sample.size < spec.min_periods:
+            continue
+        std = float(np.std(sample))
+        normalized[index] = (
+            0.0 if std <= 1e-12 else (values[index] - float(np.mean(sample))) / std
+        )
+        normalized_valid[index] = True
+        normalized_available_at[index] = np.max(
+            available_at[start : index + 1][sample_mask]
+        )
+    return normalized, normalized_valid, normalized_available_at
+
+
+def align_native_feature(
+    spec: FeatureSpec,
+    raw: RawMarketSeries,
+    contract: InstrumentContract,
+    base_timestamps: np.ndarray,
+    base_active: np.ndarray,
+    *,
+    timeframe: str,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Calculate on the native clock and causally align to the base clock."""
+
+    _validate_regular_native_series(raw, timeframe)
+    event_values, event_valid, event_available_at = _native_events(spec, raw, contract)
+    values = np.zeros(len(base_timestamps), dtype=np.float64)
+    available = np.zeros(len(base_timestamps), dtype=np.bool_)
+    age_hours = np.full(
+        len(base_timestamps),
+        spec.max_staleness_hours,
+        dtype=np.float64,
+    )
+    staleness = np.ones(len(base_timestamps), dtype=np.float64)
+
+    valid_indices = np.flatnonzero(event_valid)
+    if valid_indices.size == 0:
+        return values, available, age_hours, staleness
+
+    event_time_ns = raw.timestamps.astype("datetime64[ns]").astype(np.int64)
+    availability_ns = event_available_at.astype("datetime64[ns]").astype(np.int64)
+    order = valid_indices[np.argsort(availability_ns[valid_indices], kind="stable")]
+    base_ns = base_timestamps.astype("datetime64[ns]").astype(np.int64)
+
+    cursor = 0
+    latest_index: int | None = None
+    for base_index, timestamp_ns in enumerate(base_ns):
+        while cursor < len(order) and availability_ns[order[cursor]] <= timestamp_ns:
+            candidate = int(order[cursor])
+            if latest_index is None or event_time_ns[candidate] > event_time_ns[latest_index]:
+                latest_index = candidate
+            cursor += 1
+        if latest_index is None or not base_active[base_index]:
+            continue
+        age = float(timestamp_ns - event_time_ns[latest_index]) / _NS_PER_HOUR
+        if age < -1e-12:
+            raise ValueError("native feature event appears before its event timestamp")
+        normalized_staleness = min(age / spec.max_staleness_hours, 1.0)
+        age_hours[base_index] = age
+        staleness[base_index] = normalized_staleness
+        if age <= spec.max_staleness_hours + 1e-12:
+            values[base_index] = event_values[latest_index]
+            available[base_index] = True
+
+    return values, available, age_hours, staleness
+
+
+__all__ = ["align_native_feature"]

--- a/trade_rl/data/multitimeframe.py
+++ b/trade_rl/data/multitimeframe.py
@@ -158,7 +158,10 @@ def align_native_feature(
     for base_index, timestamp_ns in enumerate(base_ns):
         while cursor < len(order) and availability_ns[order[cursor]] <= timestamp_ns:
             candidate = int(order[cursor])
-            if latest_index is None or event_time_ns[candidate] > event_time_ns[latest_index]:
+            if (
+                latest_index is None
+                or event_time_ns[candidate] > event_time_ns[latest_index]
+            ):
                 latest_index = candidate
             cursor += 1
         if latest_index is None or not base_active[base_index]:

--- a/trade_rl/data/source.py
+++ b/trade_rl/data/source.py
@@ -7,7 +7,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Protocol
+from typing import Protocol, runtime_checkable
 
 import numpy as np
 
@@ -110,6 +110,13 @@ class RawMarketSeries:
 
 class MarketDataSource(Protocol):
     def load(self, symbol: str) -> RawMarketSeries: ...
+
+
+@runtime_checkable
+class MultiTimeframeMarketDataSource(MarketDataSource, Protocol):
+    """Source capable of loading one symbol on an explicitly requested clock."""
+
+    def load_timeframe(self, symbol: str, timeframe: str) -> RawMarketSeries: ...
 
 
 class InMemoryMarketDataSource:

--- a/trade_rl/integrations/binance.py
+++ b/trade_rl/integrations/binance.py
@@ -130,6 +130,7 @@ class BinanceDatasetBuildResult:
     dataset: MarketDataset
     metadata: tuple[BinanceInstrumentMetadata, ...]
     sources_used: tuple[str, ...]
+    feature_timeframes: tuple[str, ...] = ()
 
 
 def _market(value: BinanceMarket | str) -> BinanceMarket:
@@ -217,6 +218,57 @@ def vision_kline_url(
     else:
         prefix = "futures/cm/daily/klines"
     return f"{_VISION_ROOT}/{prefix}/{symbol}/{interval}/{symbol}-{interval}-{date}.zip"
+
+
+def vision_monthly_kline_url(
+    market: BinanceMarket | str,
+    symbol: str,
+    interval: str,
+    month: datetime,
+) -> str:
+    resolved = _market(market)
+    _interval_ms(interval)
+    period = _aware_utc(month, field="month").strftime("%Y-%m")
+    if resolved is BinanceMarket.SPOT:
+        prefix = "spot/monthly/klines"
+    elif resolved is BinanceMarket.USDS_M:
+        prefix = "futures/um/monthly/klines"
+    else:
+        prefix = "futures/cm/monthly/klines"
+    return (
+        f"{_VISION_ROOT}/{prefix}/{symbol}/{interval}/{symbol}-{interval}-{period}.zip"
+    )
+
+
+def _next_month(value: datetime) -> datetime:
+    if value.month == 12:
+        return value.replace(year=value.year + 1, month=1, day=1)
+    return value.replace(month=value.month + 1, day=1)
+
+
+def plan_vision_kline_urls(
+    market: BinanceMarket | str,
+    symbol: str,
+    interval: str,
+    start_time: datetime,
+    end_time: datetime,
+) -> tuple[str, ...]:
+    start = _aware_utc(start_time, field="start_time")
+    end = _aware_utc(end_time, field="end_time")
+    if end <= start:
+        raise ValueError("end_time must be later than start_time")
+    cursor = start.replace(hour=0, minute=0, second=0, microsecond=0)
+    urls: list[str] = []
+    while cursor < end:
+        month_start = cursor.replace(day=1)
+        next_month = _next_month(month_start)
+        if cursor == month_start and start <= cursor and next_month <= end:
+            urls.append(vision_monthly_kline_url(market, symbol, interval, month_start))
+            cursor = next_month
+        else:
+            urls.append(vision_kline_url(market, symbol, interval, cursor))
+            cursor += timedelta(days=1)
+    return tuple(urls)
 
 
 def vision_funding_url(
@@ -383,8 +435,11 @@ class BinancePublicTransport:
         end_ms: int,
     ) -> list[list[object]]:
         result: list[list[object]] = []
-        for day in _iter_days(start_ms, end_ms):
-            url = vision_kline_url(market, symbol, interval, day)
+        start_time = datetime.fromtimestamp(start_ms / 1_000, tz=UTC)
+        end_time = datetime.fromtimestamp(end_ms / 1_000, tz=UTC)
+        for url in plan_vision_kline_urls(
+            market, symbol, interval, start_time, end_time
+        ):
             rows = _csv_rows_from_zip(self._request_bytes(url), source=url)
             if rows and _looks_like_header(rows[0]):
                 rows = rows[1:]
@@ -644,8 +699,8 @@ def _parse_kline_rows(
         close = _finite_float(row[4], field="close")
         quote_volume = _finite_float(row[7], field="quote volume")
         parsed.append((close_ms, open_price, high, low, close, quote_volume))
-    if len(parsed) < 3:
-        raise ValueError("Binance range must contain at least three closed bars")
+    if len(parsed) < 2:
+        raise ValueError("Binance range must contain at least two closed bars")
     timestamps = np.asarray([item[0] for item in parsed], dtype=np.int64)
     if np.any(np.diff(timestamps) <= 0):
         raise ValueError("Binance kline timestamps must be strictly increasing")
@@ -684,7 +739,7 @@ def _align_funding(
 
 
 class BinanceMarketDataSource(MarketDataSource):
-    """Load one fixed Binance range as a causal raw series."""
+    """Load one fixed Binance range on one or more causal native clocks."""
 
     def __init__(
         self,
@@ -710,40 +765,78 @@ class BinanceMarketDataSource(MarketDataSource):
         self.transport_mode = _mode(transport_mode)
         self.transport = transport or BinancePublicTransport()
         self._sources_used: set[str] = set()
+        self._series_cache: dict[tuple[str, str], RawMarketSeries] = {}
+        self._funding_cache: dict[str, tuple[list[tuple[int, float]], object]] = {}
 
     @property
     def sources_used(self) -> tuple[str, ...]:
         return tuple(sorted(self._sources_used))
 
+    def _record_source(self, source: object) -> None:
+        if isinstance(source, str):
+            self._sources_used.add(source)
+            return
+        if isinstance(source, Sequence):
+            self._sources_used.update(str(item) for item in source)
+            return
+        self._sources_used.add(str(source))
+
+    def _funding_events(self, symbol: str) -> list[tuple[int, float]]:
+        cached = self._funding_cache.get(symbol)
+        if cached is None:
+            events, funding_source = self.transport.load_funding_rates(
+                market=self.market,
+                symbol=symbol,
+                start_ms=_epoch_ms(self.start_time),
+                end_ms=_epoch_ms(self.end_time),
+                mode=self.transport_mode,
+            )
+            cached = (list(events), funding_source)
+            self._funding_cache[symbol] = cached
+            self._record_source(funding_source)
+        return cached[0]
+
     def load(self, symbol: str) -> RawMarketSeries:
+        return self.load_timeframe(symbol, self.interval)
+
+    def load_timeframe(self, symbol: str, timeframe: str) -> RawMarketSeries:
         if not symbol:
             raise ValueError("Binance symbol must not be empty")
+        interval_ms = _interval_ms(timeframe)
         start_ms = _epoch_ms(self.start_time)
         end_ms = _epoch_ms(self.end_time)
+        if start_ms % interval_ms != 0 or end_ms % interval_ms != 0:
+            raise ValueError(
+                f"Binance range boundaries must align to native timeframe {timeframe}"
+            )
+        key = (symbol, timeframe)
+        cached = self._series_cache.get(key)
+        if cached is not None:
+            return cached
         rows, kline_source = self.transport.load_klines(
             market=self.market,
             symbol=symbol,
-            interval=self.interval,
+            interval=timeframe,
             start_ms=start_ms,
             end_ms=end_ms,
             mode=self.transport_mode,
         )
-        events, funding_source = self.transport.load_funding_rates(
-            market=self.market,
-            symbol=symbol,
-            start_ms=start_ms,
-            end_ms=end_ms,
-            mode=self.transport_mode,
-        )
-        self._sources_used.update((str(kline_source), str(funding_source)))
+        self._record_source(kline_source)
         timestamps, open_price, high, low, close, volume = _parse_kline_rows(
             rows,
-            interval_ms=self.interval_ms,
+            interval_ms=interval_ms,
             start_ms=start_ms,
             end_ms=end_ms,
         )
-        funding, funding_available = _align_funding(timestamps, events)
-        return RawMarketSeries(
+        if timeframe == self.interval:
+            funding, funding_available = _align_funding(
+                timestamps,
+                self._funding_events(symbol),
+            )
+        else:
+            funding = np.zeros(len(timestamps), dtype=np.float64)
+            funding_available = np.zeros(len(timestamps), dtype=np.bool_)
+        series = RawMarketSeries(
             timestamps=timestamps,
             available_at=timestamps,
             open=open_price,
@@ -755,6 +848,8 @@ class BinanceMarketDataSource(MarketDataSource):
             funding_available=funding_available,
             tradable=np.ones(len(timestamps), dtype=np.bool_),
         )
+        self._series_cache[key] = series
+        return series
 
 
 def _filter_value(
@@ -861,6 +956,86 @@ def _optional_datetimes(
     return result
 
 
+def binance_multitimeframe_feature_specs(
+    *,
+    base_timeframe: str,
+    feature_timeframes: Sequence[str],
+) -> tuple[FeatureSpec, ...]:
+    _interval_ms(base_timeframe)
+    resolved = tuple(feature_timeframes)
+    if len(set(resolved)) != len(resolved):
+        raise ValueError("duplicate Binance feature timeframes are not allowed")
+    if base_timeframe in resolved:
+        raise ValueError("base timeframe must not be repeated as a feature timeframe")
+    for timeframe in resolved:
+        _interval_ms(timeframe)
+    ordered = tuple(sorted((*resolved, base_timeframe), key=_interval_ms))
+    features: list[FeatureSpec] = []
+    for timeframe in ordered:
+        native = None if timeframe == base_timeframe else timeframe
+        native_hours = _interval_ms(timeframe) / 3_600_000.0
+        staleness = max(
+            native_hours * 2.0, base_timeframe == timeframe and 1.0 or native_hours
+        )
+        features.append(
+            FeatureSpec(
+                name=f"{timeframe}__log_return_1bar",
+                kind=FeatureKind.LOG_RETURN,
+                timeframe=native,
+                lookback=1,
+                max_staleness_hours=staleness,
+            )
+        )
+        if timeframe == base_timeframe:
+            one_day = max(1, int(round(24.0 / native_hours)))
+            features.extend(
+                (
+                    FeatureSpec(
+                        name=f"{timeframe}__log_return_1d",
+                        kind=FeatureKind.LOG_RETURN,
+                        lookback=one_day,
+                        max_staleness_hours=staleness,
+                    ),
+                    FeatureSpec(
+                        name=f"{timeframe}__volume_zscore_1d",
+                        kind=FeatureKind.VOLUME_ZSCORE,
+                        lookback=one_day,
+                        min_periods=min(one_day, 2),
+                        max_staleness_hours=staleness,
+                    ),
+                    FeatureSpec(
+                        name=f"{timeframe}__funding_bps",
+                        kind=FeatureKind.FUNDING_BPS,
+                        max_staleness_hours=8.0,
+                    ),
+                )
+            )
+        elif timeframe == "1d":
+            features.append(
+                FeatureSpec(
+                    name="1d__log_return_7bar",
+                    kind=FeatureKind.LOG_RETURN,
+                    timeframe="1d",
+                    lookback=7,
+                    max_staleness_hours=48.0,
+                )
+            )
+        else:
+            volatility_lookback = (
+                4 if timeframe == "15m" else max(2, int(round(24.0 / native_hours)))
+            )
+            features.append(
+                FeatureSpec(
+                    name=(f"{timeframe}__realized_volatility_{volatility_lookback}bar"),
+                    kind=FeatureKind.REALIZED_VOLATILITY,
+                    timeframe=timeframe,
+                    lookback=volatility_lookback,
+                    max_staleness_hours=staleness,
+                )
+            )
+    return tuple(features)
+
+
 def _default_features(interval: str) -> tuple[FeatureSpec, ...]:
     bar_hours = _interval_ms(interval) / 3_600_000.0
     one_day = max(1, int(round(24.0 / bar_hours)))
@@ -912,6 +1087,7 @@ def build_binance_market_dataset(
     lot_sizes: Sequence[float] | None = None,
     minimum_notionals: Sequence[float] | None = None,
     listed_ats: Sequence[datetime] | None = None,
+    feature_timeframes: Sequence[str] | None = None,
 ) -> BinanceDatasetBuildResult:
     """Build one deterministic linear-product dataset from public Binance data."""
 
@@ -927,6 +1103,15 @@ def build_binance_market_dataset(
     if len(set(resolved_symbols)) != len(resolved_symbols):
         raise ValueError("Binance symbols must be unique")
     resolved_mode = _mode(transport_mode)
+    requested_feature_timeframes = tuple(feature_timeframes or ())
+    resolved_features = (
+        _default_features(interval)
+        if not requested_feature_timeframes
+        else binance_multitimeframe_feature_specs(
+            base_timeframe=interval,
+            feature_timeframes=requested_feature_timeframes,
+        )
+    )
     resolved_tick = _optional_values(
         tick_sizes,
         symbols=resolved_symbols,
@@ -1014,7 +1199,7 @@ def build_binance_market_dataset(
     dataset = MarketDatasetBuilder(
         MarketBuildConfig(
             base_timeframe=interval,
-            features=_default_features(interval),
+            features=resolved_features,
         )
     ).build(source, tuple(item.to_contract() for item in metadata))
     sources = set(source.sources_used)
@@ -1024,6 +1209,12 @@ def build_binance_market_dataset(
         dataset=dataset,
         metadata=metadata,
         sources_used=tuple(sorted(sources)),
+        feature_timeframes=tuple(
+            sorted(
+                {spec.resolved_timeframe(interval) for spec in resolved_features},
+                key=_interval_ms,
+            )
+        ),
     )
 
 
@@ -1036,7 +1227,10 @@ __all__ = [
     "BinanceTransportError",
     "BinanceTransportMode",
     "BinanceUnsupportedContractError",
+    "binance_multitimeframe_feature_specs",
     "build_binance_market_dataset",
+    "plan_vision_kline_urls",
     "vision_funding_url",
     "vision_kline_url",
+    "vision_monthly_kline_url",
 ]

--- a/trade_rl/integrations/binance.py
+++ b/trade_rl/integrations/binance.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import csv
+import hashlib
 import io
 import json
 import math
@@ -15,6 +16,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -330,6 +332,7 @@ class BinancePublicTransport:
         timeout_seconds: float = 30.0,
         max_attempts: int = 3,
         retry_backoff_seconds: float = 0.25,
+        cache_root: str | Path | None = None,
     ) -> None:
         if not math.isfinite(timeout_seconds) or timeout_seconds <= 0.0:
             raise ValueError("timeout_seconds must be finite and positive")
@@ -342,8 +345,23 @@ class BinancePublicTransport:
         self.timeout_seconds = timeout_seconds
         self.max_attempts = max_attempts
         self.retry_backoff_seconds = retry_backoff_seconds
+        self.cache_root = None if cache_root is None else Path(cache_root)
+
+    def _vision_cache_path(self, url: str) -> Path | None:
+        if self.cache_root is None or not url.startswith(f"{_VISION_ROOT}/"):
+            return None
+        digest = hashlib.sha256(url.encode("utf-8")).hexdigest()
+        return self.cache_root / digest[:2] / f"{digest}.bin"
 
     def _request_bytes(self, url: str) -> bytes:
+        cache_path = self._vision_cache_path(url)
+        if cache_path is not None and cache_path.is_file():
+            payload = cache_path.read_bytes()
+            if not payload:
+                raise BinanceTransportError(
+                    f"cached Binance Vision archive is empty: {cache_path}"
+                )
+            return payload
         request = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
         last_error: BaseException | None = None
         for attempt in range(self.max_attempts):
@@ -352,7 +370,17 @@ class BinancePublicTransport:
                     request,
                     timeout=self.timeout_seconds,
                 ) as response:
-                    return response.read()
+                    payload = response.read()
+                if not payload:
+                    raise BinanceTransportError(
+                        f"Binance returned an empty response for {url}"
+                    )
+                if cache_path is not None:
+                    cache_path.parent.mkdir(parents=True, exist_ok=True)
+                    temporary = cache_path.with_suffix(".tmp")
+                    temporary.write_bytes(payload)
+                    temporary.replace(cache_path)
+                return payload
             except urllib.error.HTTPError as error:
                 last_error = error
                 if error.code == 404:

--- a/trade_rl/simulation/accounting.py
+++ b/trade_rl/simulation/accounting.py
@@ -115,7 +115,16 @@ class BookState:
         object.__setattr__(self, "contract_multipliers", multipliers)
         object.__setattr__(self, "termination_reason", reason)
         self._refresh_economic_state()
-        if not self.insolvent and self.peak_value + _TOLERANCE < self.portfolio_value:
+        portfolio_value = self.portfolio_value
+        comparison_tolerance = max(
+            _TOLERANCE,
+            abs(portfolio_value) * 1e-12,
+            abs(self.peak_value) * 1e-12,
+        )
+        if (
+            not self.insolvent
+            and self.peak_value + comparison_tolerance < portfolio_value
+        ):
             raise ValueError("peak_value cannot be below portfolio_value")
 
     @classmethod


### PR DESCRIPTION
Implements native multi-timeframe features and completes a reproducible BTCUSDT/ETHUSDT/BNBUSDT full PPO and nested walk-forward research run.

Current state is intentionally TDD RED: contract, causal alignment, Binance monthly archive, CLI, and full-run asset tests are committed before production implementation.

Planned maintained scope:
- 1h decision clock
- native 15m, 1h, 4h, and 1d features
- causal as-of alignment after native bar availability
- official Binance Vision monthly archives
- BTCUSDT, ETHUSDT, BNBUSDT USDⓈ-M
- repeated deterministic dataset build
- three PPO seeds with 131,072 timesteps each
- two-fold nested walk-forward with 32,768 timesteps per seed/fold

COIN-M and direct exchange routing remain fail-closed / NO-GO.