### PR TITLE
CI: remove temporary remediation branches

### DIFF
--- a/.github/workflows/prune-temporary-remediation-20260718.yml
+++ b/.github/workflows/prune-temporary-remediation-20260718.yml
@@ -1,0 +1,117 @@
+name: Prune temporary remediation branches 2026-07-18
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: prune-temporary-remediation-20260718
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    if: github.head_ref == 'ci/prune-temporary-remediation-20260718'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+
+      - name: Validate and delete temporary remediation branches
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          git fetch origin '+refs/heads/*:refs/remotes/origin/*' --prune
+
+          report=/tmp/temporary-remediation-prune-report.txt
+          : > "$report"
+          echo 'temporary_remediation_prune_v1' >> "$report"
+          echo "main_sha=$(git rev-parse origin/main)" >> "$report"
+          echo >> "$report"
+
+          branches=(
+            fix/architecture-hardening-20260717-staging
+            fix/remediation-diagnostics
+            fix/remediation-transfer-complete
+          )
+
+          for branch in "${branches[@]}"; do
+            if ! git show-ref --verify --quiet "refs/remotes/origin/$branch"; then
+              echo "SKIP missing $branch" | tee -a "$report"
+              continue
+            fi
+
+            open_count=$(gh pr list --repo "$REPO" --state open --head "$branch" --json number --jq 'length')
+            if [ "$open_count" -gt 0 ]; then
+              echo "KEEP open-pr $branch" | tee -a "$report"
+              continue
+            fi
+
+            mapfile -t changed < <(git diff --name-only "origin/main...origin/$branch")
+            if [ "${#changed[@]}" -eq 0 ]; then
+              echo "KEEP no-auditable-diff $branch" | tee -a "$report"
+              continue
+            fi
+
+            unexpected=0
+            for path in "${changed[@]}"; do
+              case "$path" in
+                .github/staging-probe.txt|\
+                .github/remediation-binary/*|\
+                .github/remediation-transfer/*|\
+                .github/workflows/apply-verified-remediation.yml|\
+                .github/workflows/verify-remediated-target.yml|\
+                .github/workflows/apply-complete-remediation-v3.yml|\
+                .github/workflows/diagnose-remediation-parts.yml|\
+                .remediation/*|\
+                .remediation-fixed/*|\
+                .verification/*)
+                  ;;
+                *)
+                  echo "UNEXPECTED $branch $path" | tee -a "$report"
+                  unexpected=1
+                  ;;
+              esac
+            done
+
+            if [ "$unexpected" -ne 0 ]; then
+              echo "KEEP unexpected-path $branch" | tee -a "$report"
+              continue
+            fi
+
+            encoded=$(printf '%s' "$branch" | jq -sRr @uri)
+            gh api --method DELETE "repos/$REPO/git/refs/heads/$encoded"
+            echo "DELETE temporary-remediation-only $branch files=${#changed[@]}" | tee -a "$report"
+          done
+
+          cat "$report" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload branch report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: temporary-remediation-prune-report-20260718
+          path: /tmp/temporary-remediation-prune-report.txt
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Delete cleanup branch
+        if: success()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          CLEANUP_BRANCH: ci/prune-temporary-remediation-20260718
+        run: |
+          set -euo pipefail
+          encoded=$(printf '%s' "$CLEANUP_BRANCH" | jq -sRr @uri)
+          gh api --method DELETE "repos/$REPO/git/refs/heads/$encoded"


### PR DESCRIPTION
Temporary cleanup PR. It targets exactly three known remediation-transfer/diagnostic branches. Before deletion, every changed path must match a fixed allowlist limited to temporary patches, base64 transfer chunks, verification logs, probes, and one-shot workflows. Any unexpected file or open PR causes that branch to be preserved. This PR must not be merged.