### PR TITLE
docs: refresh explanations and record architecture audit

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,190 +1,159 @@
 # Trade RL
 
-Trade RLは、ポートフォリオ配分を対象とした**ベースライン固定型Residual強化学習**の研究コアです。方策がポートフォリオ比率を直接自由に決めるのではなく、決定論的なTrend baselineに対して、制約された残差行動だけを加えます。報酬と評価では、独立したShadow baseline bookとの差分を使用します。
+Trade RLは、ポートフォリオ配分を対象とした研究用の強化学習基盤です。維持対象の方策は、決定論的な因果ベースラインへ制約付きResidual行動を加える方式と、銘柄順序を明示的に固定したTarget Weight方式を扱います。比較用のShadow baseline bookは学習方策と独立して更新されます。
 
-> 能力判定は **研究実行可能**、**外部Attestation付きPaper Serving可能** です。取引所への直接注文送信は **NO-GO** のままです。構造改善は収益性や実資金投入を保証しません。
+> 能力判定は **研究実行可能**、**外部Attestation付きPaper Serving可能** です。取引所への直接注文送信は **NO-GO** のままです。テストや構造改善は、収益性や実資金投入を保証しません。
 
-## 再構築内容
+## 現在の維持対象
 
-旧`mars_lite`、Direct-action PPO、旧CLIスクリプト、重複した評価計算、旧テスト群は互換層を残さず削除しました。Git履歴が旧実装のアーカイブです。
+現在のリポジトリは、次の役割を明確に分離しています。
 
-現在の責務は次のように分離されています。
+- 因果的な市場データとMulti-Timeframe特徴量artifact
+- Exploratory学習と、承認付きSelected-final学習
+- Nested walk-forward、Checkpoint選択、永続Sealed-test ledger
+- 保守的なOHLCV状態付き約定シミュレータ
+- 学習中の探索を観察するTrade RL Studio
+- 外部署名で検証されるRead-only Paper Serving
 
-- `domain`: Dataset、Signal、Policy ensemble、Selection、Releaseの不変条件
-- `artifacts`: canonical JSON、SHA-256、staging、atomic publish
-- `data`: 実データsource、因果的特徴量builder、MarketDataset検証
-- `strategies`: 決定論的Trend baseline
-- `risk`: Gross、銘柄上限、Turnover、Drawdown縮小
-- `simulation`: 約定、コスト、Funding、会計
-- `evaluation`: Return、Sharpe、Sortino、Drawdown、paired比較、bootstrap、Gate
-- `rl`: Residual action、Observation、Reward、Environment、framework非依存Training contract
-- `integrations`: Stable-Baselines3の学習・Serving adapter
+PostgreSQLは、再計算不要なartifactの検索、cache identity、依存関係、状態、Sealed-test予約を保存する任意のメタデータカタログです。NumPy配列、dataset、checkpoint、model、run evidenceは従来どおり不変filesystem artifactに保存し、DBのBLOBを数値計算の正本にはしません。
 
-維持対象の報酬契約は **Reward schema v4** です。絶対対数資産成長を主目的とし、完全な30日履歴が揃った場合だけ固定1.5%許容幅のベースライン劣後ペナルティを有効化します。
-- `workflows`: 型付き設定を受け取るApplication orchestration
-- `serving`: Bundle検証、Registry、Runtime hot-swap
+通常のEnvironment遷移では、Market、Limit、Stop-market注文を状態として保持します。注文にはLatency、Time in Force、残数量、Trigger状態、Cancel-and-replaceの対応、決定論的OrderEvent証拠が含まれます。約定容量は処理対象バーの出来高を使い、OHLC内の経路は明示した仮定として記録します。これは板復元や実取引所と同等の約定を意味しません。
+
+## 責務の分離
+
+- `domain`: Dataset、Policy、Selection、Releaseなどの不変Identity
+- `artifacts`: Canonical serialization、Hash、Staging、Atomic publish
+- `release`: Offline署名と外部Attestationの検証契約
+- `evaluation`: Return、Risk、Paired inference、Walk-forward、Gate
+- `catalog`: Framework非依存のartifact catalog契約とPostgreSQL adapter
+- `data`: Market calendar、特徴量、Execution data、Dataset検証
+- `strategies`: 決定論的な因果Baseline
+- `simulation`: Order lifecycle、Liquidity、約定、Cost、Carry、Margin、Accounting
+- `risk`: Pre-trade制約、Portfolio risk、Emergency deleverage
+- `rl`: Action、Observation、Normalizer、Reward、Environment、Training protocol
+- `learning`: Teacher、Behavior cloning、Supervised data契約
+- `serving`: Candidate bundle、Registry、Fail-closed runtime
+- `integrations`: Stable-Baselines3など外部Framework adapter
+- `workflows`: Training、Walk-forward、Artifact publicationのApplication orchestration
+- `studio`: Local GUI用の型付きRead modelとJob管理API
 - `cli`: 単一の`trade-rl`入口
+
+依存方向の正本は`.importlinter`です。`trade_rl.telemetry`は標準ライブラリ中心の診断契約ですが、現時点ではLayer stackへ明示配置されていません。この点は[最新アーキテクチャ監査](docs/verification/2026-07-22-documentation-and-architecture-audit.md)に記録しています。
+
+## Trade RL Studio
+
+固定レイアウトのReact + Vite + TypeScript画面から、検証済みdataset、config、exploratory training job、run、比較結果、Evidence chain、read-only paper-serving状態を確認できます。Live Trainingでは、学習中の探索をSeed単位の市場リプレイとして表示します。
+
+```bash
+uv sync --extra studio --extra train-sb3
+uv run trade-rl studio start --project-root .
+
+# 別ターミナル
+npm ci --prefix studio
+npm run dev --prefix studio
+```
+
+BUY／SELL表示はTarget exposureの変化であり、取引所注文ではありません。Telemetryは診断専用で、モデル選択、artifact identity、Serving承認、注文実行には使いません。詳細は[`studio/README.md`](studio/README.md)を参照してください。
 
 ## 因果的な実データ入力
 
-正式なデータ経路は、銘柄ごとのCSV実データから`MarketDatasetBuilder`で`MarketDataset`を生成します。全銘柄の共通時刻を欠損ごと削除するのではなく、規則的なunion clockを保持し、上場・廃止期間、実現した取引可否、情報利用可能時刻、特徴量ごとの利用可否と鮮度を別々に記録します。
+正式なデータ経路では、規則的なUnion clockを保持し、上場・廃止期間、実現した取引可否、情報利用可能時刻、特徴量ごとのAvailabilityとStalenessを別々に記録します。行`t`の方策判断は、行`t`のCloseまでに利用可能な情報だけを使い、最短でも`t + 1`のOpen以降で約定します。
 
-```python
-from datetime import datetime, timezone
+`dataset_id`は、FeatureとAvailabilityだけでなく、Fee、Maker/Taker fee、Spread、Participation、Lot/Tick、Minimum notional、Borrow/Funding、Buy/Sell制限、Mark/Index価格、配当・分割・上場廃止、Cash rate、Volume unit、Contract multiplierを含む実行・会計配列から再計算されます。正式artifactは任意ID、Symlink、Root escape、未宣言ファイルを拒否します。
 
-from trade_rl.data import (
-    CsvMarketDataSource,
-    FeatureKind,
-    FeatureSpec,
-    InstrumentContract,
-    MarketBuildConfig,
-    MarketDatasetBuilder,
-)
+正式APIは次の3つです。
 
-config = MarketBuildConfig(
-    base_timeframe="1h",
-    features=(
-        FeatureSpec(name="ret_1", kind=FeatureKind.LOG_RETURN),
-        FeatureSpec(name="funding_bps", kind=FeatureKind.FUNDING_BPS),
-    ),
-)
-contracts = (
-    InstrumentContract(
-        symbol="BTCUSDT",
-        listed_at=datetime(2019, 9, 1, tzinfo=timezone.utc),
-    ),
-)
-dataset = MarketDatasetBuilder(config).build(
-    CsvMarketDataSource("data/market"),
-    contracts,
-)
-```
+- `write_market_dataset_files`: 決定論的Staging file作成
+- `publish_market_dataset_artifact`: 排他的なAtomic publish
+- `load_market_dataset_artifact`: IdentityとFile closureを検証した読込
 
-CSVの必須列は`timestamp,open,high,low,close,volume`で、`available_at`、`funding_rate`、`tradable`は任意です。`timestamp`は市場イベント時刻、`available_at`はその行を知り得た最初の時刻です。遅延行は実現した執行履歴として保持しますが、同時刻の特徴量や方策観測へ遡及注入しません。方策が見る`MarketDataset.observable_tradable(t)`は`tradable[t] & information_available[t]`であり、Executorだけがマスク前の実現`tradable`を使用します。
+## Observation、学習、Servingの整合性
 
-Trend、Alpha、pre-trade targetは同じpoint-in-time eligibility maskを使用します。要求されたlookback全体で、上場中・取引可能・情報利用可能である銘柄だけを対象にします。翌バー以降の取引可否はExecutorが実現状態として処理し、現在のtarget生成には使用しません。
+Observation schema v3は、Feature、Availability、Staleness、Baseline、Factor、現在・要求Portfolio、Fill/Cost/Capacity、Pending order、Cash/Net/Gross/Margin、Previous actionを含みます。Multi-Timeframe方策は、15m、1h、4h、1dのNative sequenceをDict observationとして受け取り、各時間足専用の因果TCNとCross-asset attentionを使用します。
 
-Alpha providerへ渡すのは、判断時点までをコピーした読み取り専用`CausalMarketView`だけです。因果的特徴量とmaskは含みますが、未来行やraw OHLCは公開しません。学習環境とServingは、Trend・Alpha設定をdigest化した同じ`MarketInputResolver`を使用します。
+学習EnvironmentとServingは同じObservation builder、Normalizer、Sequence adapter、Symbol/Feature順序を検証します。Candidate bundleは **Serving bundle v5** です。Bundle自体にApproval秘密情報は含めず、別の`ReleaseAttestation`がBundle、Selected-final run、Walk-forward、Gate、Fresh confirmation、Source commit、Dependency provenance、Approver、Expiryを結合します。
 
-`volume`の意味は銘柄契約ごとにbase asset数量、quote notional、契約枚数のいずれかを明示し、契約枚数にはbase asset換算用のcontract multiplierを設定します。
+Runtimeは、署名、Identity、File closure、Action shape、有限値、Bounds、Observation schema、Normalizer、Pending-order state、ServingStateSnapshotが一致しない場合、Policy実行前またはActivation前にFail closedします。
 
-`dataset_id`には、特徴量と利用可能時刻だけでなく、fee、spread、participation、lot/tick、borrow/funding、buy/sell制限、mark/index価格、配当・分割・上場廃止回収率、cash rate、volume単位、contract multiplierを含む全実行・会計配列を含めます。正式artifactはIDを保存時と読込時に再計算し、任意ID、symlink、未宣言ファイルを拒否します。
+## Rewardと評価
 
-## 決定論的Dataset artifact
+維持対象は **Reward schema v4** です。主目的は絶対対数資産成長で、Baseline-relative growthは補助目的です。DrawdownとBaseline劣後は、許容幅を超えて悪化した増分だけを段階的に罰します。
 
-正式APIは、staging用の `write_market_dataset_files`、排他的なatomic publish用の `publish_market_dataset_artifact`、検証付き読込用の `load_market_dataset_artifact` です。旧writerは1リリースだけ警告付き互換wrapperとして残ります。alpha/factor artifactのidentityはファイルパスではなく検証済み内容digestで決まります。
+Nested walk-forwardでは、Train、Checkpoint validation、Configuration selection、Sealed outer testを分離します。NormalizerはFold train capabilityだけでFitし、その後Freezeします。Outer testは選択完了後に一度だけ開き、Servingと同じ決定論的Mean ensembleを評価します。
 
-厳格なJSON設定から正式なCLI経路を実行できます。
+Production statusは、GPU検証、十分なOOS期間、Paired block-bootstrap、Fresh confirmation、Paper reconciliationなどの必須Gateが揃うまで`NO-GO`です。
 
-```json
-{
-  "source_root": "data/market",
-  "base_timeframe": "1h",
-  "features": [
-    {"name": "ret_1", "kind": "log_return", "lookback": 1}
-  ],
-  "instruments": [
-    {
-      "symbol": "BTCUSDT",
-      "listed_at": "2019-09-01T00:00:00Z",
-      "volume_unit": "quote_notional"
-    }
-  ]
-}
-```
+## セットアップと最初の学習
 
-```bash
-uv run trade-rl data build --config market-build.json --output output/dataset
-```
-
-出力先は未作成でなければなりません。完全な`manifest.json`と決定論的な`arrays.npz`を同じ親ディレクトリのstaging領域に書いて再読込検証した後、ディレクトリを1回だけrenameして公開します。既存artifactは上書きしません。manifestにはcanonicalなidentity payloadを保存し、loaderは記載されたID文字列を信用せず、payloadと配列から`dataset_id`を独立再計算します。
-
-## ObservationとServingの整合性
-
-学習環境とServingは同じ`ObservationBuilder`と`MarketInputResolver`を使用します。Servingは呼出側が渡したTrend・Alphaを信用せず、因果的なresolverで再計算します。候補bundle v4は`dataset_id`、action schema、observation schema digest、vector長、normalizer、market-input resolver digestを保持しますが、release IDは含めません。別の`ReleaseAttestation`がbundle、評価・Gate証拠、選択Policy、Git commit、依存関係、承認者を結合します。
-
-構造化入力はいずれかのidentityが一致しなければpolicy実行前にfail-closedで拒否します。Activation時には共有Observation/Normalizerを読み込み、複数のprobe観測を全ensemble memberへ通してshape・finite・boundsを検証してからだけlive stateを交換します。
-
-## セットアップ
+Python 3.12が必要です。
 
 ```bash
 uv sync --extra dev --extra train-sb3
+uv run trade-rl --version
 ```
 
-## 使用例
+最短手順は[START.md](START.md)を参照してください。
 
 ```bash
-uv run trade-rl --version
+uv run python examples/quickstart/create_demo_dataset.py \
+  --output var/quickstart/dataset
 
-uv run trade-rl data build \
-  --config market-build.json --output output/dataset
+uv run trade-rl train run \
+  --config examples/quickstart/training.json \
+  --dataset var/quickstart/dataset \
+  --output var/quickstart/artifacts \
+  --run-id quickstart-001
+```
 
-uv run trade-rl train config \
-  --timesteps 1024 --gamma 0.5 --seed 0 --seed 1
+## PostgreSQL artifact catalog
 
-uv run trade-rl walk-forward plan \
-  --bars 220 --train-bars 80 --checkpoint-bars 10 \
-  --selection-bars 10 --test-bars 20 --purge-bars 2 --max-folds 2
+```bash
+cp .env.example .env
+docker compose up -d postgres
+
+uv sync --extra postgres
+export TRADE_RL_DATABASE_URL=postgresql://trade_rl:trade_rl@localhost:5432/trade_rl
+uv run trade-rl catalog migrate
+uv run trade-rl catalog health
+```
+
+DB未設定時はFilesystemだけで動作します。Market dataset publish時にDBが利用可能なら、Dataset ID、Artifact digest、Canonical cache key、Location、Sizeなどを登録します。
+
+停止してVolumeを保持する場合:
+
+```bash
+docker compose down
+```
+
+Volumeも削除する場合だけ:
+
+```bash
+docker compose down -v
 ```
 
 ## Docker GPU完全リサーチ実行
-
-維持対象のコンテナはCUDAを必須とし、実行時データをDocker named volume
-`trade-rl-training-data`へ保存して、Binance multi-timeframeの完全な研究workflowを
-実行します。repository rootで次を実行します。
 
 ```bash
 docker compose -f compose.training.yaml build trainer
 docker compose -f compose.training.yaml run --rm trainer
 ```
 
-2番目のcommandは、CUDA preflight、学習、評価、またはresearch gateが失敗すると
-非ゼロで終了します。終了コード0は研究上の証拠であり、収益性を保証しません。
-production statusは`NO-GO`のままです。
+CUDA preflight、学習、評価、Research gateのいずれかが失敗すると非ゼロ終了します。成功はPipelineとResearch evidenceであり、利益を保証しません。Metadata modeの既定は`frozen_snapshot`で、Current official payloadをPoint-in-time履歴として偽装しません。最高Integrityの`historical_signed`は、期間を覆う署名済みMetadataが必要です。
 
-detached起動、status、log、volume確認、artifact抽出、fresh retry、cleanupの正確な
-commandは[Docker GPU完全学習の運用手順](docs/operations/docker-gpu-full-training.md)を
-参照してください。artifact抽出ではPowerShellの絶対host pathと、実行中のAlpine
-copy containerを使用します。CUDA preflightとsmoke toolは
-`examples/binance-multitimeframe/`配下にあります。
+運用手順は[Docker GPU完全学習](docs/operations/docker-gpu-full-training.md)を参照してください。
 
 ## 品質確認
 
 ```bash
 uv run ruff check .
 uv run ruff format --check .
-uv run mypy trade_rl
+uv run mypy .
 uv run lint-imports
 uv run pytest --cov=trade_rl --cov-branch
+npm test --prefix studio -- --run
+npm run typecheck --prefix studio
+npm run build --prefix studio
+npm run check:layout --prefix studio
 ```
 
-詳細は[アーキテクチャ](docs/ARCHITECTURE.md)と[研究結果の扱い](docs/RESEARCH_STATUS.md)を参照してください。
-
-## PostgreSQL artifact catalog
-
-再計算不要な研究artifactの検索・依存関係・cache identityは、Dockerで起動するPostgreSQLへ保存できます。NumPy配列、dataset本体、checkpoint、modelはPostgreSQLのBLOBにはせず、従来どおり不変filesystem artifactとして保持します。
-
-```bash
-cp .env.example .env
-docker compose up -d postgres
-docker compose ps
-
-uv sync --extra dev --extra postgres
-export TRADE_RL_DATABASE_URL=postgresql://trade_rl:trade_rl@localhost:5432/trade_rl
-uv run trade-rl catalog migrate
-uv run trade-rl catalog health
-```
-
-market datasetのpublish時に`TRADE_RL_DATABASE_URL`が設定されていれば、dataset ID、artifact digest、canonical cache key、保存場所、サイズが自動登録されます。DB未設定時は従来どおりfilesystemだけで動作します。
-
-停止してデータを保持する場合:
-
-```bash
-docker compose down
-```
-
-PostgreSQL volumeも削除する場合のみ、明示的に次を実行します。
-
-```bash
-docker compose down -v
-```
+詳細は[アーキテクチャ](docs/ARCHITECTURE.md)、[研究結果の扱い](docs/RESEARCH_STATUS.md)、[Binance Public Data Workflow](docs/BINANCE.md)、[2026-07-22アーキテクチャ監査](docs/verification/2026-07-22-documentation-and-architecture-audit.md)を参照してください。

--- a/README.md
+++ b/README.md
@@ -1,64 +1,81 @@
 # Trade RL
 
-Trade RL is a research-grade, baseline-anchored residual reinforcement-learning core for portfolio allocation. The maintained policy adjusts a deterministic causal baseline through a bounded, explicitly identified action specification while an independent shadow book supplies the comparison path.
+Trade RL is a research-grade, baseline-anchored residual reinforcement-learning core for portfolio allocation. The maintained policy can adjust a deterministic causal baseline through a bounded residual action specification or emit explicitly identified per-symbol target weights. An independent shadow book supplies the comparison path.
 
 > Capability status: **research-ready** and **attested paper-serving-ready**. Direct exchange order routing remains **NO-GO**. The repository does not claim profitability or authorize live capital deployment.
 
+## Current maintained system
+
+The current repository combines six distinct capabilities that must not be conflated:
+
+1. causal market-data and multi-timeframe feature artifacts;
+2. exploratory and selected-final reinforcement-learning workflows;
+3. nested walk-forward selection with persistent sealed-test access;
+4. conservative, stateful OHLCV order simulation with auditable order events;
+5. local research visualization through Trade RL Studio;
+6. attested, read-only paper-serving bundles.
+
+PostgreSQL is an optional metadata catalog for reusable artifact identities, provenance, dependencies, lifecycle state, and sealed-test reservations. Large arrays, datasets, checkpoints, models, and run evidence remain immutable filesystem artifacts; PostgreSQL is not the numerical source of truth.
+
+Normal environment transitions use persistent market, limit, or stop-market orders. Orders carry latency, time-in-force, remaining quantity, trigger state, replacement linkage, and deterministic evidence across decision boundaries. Fills use the processing bar's capacity under an explicit OHLC path assumption. Selected-final promotion requires conservative path mode, processing-bar capacity, partial-fill carry, complete order evidence, and the expected execution-policy digest. OHLCV simulation is not an order-book reconstruction or a guarantee of exchange-equivalent fills.
+
 ## Trade RL Studio
 
-ローカルGUIは`studio/`にあります。固定レイアウトのReact + Vite + TypeScript画面から、検証済みdataset、training config、exploratory training job、run artifact、run比較、Evidence chain、read-only paper serving状態を扱えます。Live Trainingでは、学習中の探索行動をチャート中心の市場リプレイとして表示し、ほぼライブ／バッファ再生、ローソク足／イベント圧縮、position変化、損益、reward、drawdownを同期して観察できます。
+The local GUI lives in `studio/`. Its fixed-layout React + Vite + TypeScript interface operates on validated datasets, training configs, exploratory training jobs, run artifacts, comparisons, evidence, and read-only paper-serving state. Live Training presents sampled exploration as a chart-first market replay with near-live or buffered playback, candle or event-compressed views, position/risk markers, PnL, reward, and drawdown.
 
 ```bash
 uv sync --extra studio --extra train-sb3
 uv run trade-rl studio start --project-root .
-# 別ターミナル
+# In another terminal
 npm ci --prefix studio
 npm run dev --prefix studio
 ```
 
-Studioも直接取引所注文を提供せず、production statusは`NO-GO`のままです。Live TrainingのBUY／SELL表示は学習中のweight変化を可視化したもので、実注文ではありません。詳細は[`studio/README.md`](studio/README.md)を参照してください。
+Studio does not submit exchange orders. BUY/SELL markers visualize changes in learned target exposure, not real orders. Training telemetry is diagnostic, seed-scoped, append-only, and excluded from selection, artifact identity, release approval, and execution. See [`studio/README.md`](studio/README.md).
 
 ## Start here
 
-For a copy-paste first training run, including deterministic demo-data generation, a maintained PPO configuration, artifact inspection, real-data replacement, GPU settings and troubleshooting, read [START.md](START.md). For the maintained public Binance ingestion and live-smoke path, read [Binance Public Data Workflow](docs/BINANCE.md).
+For a copy-paste first training run, including deterministic demo-data generation, a maintained PPO configuration, artifact inspection, real-data replacement, GPU settings, and troubleshooting, read [START.md](START.md). For the maintained public Binance ingestion and live-smoke path, read [Binance Public Data Workflow](docs/BINANCE.md).
 
 ## Action and environment v3
 
-The maintained environment now provides:
+The maintained environment provides:
 
-- a dynamic residual action contract with independent fast, slow and risk controls, optional alpha scale and optional causal factor residuals;
+- a dynamic residual action contract with independent fast, slow, and risk controls, optional alpha scale, and optional causal factor residuals;
+- an explicit direct `target_weight:<symbol>` mode whose symbol order is identity-bound;
 - no dead alpha action when alpha is disabled, with exact action names and an ActionSpec digest bound into training and serving artifacts;
-- time-series, cross-sectional, long-only, market-neutral and cash-or-trend deterministic baselines, including a nonzero one-symbol mode;
-- continuous 24/7 and irregular session-calendar datasets with feature-level availability, staleness and execution metadata;
-- next-open execution with fees, spread, impact, paired stochastic slippage, participation limits, minimum notional, lot/tick rounding, borrow, funding schedules, market/limit orders, latency, margin, corporate actions and delisting settlement;
-- hard risk limits that override soft turnover throttles during concentration, leverage or emergency drawdown violations;
-- economic terminal states for insolvency, minimum equity, execution-cost exhaustion, margin call and liquidation instead of training-process crashes;
-- cash, baseline, random, stressed, partial-fill and restored causal reset states, duration curricula and regime/stress episode sampling;
-- observation schema v3 with per-feature masks and staleness, factor loadings, requested and realized execution state, cash/net/gross/margin state, previous action and optional finite-horizon time;
+- time-series, cross-sectional, long-only, market-neutral, and cash-or-trend deterministic baselines, including a nonzero one-symbol mode;
+- continuous 24/7 and irregular session-calendar datasets with feature-level availability, staleness, and execution metadata;
+- next-open execution with fees, maker/taker costs, spread, impact, paired stochastic slippage, participation limits, minimum notional, lot/tick rounding, borrow, funding schedules, latency, margin, corporate actions, and delisting settlement;
+- persistent market, limit, and stop-market order state with partial-fill carry, cancel-and-replace, deterministic OHLC path assumptions, and shared processing-bar capacity;
+- hard risk limits that override soft turnover throttles during concentration, leverage, or emergency drawdown violations;
+- economic terminal states for insolvency, minimum equity, execution-cost exhaustion, margin call, liquidation, and drawdown stop instead of training-process crashes;
+- cash, baseline, random, stressed, partial-fill, and restored causal reset states, duration curricula, and regime/stress episode sampling;
+- observation schema v3 with per-feature masks and staleness, factor loadings, requested and realized execution state, pending-order state, cash/net/gross/margin state, previous action, and optional finite-horizon time;
 - fold-fitted, frozen, content-addressed observation normalization that preserves categorical masks exactly;
 - reward schema v4 prioritizing absolute log-wealth growth, then excess growth, with incremental drawdown and rolling baseline-underperformance progressive hinges;
-- PPO exploration/network controls plus sealed-comparison support for SAC, TD3 and TQC;
-- AUM capacity curves, action saturation/projection diagnostics and permutation-aware shared per-asset encoding.
+- PPO exploration/network controls plus sealed-comparison support for SAC, TD3, and TQC;
+- AUM capacity curves, action saturation/projection diagnostics, and permutation-aware shared per-asset encoding.
 
 ## Identity and serving
 
-Dataset identity v6 is recomputed from every observation, eligibility, execution and accounting field, including effective-dated tick/lot/minimum-notional rules, aggregated funding-event counts, fees, spread, participation, borrow/funding schedules, mark/index prices, corporate actions, cash rates, volume-unit semantics, contract multipliers and feature availability/age. Published dataset artifacts reject arbitrary identities, symlinks, root escapes and undeclared files.
+Dataset identity v6 is recomputed from every observation, eligibility, execution, and accounting field, including effective-dated tick/lot/minimum-notional rules, aggregated funding-event counts, fees, spread, participation, borrow/funding schedules, mark/index prices, corporate actions, cash rates, volume-unit semantics, contract multipliers, and feature availability/age. Published dataset artifacts reject arbitrary identities, symlinks, root escapes, and undeclared files.
 
-Environment identity includes the verified dataset, calendar, action specification, content-addressed fold-local alpha/factor artifacts, semantic normalizer, episode curriculum, trend, reward, portfolio risk, execution and AUM. Signal filesystem paths are diagnostics only and never change experiment identity.
+Environment identity includes the verified dataset, calendar, action specification, content-addressed fold-local alpha/factor artifacts, semantic normalizer, episode curriculum, trend, reward, portfolio risk, execution policy, AUM, and sequence-policy architecture. Signal filesystem paths are diagnostics only and never change experiment identity.
 
-Serving bundle v5 contains the complete selected-final evidence chain but no approval material. A detached Ed25519 `ReleaseAttestation` binds the immutable bundle digest to the training run, selection proposal and authorization, walk-forward and gate evidence, fresh confirmation, selected policy, source commit, dependency provenance, approver and expiry. Runtime and registry processes receive purpose-bound public keys only; private keys are accepted exclusively by explicit offline CLI commands. Exploratory runs, unsigned bundles, legacy release sidecars, wrong-purpose keys and incomplete evidence chains fail closed before activation. Structured prediction additionally requires a monotonic identity-bound account-state snapshot. Runtime inference rejects non-finite, incorrectly shaped or out-of-range actions rather than clipping them silently.
+Serving bundle v5 contains the complete selected-final evidence chain but no approval material. A detached Ed25519 `ReleaseAttestation` binds the immutable bundle digest to the training run, selection proposal and authorization, walk-forward and gate evidence, fresh confirmation, selected policy, source commit, dependency provenance, approver, and expiry. Runtime and registry processes receive purpose-bound public keys only; private keys are accepted exclusively by explicit offline CLI commands. Exploratory runs, unsigned bundles, legacy release sidecars, wrong-purpose keys, incomplete evidence chains, and incompatible execution evidence fail closed before activation.
 
-The framework-independent serving layer accepts a `PolicyLoader`. `trade_rl.integrations.StableBaselines3PolicyLoader` is the maintained concrete adapter for PPO, SAC, TD3 and TQC ensemble bundles. Stable-Baselines3 and PyTorch are installed only with the `train-sb3` extra.
+The framework-independent serving layer accepts a `PolicyLoader`. `trade_rl.integrations.StableBaselines3PolicyLoader` is the maintained concrete adapter for PPO, SAC, TD3, and TQC ensemble bundles. Stable-Baselines3 and PyTorch are installed only with the `train-sb3` extra.
 
-## Training artifacts
+## Training artifacts and evidence
 
-A market dataset artifact is a validated directory containing canonical `manifest.json` and deterministic `arrays.npz`. The maintained API is `write_market_dataset_files` for deterministic staging files, `publish_market_dataset_artifact` for exclusive atomic publication, and `load_market_dataset_artifact` for verified loading; older same-named writers remain warning-only compatibility wrappers for one release. Training and walk-forward runs are staged, validated and then atomically published under `runs/<run-id>`; incomplete runs are isolated under `failed/<run-id>` and never replace `latest.json`.
+A market dataset artifact is a validated directory containing canonical `manifest.json` and deterministic `arrays.npz`. The maintained API is `write_market_dataset_files` for deterministic staging files, `publish_market_dataset_artifact` for exclusive atomic publication, and `load_market_dataset_artifact` for verified loading. Training and walk-forward runs are staged, validated, and atomically published under `runs/<run-id>`; incomplete runs are isolated under `failed/<run-id>` and never replace `latest.json`.
 
-A published training run contains the source dataset identity, resolved training/environment configuration, ensemble manifest, one authoritative `policy.zip` per seed, content-addressed intermediate checkpoints selected only on checkpoint-validation data, a `policy-loader.json`, optional verified ONNX/TorchScript actors and a content-addressed `run.json`. `policy.zip` remains the authoritative recovery and retraining format. ONNX is an optional required export when requested; TorchScript is best-effort and records an explicit unsupported reason when conversion is unsafe.
+A published training run contains the source dataset identity, resolved training/environment configuration, ensemble manifest, one authoritative `policy.zip` per seed, content-addressed intermediate checkpoints selected only on checkpoint-validation data, a `policy-loader.json`, optional verified ONNX/TorchScript actors, execution evidence, and a content-addressed `run.json`. `policy.zip` remains the authoritative recovery and retraining format.
 
-Exploratory Stable-Baselines3 training also emits sampled, append-only `training_telemetry_v1` JSON Lines beneath each seed's `telemetry/` directory. Normal rollout transitions are sampled, while material position changes, risk events and episode termination are retained for Studio replay. Telemetry is diagnostic and does not participate in model selection, artifact identity, serving approval or order execution.
+Exploratory Stable-Baselines3 training emits sampled `training_telemetry_v1` JSON Lines beneath each seed's `telemetry/` directory. Normal rollout transitions are sampled, while material position changes, risk events, and episode termination are retained. Telemetry is diagnostic and does not participate in model selection, artifact identity, serving approval, or order execution.
 
-Nested walk-forward execution builds fold-local causal signals, fits only exogenous normalization statistics on each train capability, records one-shot sealed-test access, and evaluates the exact deterministic mean seed ensemble used by serving on the outer test range only after selection. Training, behavior cloning, checkpoint selection and sealed evaluation all use liquidation-at-close terminal accounting. Independent folds retain full execution evidence and are reported as a distribution; continuous return and drawdown are produced only with verified contiguous account-state handoff. An optional identity-bound post-selection execution-sensitivity pack replays the selected ensemble and baseline closed-loop under nominal, individual 2x, joint 2x and report-only joint 5x rule stresses without participating in selection.
+Nested walk-forward execution builds fold-local causal signals, fits normalization only on each train capability, records one-shot sealed-test access, and evaluates the exact deterministic mean seed ensemble used by serving on the outer test range only after selection. Independent folds retain complete execution evidence and are reported as a distribution; continuous return and drawdown require verified contiguous account-state handoff. An optional identity-bound execution-sensitivity pack replays the selected ensemble and baseline under declared rule stresses without participating in selection.
 
 ## Commands
 
@@ -94,6 +111,17 @@ uv run trade-rl walk-forward run \
   --run-id btc-eth-wf-001
 ```
 
+Start the optional PostgreSQL catalog:
+
+```bash
+cp .env.example .env
+docker compose up -d postgres
+uv sync --extra postgres
+export TRADE_RL_DATABASE_URL=postgresql://trade_rl:trade_rl@localhost:5432/trade_rl
+uv run trade-rl catalog migrate
+uv run trade-rl catalog health
+```
+
 Build a deterministic public Binance USDⓈ-M dataset:
 
 ```bash
@@ -107,9 +135,9 @@ uv run trade-rl data binance \
   --output artifacts/datasets/binance-btcusdt
 ```
 
-Spot and USDⓈ-M are supported linear products. COIN-M inverse futures fail closed because the current accounting model is linear and must not publish misleading inverse-contract PnL. See [docs/BINANCE.md](docs/BINANCE.md) for the fixed-range end-to-end smoke.
+Spot and USDⓈ-M are supported linear products. COIN-M inverse futures fail closed because the current accounting model is linear. See [docs/BINANCE.md](docs/BINANCE.md).
 
-Both execution commands print one machine-readable JSON result. Exploratory training cannot be packaged or released. A selected-final run requires an externally signed selection authorization before model construction, at least 30 days of Ed25519-signed post-training confirmation, deterministic bundle packaging, and a separate offline release approval. Fresh-confirmation metrics are recomputed from the immutable return series and must begin at the exact frozen boundary without extending into the future. Direct exchange connectivity is not implemented.
+Both execution commands print one machine-readable JSON result. Exploratory training cannot be packaged or released. A selected-final run requires an externally signed selection authorization before model construction, at least 30 days of Ed25519-signed post-training confirmation, deterministic bundle packaging, matching conservative execution evidence, and a separate offline release approval. Direct exchange connectivity is not implemented.
 
 ### Offline evidence and release commands
 
@@ -139,41 +167,37 @@ uv run trade-rl release approve \
   --expires-at 2026-09-18T03:00:00Z
 ```
 
-The resulting authorization, confirmation, and release files are immutable and remain external to the candidate bundle until verification.
+The authorization, confirmation, and release files are immutable and remain external to the candidate bundle until verification.
 
 ## Docker GPU full research run
 
-The maintained container requires CUDA, keeps runtime data in the
-`trade-rl-training-data` Docker volume, and runs the complete Binance
-multi-timeframe research workflow. Build and run it from the repository root:
+The maintained container requires CUDA, stores runtime data in the `trade-rl-training-data` Docker volume, and runs the complete Binance multi-timeframe research workflow:
 
 ```bash
 docker compose -f compose.training.yaml build trainer
 docker compose -f compose.training.yaml run --rm trainer
 ```
 
-The second command exits nonzero when CUDA preflight, training, evaluation, or
-the research gate fails. A successful process is research evidence only: it is
-not a profitability guarantee and production status remains `NO-GO`.
+The run exits nonzero when CUDA preflight, training, evaluation, or the research gate fails. A successful process is research evidence only; it is not a profitability guarantee and production status remains `NO-GO`.
 
-The Docker workflow defaults to `TRADE_RL_METADATA_MODE=frozen_snapshot`: one official current `exchangeInfo` payload is preserved byte-for-byte, identity-bound and disclosed as unauthenticated, non-point-in-time evidence. `historical_signed` is the highest-integrity opt-in and requires a v4 signed document plus a read-only Ed25519 public-key store; the trainer never receives signing secrets. `conservative_static` requires a versioned payload path. No mode silently projects current values backward as historical truth. Full research is phase-separated into `develop`, `train-selected`, and `finalize`; waiting for external selection approval or fresh confirmation is a successful persisted state, not an infrastructure failure.
+The Docker workflow defaults to `TRADE_RL_METADATA_MODE=frozen_snapshot`: one official current `exchangeInfo` payload is preserved byte-for-byte, identity-bound, and disclosed as unauthenticated, non-point-in-time evidence. `historical_signed` is the highest-integrity opt-in and requires a signed point-in-time document plus a read-only Ed25519 public-key store. `conservative_static` requires a versioned payload path. No mode silently projects current values backward as historical truth.
 
-See [Docker GPU full-training operations](docs/operations/docker-gpu-full-training.md)
-for exact detached start, status, logs, volume inspection, artifact extraction,
-fresh retry, and cleanup commands. Artifact extraction uses an absolute
-PowerShell host path and a running Alpine copy container. The CUDA preflight and
-smoke tools live under `examples/binance-multitimeframe/`.
+See [Docker GPU full-training operations](docs/operations/docker-gpu-full-training.md) for detached start, status, logs, volume inspection, artifact extraction, retry, and cleanup commands.
 
 ## Verification
 
 ```bash
 uv run ruff check .
 uv run ruff format --check .
-uv run mypy trade_rl
+uv run mypy .
 uv run lint-imports
 uv run pytest --cov=trade_rl --cov-branch
+npm test --prefix studio -- --run
+npm run typecheck --prefix studio
+npm run build --prefix studio
+npm run check:layout --prefix studio
 ```
 
 Install export verification dependencies with `uv sync --extra dev --extra train-sb3 --extra export`.
 
-See [Architecture](docs/ARCHITECTURE.md), [Research Status](docs/RESEARCH_STATUS.md), and [Binance Public Data Workflow](docs/BINANCE.md).
+See [Architecture](docs/ARCHITECTURE.md), [Research Status](docs/RESEARCH_STATUS.md), [Binance Public Data Workflow](docs/BINANCE.md), and the latest [documentation and architecture audit](docs/verification/2026-07-22-documentation-and-architecture-audit.md).

--- a/START.md
+++ b/START.md
@@ -1,23 +1,34 @@
 # Trade RL 学習クイックスタート
 
-このページは、リポジトリを取得した直後に、**データartifact生成 → PPO学習 → 成果物確認**までを最短で実行する手順です。
+このページは、リポジトリ取得直後に **データartifact生成 → PPO学習 → 成果物確認 → Studioで探索観察** までを実行する手順です。
 
-最初の例では決定論的なデモ相場を使います。デモデータは学習パイプラインの動作確認用であり、収益性の検証には使用できません。
+最初の例は決定論的なデモ相場を使います。デモデータと短時間学習はPipelineの動作確認用であり、収益性評価には使用できません。
 
 > Production status: **NO-GO**  
-> 学習やテストの成功は、本番資金での運用許可や利益を保証しません。
+> 学習、テスト、Studio表示、Paper Servingの成功は、本番資金での運用許可や利益を保証しません。
 
 ## 1. 環境を準備する
 
-Python 3.12以上が必要です。リポジトリのルートで実行してください。
+Pythonは`>=3.12,<3.13`です。リポジトリのルートで実行してください。
 
 ```bash
 python -m pip install uv
-uv sync --extra dev
+uv sync --extra dev --extra train-sb3
 uv run trade-rl --version
 ```
 
-GPUやONNX/TorchScript exportを初回から使わない場合、`--extra export`は不要です。
+`train run`はStable-Baselines3とPyTorchを使うため、`--extra train-sb3`が必要です。Studio、PostgreSQL、ONNXを使う場合だけ、対応するExtraを追加します。
+
+```bash
+# Studio
+uv sync --extra dev --extra train-sb3 --extra studio
+
+# PostgreSQL catalog
+uv sync --extra dev --extra train-sb3 --extra postgres
+
+# ONNX/TorchScript export検証
+uv sync --extra dev --extra train-sb3 --extra export
+```
 
 ## 2. デモ用の市場データを作る
 
@@ -26,7 +37,7 @@ uv run python examples/quickstart/create_demo_dataset.py \
   --output var/quickstart/dataset
 ```
 
-成功すると、次の2ファイルが作られます。
+生成物:
 
 ```text
 var/quickstart/dataset/
@@ -34,19 +45,19 @@ var/quickstart/dataset/
 └── arrays.npz
 ```
 
-`manifest.json`にはデータセット識別子、配列名、shape、dtype、SHA-256が保存されます。`arrays.npz`が変更・破損すると、学習前の検証で拒否されます。
+`manifest.json`はDataset identity、配列名、Shape、Dtype、Digestを保持します。`arrays.npz`やManifestが変更・破損すると、学習前に拒否されます。
 
-バー数を増やす場合は次のように指定します。
+バー数を増やす場合:
 
 ```bash
 uv run python examples/quickstart/create_demo_dataset.py \
-  --output var/quickstart/dataset \
+  --output var/quickstart/dataset-large \
   --bars 4096
 ```
 
-## 3. 学習を開始する
+Published datasetは不変です。同じ出力先を上書きせず、新しいDirectoryへ生成してください。
 
-最小設定は`examples/quickstart/training.json`にあります。
+## 3. 学習を開始する
 
 ```bash
 uv run trade-rl train run \
@@ -56,7 +67,7 @@ uv run trade-rl train run \
   --run-id quickstart-001
 ```
 
-この設定は、CPU、PPO、1 seed、512 timestepsの小規模な動作確認です。行動空間は次の3次元です。
+Quickstart設定はCPU、PPO、1 seed、512 timestepsの小規模Smokeです。初期設定のResidual actionは次の3次元です。
 
 ```text
 fast_tilt
@@ -64,9 +75,9 @@ slow_tilt
 risk_tilt
 ```
 
-alphaとfactorは初回設定では無効です。
+AlphaとFactorは無効です。通常のEnvironment遷移は、保守的なOHLC path、処理バーの出来高容量、Partial-fill carryを使う状態付き注文経路で実行されます。
 
-成功時、CLIは1行のJSONを出力します。
+成功時、CLIはMachine-readable JSONを1行出力します。概念例:
 
 ```json
 {
@@ -77,16 +88,14 @@ alphaとfactorは初回設定では無効です。
 }
 ```
 
-実際のJSONにはdataset、run、policyのdigestも含まれます。
-
 ## 4. 学習成果物を確認する
 
 ```bash
 cat var/quickstart/artifacts/latest.json
-find var/quickstart/artifacts/runs/quickstart-001 -maxdepth 4 -type f | sort
+find var/quickstart/artifacts/runs/quickstart-001 -maxdepth 6 -type f | sort
 ```
 
-主な成果物は次のとおりです。
+主な成果物:
 
 ```text
 var/quickstart/artifacts/
@@ -101,20 +110,43 @@ var/quickstart/artifacts/
         ├── policy-loader.json
         └── members/
             └── member-000/
-                └── policy.zip
+                ├── policy.zip
+                └── telemetry/
+                    └── training-telemetry.jsonl
 ```
 
-- `run.json`: 全成果物のpath、size、SHA-256を束ねた最終manifest
-- `training-config.json`: 実際に使用された学習設定
-- `dataset-reference.json`: 学習対象データの識別情報
-- `environment.json`: action、risk、reward、trend、execution設定
-- `ensemble.json`: seedごとのpolicyを束ねるmanifest
-- `policy.zip`: Stable-Baselines3の正式な保存形式
-- `latest.json`: 最後に正常publishされたrunへのポインタ
+- `run.json`: 宣言済み成果物のPath、Size、SHA-256を束ねる最終Manifest
+- `training-config.json`: 解決後の学習設定
+- `dataset-reference.json`: 学習対象DatasetのIdentity
+- `environment.json`: Action、Risk、Reward、Trend、Execution設定
+- `ensemble.json`: Seed memberを束ねるManifest
+- `policy.zip`: Stable-Baselines3の正式なRecovery/再学習形式
+- `training-telemetry.jsonl`: Studio用のSeed単位・Append-only診断Telemetry
+- `latest.json`: 最後に正常PublishされたRunへのPointer
 
-## 5. 再学習する
+Telemetryは探索観察用で、Checkpoint選択、Outer-test、Artifact identity、Serving承認、注文実行には使いません。
 
-runは不変artifactとして扱われるため、同じ`--run-id`を再利用しないでください。
+## 5. Studioで学習中の探索を見る
+
+Python APIを起動します。
+
+```bash
+uv sync --extra studio --extra train-sb3
+uv run trade-rl studio start --project-root .
+```
+
+別ターミナル:
+
+```bash
+npm ci --prefix studio
+npm run dev --prefix studio
+```
+
+`http://127.0.0.1:5173`を開き、`Live Training`からJobとSeedを選択します。`バッファ再生`は人間が追える速度、`ほぼライブ`は最新受信位置への追従です。BUY／SELL MarkerはWeight変化であり、取引所注文ではありません。
+
+## 6. 再学習する
+
+Runは不変Artifactです。同じ`--run-id`を再利用しないでください。
 
 ```bash
 uv run trade-rl train run \
@@ -124,13 +156,11 @@ uv run trade-rl train run \
   --run-id quickstart-002
 ```
 
-失敗したrunは`failed/<run-id>`へ隔離され、正常な`latest.json`は変更されません。
+失敗したRunは`failed/<run-id>`へ隔離され、正常な`latest.json`は変更されません。
 
-## 6. 本格的な学習設定へ変更する
+## 7. 本格的な学習設定へ変更する
 
-`examples/quickstart/training.json`の`training`を変更します。
-
-研究用の開始例:
+`examples/quickstart/training.json`の`training` Sectionを変更します。例:
 
 ```json
 {
@@ -144,27 +174,17 @@ uv run trade-rl train run \
 }
 ```
 
-設定全体を上の断片で置き換えるのではなく、既存JSONの`training`セクション内の値を変更してください。
+設定全体を上の断片で置換せず、既存JSON内の対応Sectionだけを変更してください。
 
-### GPUを使う
-
-まずCUDAが認識されるか確認します。
+GPU確認:
 
 ```bash
 uv run python -c "import torch; print(torch.cuda.is_available())"
 ```
 
-`True`の場合、設定の次の値を変更します。
+`True`なら`training.device`を`"cuda"`へ変更できます。GPU利用率ではなく、Throughput、再現性、Sealed OOS evidenceを評価してください。
 
-```json
-"device": "cuda"
-```
-
-CUDAが利用できない環境では`cpu`を使用してください。
-
-### 学習アルゴリズムを変える
-
-`algorithm`は次を選択できます。
+対応Algorithm:
 
 ```text
 ppo
@@ -173,11 +193,11 @@ td3
 tqc
 ```
 
-PPO以外では`buffer_size`、`learning_starts`、`train_freq`、`gradient_steps`も確認してください。アルゴリズム間の比較では、データ範囲、action contract、reward、cost、seedを固定します。
+Algorithm比較ではDataset range、Action contract、Reward、Cost、Execution policy、Seedを固定します。
 
-## 7. 実データへ置き換える
+## 8. 実データへ置き換える
 
-`trade-rl train run`が受け取るのは、次の形式の市場データartifactです。
+`train run`が受け取るのは検証済みMarket dataset artifactです。
 
 ```text
 my-dataset/
@@ -185,97 +205,66 @@ my-dataset/
 └── arrays.npz
 ```
 
-Python側では`MarketDataset`を作成し、正式writerで保存します。
+最低限の因果契約:
 
-```python
-from pathlib import Path
+- 行`t`のFeatureは行`t`のBar closeまでに利用可能な情報だけで作る
+- 行`t`の判断は最短でも`t + 1`のOpen以降で約定する
+- Future return、将来High/Low、後日改訂値をFeatureへ混入させない
+- 欠損値だけでなくAvailabilityとStalenessを保存する
+- Split、Dividend、Delisting、Funding、Borrow、Session gapを対象市場に合わせる
+- Tick、Lot、Minimum notional、Fee、Spread、ParticipationなどのExecution metadataをIdentityへ含める
+- Slow lookback、Sequence window、Reward pre-roll、Episode、評価Rangeより十分長い期間を用意する
 
-from trade_rl.data import MarketDataset, write_market_dataset_files
+公開Binance経路は[docs/BINANCE.md](docs/BINANCE.md)を参照してください。
 
-# dataset = MarketDataset(...)
-write_market_dataset_files(Path("artifacts/datasets/btc-usdt"), dataset)
-```
+## 9. PostgreSQL catalogを使う
 
-最低限、次の配列が必要です。
-
-- `timestamps`: bar close時刻。連続市場では完全に等間隔
-- `features`: `(bars, symbols, features)`
-- `global_features`: `(bars, global_features)`
-- `open`, `high`, `low`, `close`, `volume`, `funding_rate`: `(bars, symbols)`
-- `tradable`: `(bars, symbols)`
-- `feature_available`: `features`と同じshape
-
-重要な因果契約:
-
-- 行`t`の特徴量は行`t`のbar close時点までに利用可能な情報だけで作る
-- 行`t`の意思決定は最短でも行`t + 1`のopenで約定する
-- future return、将来のhigh/low、後日改訂値を特徴量へ混入させない
-- 欠損を0に置換するだけでなく、availabilityとstalenessを保存する
-- split、dividend、delisting、funding、borrow、session gapを対象市場に合わせる
-- データ期間はslow lookback、reward preroll、episode期間、評価範囲より十分長くする
-
-実データartifactを作った後は、`--dataset`だけを差し替えます。
+PostgreSQLは任意です。DatasetやModel本体をDBへ移さず、Metadataと再利用Identityを登録します。
 
 ```bash
-uv run trade-rl train run \
-  --config configs/btc-usdt-ppo.json \
-  --dataset artifacts/datasets/btc-usdt \
-  --output artifacts/research \
-  --run-id btc-usdt-ppo-001
+cp .env.example .env
+docker compose up -d postgres
+uv sync --extra postgres
+export TRADE_RL_DATABASE_URL=postgresql://trade_rl:trade_rl@localhost:5432/trade_rl
+uv run trade-rl catalog migrate
+uv run trade-rl catalog health
 ```
 
-## 8. alphaやfactorを使う
+DB未設定時はFilesystemだけで動作します。
 
-初回設定では無効です。利用する場合は、先にcontent-addressed signal artifactを用意し、設定を一致させる必要があります。
+## 10. よくあるエラー
 
-alphaの例:
+### `No module named stable_baselines3`
 
-```json
-"alpha_artifact": "artifacts/signals/my-alpha",
-"action": {
-  "alpha_enabled": true,
-  "n_factors": 0,
-  "validation_mode": "clip"
-}
+```bash
+uv sync --extra dev --extra train-sb3
 ```
-
-factorの例では、`factor_artifact`と`action.n_factors`の両方を一致させます。不一致、symbol順序違い、dataset ID違い、digest不一致は学習前に拒否されます。
-
-## 9. よくあるエラー
 
 ### `run already exists`
 
-`--run-id`を新しい値へ変更してください。publish済みrunは上書きしません。
+新しい`--run-id`を指定してください。Published runは上書きしません。
 
 ### `dataset digest mismatch`
 
-`arrays.npz`または`manifest.json`が変更されています。元データからartifactを再生成してください。
+`arrays.npz`または`manifest.json`が変更されています。元データからArtifactを再生成してください。
 
-### episodeを開始できない
+### Episodeを開始できない
 
-データ期間が短い可能性があります。バー数を増やすか、次を短くしてください。
-
-- `environment.episode_hours`
-- `trend.fast_hours`
-- `trend.base_hours`
-- `trend.slow_hours`
-- rewardのbaseline window
+Dataset期間が短い可能性があります。Bar数を増やすか、Episode、Trend lookback、Sequence window、Reward baseline windowを見直してください。
 
 ### CUDA関連で失敗する
 
-`training.device`を`cpu`へ戻し、まずCPUで学習パイプラインを確認してください。
+`training.device`を`cpu`へ戻し、まずCPU SmokeでPipelineを確認してください。
 
 ### 学習途中で失敗した
 
 ```bash
-find var/quickstart/artifacts/failed -maxdepth 3 -type f | sort
+find var/quickstart/artifacts/failed -maxdepth 5 -type f | sort
 ```
 
-失敗したstaging runは`failed/<run-id>`へ隔離されます。正常publish済みrunと`latest.json`は保持されます。
+## 11. 次の段階
 
-## 10. 次の段階
-
-単一runの動作確認後は、nested walk-forwardを使用します。
+単一Runの動作確認後はNested walk-forwardを使用します。
 
 ```bash
 uv run trade-rl walk-forward run \
@@ -285,4 +274,4 @@ uv run trade-rl walk-forward run \
   --run-id btc-usdt-wf-001
 ```
 
-最終判断には、手数料・spread・impact・funding・borrowを含むsealed out-of-sample評価と、別期間・複数seed・複数AUMでの再現性確認が必要です。
+最終判断には、複数Seed、複数Fold、複数AUM、Fee/Spread/Impact/Funding/Borrow、Conservative stateful execution、未使用Outer test、Fresh confirmation、Paper reconciliationが必要です。詳細は[Architecture](docs/ARCHITECTURE.md)、[Research Status](docs/RESEARCH_STATUS.md)、[最新監査](docs/verification/2026-07-22-documentation-and-architecture-audit.md)を参照してください。

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,106 +2,161 @@
 
 ## Status
 
-`trade_rl` is a research-grade baseline-anchored residual-RL core with attested local/paper-serving contracts. Direct exchange trading remains unavailable. Architecture quality, empirical profitability and operational authorization are separate gates.
+`trade_rl` is a research-grade portfolio-RL core with attested local/paper-serving contracts. Direct exchange trading remains unavailable. Architecture integrity, empirical profitability, and operational authorization are separate gates; passing one does not imply the others.
+
+The current maintained system uses causal market artifacts, baseline-anchored or direct-target policies, persistent stateful order simulation, nested walk-forward selection, immutable evidence, an optional PostgreSQL metadata catalog, a local read-only research console, and fail-closed serving activation.
 
 ## Responsibility map
 
 ```text
 trade_rl/
-  domain/        immutable dataset, policy, selection and release identities
-  artifacts/     canonical serialization, hashing and atomic publication
-  data/          market calendar, feature and execution-data contracts
+  domain/        immutable dataset, policy, selection, and release identities
+  artifacts/     canonical serialization, hashing, file closure, atomic publication
+  release/       external attestation verification and offline approval contracts
+  evaluation/    metrics, paired inference, folds, gates, and AUM capacity
+  catalog/       framework-independent artifact metadata contracts and PostgreSQL adapter
+  data/          market calendar, causal features, execution-data contracts, datasets
   strategies/    deterministic causal baselines
-  risk/          pure hard/soft pre-trade constraints
-  simulation/    execution, costs, carry, margin and accounting
-  evaluation/    metrics, paired tests, folds, gates and AUM capacity
-  learning/      framework-light teacher, behavior-cloning and supervised-data contracts
-  rl/            actions, observations, normalization, rewards, environment and framework-neutral training protocols
-  release/       verification contracts for non-circular external release attestations
-  serving/       framework-independent candidate bundles, registry and fail-closed runtime
-  integrations/  Stable-Baselines3 training/serving and other framework adapters
-  workflows/     typed training, walk-forward and publication orchestration
+  simulation/    orders, bar paths, liquidity, execution, carry, margin, accounting
+  risk/          pure hard/soft pre-trade and portfolio constraints
+  rl/            actions, observations, normalization, rewards, environment, protocols
+  learning/      framework-light teachers, behavior cloning, supervised-data contracts
+  serving/       candidate bundles, registry, and fail-closed runtime
+  integrations/  Stable-Baselines3 and external-system adapters
+  workflows/     typed training, walk-forward, sensitivity, and publication orchestration
+  studio/        local research read models, job control, and typed API surfaces
+  telemetry/     append-only diagnostic training-event contracts
   cli/           single authoritative configuration and execution entry point
 ```
 
-The enforced dependency order is `cli -> workflows -> integrations -> serving -> learning -> rl -> risk -> simulation -> strategies -> data -> evaluation -> release -> artifacts -> domain`. Integrations own external model-framework adapters. Release verification cannot import serving, integrations or workflows. Learning contracts cannot depend on Stable-Baselines3 or sb3-contrib. Core training and serving modules do not import Stable-Baselines3 directly.
+The enforced Import Linter layer order is exactly:
+
+```text
+cli
+  -> studio
+  -> workflows
+  -> integrations
+  -> serving
+  -> learning
+  -> rl
+  -> risk
+  -> simulation
+  -> strategies
+  -> data
+  -> catalog
+  -> evaluation
+  -> release
+  -> artifacts
+  -> domain
+```
+
+`domain` is standard-library only. `release` cannot depend on evaluation, data, simulation, RL, serving, integrations, workflows, Studio, or model frameworks. `learning` and the core training protocol cannot depend on Stable-Baselines3, sb3-contrib, or Torch. `workflows` may use integration interfaces but may not directly import model frameworks. Serving cannot import training workflows or Stable-Baselines3. Runtime, training, and Studio paths cannot import offline signing modules. Catalog contracts cannot depend on NumPy, model frameworks, psycopg, data, RL, learning, integrations, workflows, or CLI.
+
+`trade_rl.telemetry` was added after the current layer stack and is not yet explicitly placed in `.importlinter`. Its current implementation is standard-library only and is consumed by integrations and Studio, but this is a convention rather than an enforced dependency boundary. The latest architecture audit records this as a remediation item.
 
 ## Privileged GPU boundary
 
-Self-hosted GPU runners never execute pull-request-controlled workflows. The maintained full-run workflow is restricted to the protected `main` ref, the repository owner and the `gpu-full-training` GitHub Environment. External Actions in that privileged workflow are pinned to immutable commit SHAs. Detached full runs are labeled and supervised through explicit `start`, `status` and `stop` operations; terminal exit status and retained logs are collected without deleting the failed container before evidence is captured.
+Self-hosted GPU runners never execute pull-request-controlled workflows. The maintained full-run workflow is restricted to the protected `main` ref, the repository owner, and the `gpu-full-training` GitHub Environment. External Actions in that privileged workflow are pinned to immutable commit SHAs. Detached full runs expose explicit start, status, and stop operations; failed-container logs and exit status are retained before cleanup.
 
-## Action contract
+## Action and baseline contracts
 
-`portfolio_action_v3` supports either the maintained baseline-residual controls or direct per-symbol `target_weight:<symbol>` controls. The environment derives the exact dimension from `ActionSpec` and binds symbol order into its identity. In target-weight mode, zero action means flat; in residual mode, zero action remains exact baseline identity. Training may clip with diagnostics; evaluation and serving can reject out-of-range actions fail closed.
+`portfolio_action_v3` supports the maintained baseline-residual controls and direct per-symbol `target_weight:<symbol>` controls. The environment derives the exact dimension from `ActionSpec` and binds symbol order into identity. In target-weight mode, zero action means flat. In residual mode, zero action is exact baseline identity. Training may clip with diagnostics; evaluation and serving can reject out-of-range actions fail closed.
 
-## Baseline contract
+Trend baselines distinguish time-series direction from cross-sectional ranking. `auto` uses time-series trend for a one-symbol universe and cross-sectional trend for multiple symbols. Directional modes preserve signal confidence and cash rather than always normalizing to full gross exposure.
 
-Trend baselines distinguish time-series direction from cross-sectional ranking. `auto` uses time-series trend for a one-symbol universe and cross-sectional trend for multiple symbols. Directional modes preserve signal confidence and cash allocation rather than always normalizing to full gross exposure.
+## Market-data and metadata contracts
 
-## Market and execution contract
+Bar timestamps are close times and decisions first execute after the decision close. Continuous datasets require regular cadence; session datasets use wall-clock lookup across overnight, weekend, and holiday gaps. Feature values, eligibility, availability, and staleness are point-in-time contracts. Executor-only realized tradability is not exposed to the policy before the transition.
 
-Bar timestamps are close times and decisions first execute at the next open. Continuous datasets require regular cadence; session datasets use wall-clock lookup helpers across overnight, weekend and holiday gaps. Execution uses only information available at the decision and execution timestamps. Hybrid and shadow books share one episode RNG stream while different episodes receive distinct deterministic seeds.
+Dataset identity v6 is recomputed from every observation, execution, and accounting scalar/array, including effective-dated instrument filters, funding-event counts, quantity semantics, maker/taker fees, spread, participation, borrow/funding schedules, mark/index prices, corporate actions, cash rates, availability/age, and contract multipliers. The maintained artifact consists of canonical `manifest.json` and deterministic `arrays.npz`. Loading checks exact file closure, rejects symlinks/root escapes, recomputes identity, and validates array allow-list, shape, dtype, ordering, and `MarketDataset` invariants.
 
-The execution layer models partial fills, fees, spread, impact, random and tail slippage, per-bar constraints, minimum notional, lot/tick rules, borrow, carry, latency, market/limit orders, margin, dividends, splits and delisting recovery. Economic failures become structured terminal transitions; malformed market data remains an exception.
+Binance `historical_signed` metadata carries market, ordered symbols, coverage range, issue time, source URI, policy version, payload digest, and a purpose-bound signature. The resolver requires exact market, symbol-order, and research-interval coverage. `frozen_snapshot` and `conservative_static` are explicitly non-point-in-time and retain those limitations in dataset identity and reports. They cannot enter final promotion as authenticated historical metadata.
 
-Binance `historical_signed` execution rules carry an authenticated semantic scope: market, ordered symbols, coverage start/end, issue time, source URI, policy version and payload digest. The maintained resolver requires an exact USD-M, symbol-order and research-interval match. Tick size, lot size and minimum notional are strictly positive for every signed metadata entry and effective rule. Frozen and conservative-static modes remain explicitly non-point-in-time and retain their limitations in dataset identity.
+## Stateful execution contract
+
+Normal RL environment transitions use the stateful execution API:
+
+```text
+target proposal
+  -> risk projection
+  -> target-to-order reconciliation
+  -> persistent OrderBookState
+  -> deterministic admission and OHLC path interpretation
+  -> shared processing-bar liquidity allocation
+  -> BookState accounting
+  -> OrderEvent and capacity evidence
+```
+
+Order intents bind dataset ID, target identity, execution-policy digest, symbol, fixed decision-time quantity, type, time in force, limit/stop price, submission/eligibility/expiry indices, reference price, decision equity, and replacement linkage. Pending orders preserve remaining quantity, cumulative fills, trigger state, terminal reason, last processed index, and a monotonic evidence version.
+
+The simulator supports market, limit, and stop-market instructions; latency; IOC, day, and GTC semantics; cancel-and-replace; partial-fill carry; deterministic rejection; gap handling; and persistent stop triggers. One explicit optimistic, neutral, or conservative OHLC path is selected per symbol and bar. Capacity uses the processing bar's volume, a configured trigger-position fraction, and one deterministic symbol-level priority pool. `BookState` remains the accounting authority for cash, quantities, fees, funding, borrow, dividends, cash interest, splits, delisting settlement, margin, and economic termination.
+
+Final promotion requires conservative primary path mode, processing-bar volume capacity, partial-fill carry, complete order-event evidence, conservative trigger-volume fractions, and an execution-policy digest matching the experiment plan. Optimistic and neutral modes are sensitivity tools only. OHLCV cannot recover queue position, hidden liquidity, auctions, or L2 depth.
+
+The compatibility `MarketExecutor.execute_interval` path remains in the codebase for older callers and selected utilities. It currently retains its own target-filling implementation rather than being a thin adapter over the stateful engine. The maintained RL step path is stateful, but any compatibility caller must not be described as producing complete stateful order evidence. The latest audit identifies remaining maintained call sites that require convergence.
 
 ## Risk ordering
 
-Turnover is a soft operational constraint. Concentration, gross leverage and emergency drawdown limits are hard constraints applied afterward and validated again. A hard deleveraging requirement may override turnover, and every projection exposes reasons and L1 distance.
+Turnover is a soft operational constraint. Concentration, gross leverage, portfolio risk, and emergency drawdown limits are hard constraints applied afterward and validated again. A hard deleveraging requirement may override turnover, and each projection exposes reasons and L1 distance.
 
 ## Observation and normalization
 
-Observation schema v3 carries feature values, feature-level availability/staleness/reasons, active/tradable state, all baseline and factor inputs, current and requested portfolios, fill/cost/capacity state, cash/net/gross/margin state and previous action. Remaining time is included only for an explicitly finite-horizon MDP. Normalization statistics are fitted on an explicit train range, frozen elsewhere, content-addressed, and preserve mask/categorical coordinates exactly.
+Observation schema v3 carries feature values, feature-level availability/staleness/reasons, active/tradable state, baseline and factor inputs, current/requested portfolios, fill/cost/capacity state, persistent pending-order state, cash/net/gross/margin state, and previous action. Remaining time appears only for an explicitly finite-horizon MDP. Normalization statistics are fitted on an explicit train capability, frozen elsewhere, content-addressed, and preserve mask/categorical coordinates exactly.
 
-The maintained multi-timeframe policy uses a structured Dict observation rather than flattening history into one vector. Completed native sequences are 15m=96 bars, 1h=168, 4h=120 and 1d=60. Each clock has ordered values, availability and staleness tensors. Timeframe-specific left-padded residual TCNs use per-timestep LayerNorm and dilation schedules whose receptive fields cover the complete declared window, so neither convolution nor normalization can read future timesteps and the oldest declared observation can still affect the final latent. A timestep mask is true when any channel is available; unavailable channels are zeroed and remain individually masked. Train-range-only robust median/IQR statistics normalize sequence values per native feature while availability and staleness remain separate inputs.
+The maintained multi-timeframe policy uses a structured Dict observation. Completed native sequences are 15m=96 bars, 1h=168, 4h=120, and 1d=60. Each clock has ordered values, availability, and staleness tensors. Timeframe-specific left-padded residual TCNs use per-timestep LayerNorm and dilation schedules whose receptive fields cover the declared window without reading future timesteps.
 
-Cross-asset attention preserves one contextual token per ordered symbol. Learned symbol embeddings bind token identity, the actor receives ordered per-symbol tokens so each target weight remains attached to its symbol, and only the critic/global context uses pooled portfolio representations. PPO and behavior cloning share this exact feature extractor.
+Cross-asset attention preserves one contextual token per ordered symbol. Learned symbol embeddings bind token identity; the actor receives ordered per-symbol tokens so each target weight remains attached to its symbol. Only critic/global context uses pooled portfolio representations. PPO and behavior cloning share this feature extractor.
 
-The maintained dataset has 226 ordered point-in-time channels across the four clocks, including explicit BTC-relative return, rolling BTC correlation/beta, cross-sectional momentum rank and dispersion. Derived features preserve native source age through as-of alignment. Dataset and policy identities bind symbols, feature order, window lengths, availability rules and architecture settings, and reject mismatched artifacts.
+The maintained dataset has 226 ordered point-in-time channels across four clocks, including BTC-relative return, rolling BTC correlation/beta, cross-sectional momentum rank, and dispersion. Derived features retain native source age through as-of alignment. Dataset and policy identities bind symbols, feature order, windows, availability rules, and architecture settings.
+
+Training–Serving observation parity includes symbol and feature order, availability, staleness, hybrid/shadow books, pending target, previous action, pending-order remaining/type/status/age/eligibility/trigger/expiry state, raw observation, normalized observation, each member action, and deterministic ensemble action.
 
 ## Reward contract
 
-Reward schema v4 prioritizes absolute log-wealth growth. Baseline-relative growth is secondary. Drawdown is penalized only on new excess drawdown beyond a dead zone. Baseline underperformance uses a fixed real-time rolling window, tolerance and progressive hinge. Terminal penalties are continuous in equity shortfall rather than fixed jackpots. Every component is returned for audit.
+Reward schema v4 prioritizes absolute log-wealth growth. Baseline-relative growth is secondary. Drawdown is penalized only on newly worsening excess drawdown beyond a dead zone. Baseline underperformance uses a fixed real-time rolling window, tolerance, and progressive hinge. Terminal penalties are continuous in equity shortfall rather than fixed jackpots. Every component is returned for audit.
 
-## Dataset and run artifacts
+Maintained finite-horizon training, behavior cloning, checkpoint validation, configuration selection, and sealed evaluation use liquidation-at-close terminal accounting. The baseline reward pre-roll is intended to represent the same economics as the main environment, but it currently calls the compatibility `execute_interval` path. Because normal transitions use persistent orders, latency and partial residuals can diverge between pre-roll and episode execution. This is a confirmed architecture/correctness gap pending migration to the stateful reconciliation path.
 
-Dataset identity v6 is recomputed from every observation, execution and accounting scalar/array, including effective-dated instrument filters, funding-event counts, quantity semantics and corporate actions. The maintained dataset artifact consists of canonical `manifest.json` and deterministic `arrays.npz`. `write_market_dataset_files`, `publish_market_dataset_artifact`, and `load_market_dataset_artifact` are the authoritative staging, publication, and loading APIs. Loading verifies exact file closure, rejects symlinks/root escapes, recomputes dataset identity, and checks array allow-list, shape, dtype, ordering and `MarketDataset` invariants. `MarketDatasetView` carries an immutable half-open absolute range and rejects subviews outside its parent range. The former duplicate `write_market_dataset_artifact` compatibility export is not part of the maintained API.
+## Artifact store and PostgreSQL catalog
 
-Training outputs are first written to `ArtifactStore/.staging/<run-id>`. `run.json` binds every declared file by relative path, byte size and SHA-256 together with dataset, environment, training-config and ensemble identities. Only a fully validated run is atomically moved to `runs/<run-id>` and made current through `latest.json`; partial failures are moved to `failed/<run-id>`.
+Training output is first written to `ArtifactStore/.staging/<run-id>`. `run.json` binds each declared file by relative path, byte size, and SHA-256 together with dataset, environment, training-config, ensemble, execution, and evidence identities. Only a fully validated run moves atomically to `runs/<run-id>` and updates `latest.json`; partial failures move to `failed/<run-id>`.
+
+The optional PostgreSQL catalog stores reusable artifact metadata, canonical cache keys, dependencies, lifecycle status, and persistent sealed-test reservations. Catalog registration is idempotent for an identical artifact and fails on digest/cache-key conflicts. The filesystem artifact remains authoritative: the catalog stores its verified location and identity, not mutable numerical payloads.
+
+A PostgreSQL uniqueness boundary prevents separate workflow processes from opening the same `(experiment_plan_digest, dataset_id, fold_index)` sealed test twice. When PostgreSQL is not configured, workflows retain filesystem behavior, but cross-process sealed-test uniqueness is not provided by an in-memory object alone.
 
 ## Training and nested walk-forward
 
-`trade-rl train run` loads a validated dataset artifact, resolves content-addressed alpha/factor artifacts independently of filesystem location, requires a complete causal reward pre-roll, fits flat and sequence normalizers only on the declared training capability, constructs the real residual market environment, trains one Stable-Baselines3 checkpoint per seed, writes canonical configuration and ensemble manifests, validates the complete run and publishes atomically. Flat and structured policies both emit their matching SB3 loader contract; structured bundles include the native dataset/sequence adapter and never masquerade as flat policies. Maintained training, behavior cloning, checkpoint validation, configuration selection and outer testing share liquidation-at-close terminal accounting.
+`trade-rl train run` loads a validated dataset, resolves content-addressed alpha/factor artifacts independently of path, requires complete causal reward pre-roll, fits flat and sequence normalizers only on the declared training capability, constructs the real environment, trains one policy per seed, writes canonical configuration and ensemble manifests, validates the run, and publishes atomically.
 
-Direct training without selection evidence is labeled `research_exploratory`. A `research_selected_final` run requires an immutable `SelectionAuthorization` before normalizer fitting or model construction. That authorization binds the walk-forward run digest, gate-evidence digest, dataset ID, selected configuration, canonical candidate-config digest and fixed seed set. The authorization is copied into the staged run and therefore included in `run.json` file closure.
+Direct training without selection evidence is `research_exploratory`. A `research_selected_final` run requires an immutable `SelectionAuthorization` before normalizer fitting or model construction. It binds the walk-forward run digest, gate-evidence digest, dataset ID, selected configuration, canonical candidate-config digest, and fixed seed set.
 
-`trade-rl walk-forward run` uses the existing nested fold contract with concrete market adapters. Each fold receives disjoint train, checkpoint-validation, configuration-selection and sealed-test ranges. Training views include the maximum of trend and native-sequence history plus any reward/baseline pre-roll, so the nominal train start is never silently discarded. Flat and sequence normalizers fit only the chronological fold-train capability and are frozen and identity-bound thereafter. Masks, actions, portfolio/risk and bounded execution coordinates are pass-through or fixed-scaled.
+`trade-rl walk-forward run` provides disjoint train, checkpoint-validation, configuration-selection, and sealed-test ranges. Fold train views include required trend, reward, and sequence history without treating pre-range history as fit data. Normalizers fit only the chronological fold-train capability and remain frozen thereafter.
 
-Checkpoint validation selects the deterministic winner for each predeclared seed. Configuration selection retains per-seed evidence for median score, worst-seed uplift, seed dispersion, success fraction, daily turnover, cost fraction and drawdown, then separately evaluates the exact deterministic mean ensemble across those fixed seed members. That same ensemble rule is used for the sealed fold evaluation and final serving. The maintained hardened research runner executes walk-forward before final training, freezes the agreed recipe and complete seed set, writes `SelectionAuthorization`, and blocks final RL training when folds disagree, select baseline, or authorization identity differs. Sealed outer-test returns never flow back into training or selection.
+Checkpoint validation selects a deterministic winner for each predeclared seed. Configuration selection retains per-seed score, worst-seed uplift, dispersion, success fraction, turnover, cost fraction, and drawdown evidence, then evaluates the exact deterministic mean ensemble. The same ensemble rule is used for sealed evaluation and serving. Sealed returns never flow back into training or selection.
 
-Fold results retain complete execution evidence. Independent folds expose fold-distribution summaries rather than synthetic continuous-account metrics; continuous results require verified state handoff. Final `policy.zip` files are authoritative model artifacts. Training emits bounded, atomic intermediate policy checkpoints during each SB3 learning call. The checkpoint selector compares intermediate and final member checkpoints only on the checkpoint-validation range and records the selected content digest before sealed outer-test evaluation.
+Independent folds expose distribution summaries rather than synthetic continuous-account metrics. Continuous results require contiguous ranges and verified account-state handoff. Final `policy.zip` files remain authoritative model artifacts.
 
-## Export contract
+## Training telemetry and Studio boundary
 
-ONNX and TorchScript export a deterministic actor wrapper rather than the optimizer or replay state. Each export is compared with Stable-Baselines3 deterministic predictions on a fixed finite observation corpus. Shape, finite values and maximum absolute error must satisfy the configured tolerance. Requested ONNX failure rejects the run. TorchScript is best-effort and records an explicit `unsupported` result when conversion cannot be proven safe.
+Exploratory SB3 training emits seed-scoped, append-only `training_telemetry_v1` JSONL. Normal intervals are sampled; position, risk, emergency, and terminal events are retained. Telemetry is best-effort diagnostics: a telemetry write failure may disable visualization but must not stop learning.
 
-## Serving and release
+Studio reads telemetry only beneath a known job's declared artifact root and run namespaces. It rejects project-root escapes, symlinks, unknown jobs, and records whose seed differs from the selected stream. Studio never ranks checkpoints from replay data, retrains a policy, activates a bundle, or submits an exchange order.
 
-Candidate bundle v5 binds action size/names/spec digest, observation schema/size, environment, normalizer, alpha/factor artifacts, the selected-final training run, selection proposal and authorization, walk-forward/gate evidence, and fresh confirmation. Approval remains detached from bundle identity. An offline Ed25519 signer creates a purpose-bound `ReleaseAttestation`; registry and runtime load public verification keys only and reject exploratory runs, legacy sidecars, wrong-purpose keys, expired signatures, or incomplete chains.
+Telemetry currently uses whole-file scans for status and paged reads. Repeated polling therefore scales with total file size rather than only newly appended bytes. It also requires stricter boolean parsing and duplicate-seed stream rejection. These are audit findings, not claims that telemetry participates in the research evidence chain.
 
-Private signing material is accepted only by `trade_rl.release.offline_keys` and offline approval modules/CLI handlers. Trainer, Docker, CI verification, registry, and runtime packages cannot import those modules under the architecture contracts. Source-tree, lockfile, image, generation, heartbeat, and external expectation identities are independently checked before and during privileged GPU execution.
+## Export, serving, and release
 
-`StableBaselines3PolicyLoader` lives in the integration layer. It verifies the bundle-declared `policy-loader.json`, loads every declared PPO, SAC, TD3 or TQC member and runs deterministic probe observations before the runtime swaps active state. Every member must return a finite dynamic action vector inside `[-1, 1]`; the ensemble is averaged only when all members succeed. The runtime loads the same normalizer contract used in training.
+ONNX and TorchScript export a deterministic actor wrapper rather than optimizer state. Each export is compared with Stable-Baselines3 deterministic predictions on a fixed finite corpus. Requested ONNX failure rejects the run. TorchScript is best-effort and records an explicit unsupported reason when conversion cannot be proven safe.
 
-Direct exchange connectivity, order routing, broker reconciliation and operational secrets/alerting are deliberately outside this repository's current capability boundary.
+Candidate bundle v5 binds action size/names/spec digest, observation schema/size, environment, normalizers, alpha/factor artifacts, selected-final run, selection proposal and authorization, walk-forward/gate evidence, fresh confirmation, execution evidence, and policy-loader contract. Approval remains detached from bundle identity. An offline Ed25519 signer creates a purpose-bound `ReleaseAttestation`; registry and runtime load public verification keys only.
 
-## Final causal sequence hardening
+`StableBaselines3PolicyLoader` lives in the integration layer. It verifies `policy-loader.json`, loads every PPO, SAC, TD3, or TQC member, and executes deterministic probe observations before runtime activation. Every member must return a finite dynamic action vector inside `[-1, 1]`; the ensemble is averaged only when all members succeed. Structured prediction requires a monotonic identity-bound `ServingStateSnapshot`.
 
-The maintained policy uses a shared per-asset actor over contextual asset tokens. The critic remains portfolio-level. PPO uses an index-backed rollout: persistent rollout state contains decision indices and current state, while overlapping native sequences are reconstructed from the immutable causal dataset only for sampled minibatches.
+Direct exchange websocket ingestion, order submit/cancel/replace, broker reconciliation, venue kill switches, production secrets, and operational alerting remain outside this repository.
 
-The BC teacher is an approximate portfolio teacher rather than a globally optimal oracle. It uses a bounded beam and executor-compatible minimum-notional and partial-fill semantics. Model artifacts record the approximation contract.
+## Production gate
 
-Structured sequence serving is native SB3 serving. The runtime restores the flat and sequence normalizers, validates symbols, ordered features, global features, cadence and sequence layout, rebuilds the Dict observation from a bounded rolling dataset, and requires a monotonic `ServingStateSnapshot` binding dataset, decision index, portfolio state, pending target and current observation before released inference. Live order routing remains outside the policy artifact.
+Production remains `NO-GO` until the maintained GPU verification, at least 180 OOS days, a strictly positive paired block-bootstrap lower bound on RL-minus-baseline daily log excess, signed fresh confirmation, conservative complete execution evidence, and paper-trading reconciliation all pass. Passing repository CI proves code and artifact integrity at one source head; it does not prove profitability or authorize capital deployment.
 
-Production remains NO-GO until the maintained GPU verification, 180 OOS days, a strictly positive paired block-bootstrap lower bound on RL-minus-baseline daily log excess, a signed fresh confirmation interval and paper-trading reconciliation all pass.
+See [Research Status](RESEARCH_STATUS.md) and the [2026-07-22 documentation and architecture audit](verification/2026-07-22-documentation-and-architecture-audit.md).

--- a/docs/RESEARCH_STATUS.md
+++ b/docs/RESEARCH_STATUS.md
@@ -1,8 +1,117 @@
 # Research Status
 
+## Current capability status — 2026-07-22
+
+```text
+RepositoryIntegrity: VERIFIED_ON_PR_75_HEAD
+ResearchWorkflows: AVAILABLE
+StatefulOHLCExecution: AVAILABLE_WITH_KNOWN_COMPATIBILITY_GAPS
+TradeRLStudio: AVAILABLE_FOR_DIAGNOSTIC_REPLAY
+AttestedPaperServing: AVAILABLE_FOR_ELIGIBLE_SELECTED_FINAL_BUNDLES
+DirectExchangeRouting: NOT_IMPLEMENTED
+EmpiricalProductionGate: NO-GO
+ProfitabilityClaim: NONE
+```
+
+The latest integrated verification record is PR #75's conservative stateful order simulator. On exact product head `27a564313f64a4ebbd4001fc77518c9985af78b8`, repository CI run `29858620871` and PostgreSQL run `29858620803` succeeded. The full Python result was `1131 passed, 2 skipped`, with 83.43% total coverage. Studio tests/build/layout, Ruff, Mypy, Import Linter, critical coverage, Ubuntu/Windows suites, PostgreSQL migration/integration, structured Serving smoke, and the non-root training image were included in that verification record.
+
+This evidence establishes code, packaging, artifact, and test integrity for that source head. It does not establish profitability, exchange-equivalent fills, paper/live reconciliation, or permission to deploy capital.
+
+## 2026-07-21 P0 validation boundaries
+
+The maintained P0 validation work added three explicit trust boundaries:
+
+1. a PostgreSQL-backed persistent sealed-test ledger that rejects a second opening of the same experiment-plan, dataset, and fold identity across processes;
+2. a real, non-zero Training–Serving observation parity test covering symbol/feature order, availability, staleness, hybrid/shadow books, pending target, previous action, raw and normalized observations, policy-member actions, and deterministic ensemble action;
+3. a historical-metadata promotion gate that requires dataset-bound, point-in-time, Ed25519-authenticated, effective-dated full-interval evidence.
+
+A three-seed CPU smoke selected the baseline because both the candidate median seed score and deployable ensemble score were below the declared threshold. The sealed outer test was opened once and production status remained `NO-GO`. This is correct fail-closed behavior rather than a failed pipeline.
+
+## Conservative stateful execution status
+
+Normal RL environment transitions now use persistent market, limit, and stop-market instructions. The maintained configuration selects:
+
+```text
+path mode: conservative
+processing-bar volume capacity: true
+partial-fill carry: true
+trigger-volume fractions: 1.00 / 0.50 / 0.25 / 0.00
+stateful environment time in force: GTC
+```
+
+Order quantity is fixed using decision-time information. Pending orders preserve residual quantity, latency, trigger state, replacement linkage, status, and deterministic event evidence across decisions. Fills share one symbol-level processing-bar capacity pool. Final promotion requires complete conservative execution evidence and a matching execution-policy digest.
+
+The deterministic replay smoke reproduced identical order-event, equity-curve, and observation-trace digests. Its candidate was not promoted because the declared performance requirements failed. No profitability claim was made.
+
+Two boundaries remain important:
+
+- OHLCV cannot reconstruct true intrabar order, exchange queue position, hidden liquidity, auctions, or L2 depth.
+- `MarketExecutor.execute_interval` remains a separate compatibility target-filling implementation instead of a thin stateful adapter. Normal episode steps are stateful, but baseline reward pre-roll and some compatibility/sensitivity callers still use this path. Their outputs must not be described as complete persistent-order evidence until migrated.
+
+## Trade RL Studio and training telemetry
+
+Trade RL Studio provides a local research console for validated datasets, configs, exploratory jobs, runs, evidence, comparisons, and read-only serving state. Live Training shows seed-scoped exploration telemetry as a market replay.
+
+`training_telemetry_v1` is append-only diagnostic data. It does not participate in checkpoint selection, configuration selection, sealed evaluation, run identity, release approval, or order execution. BUY/SELL markers represent exposure changes, not exchange orders.
+
+Current telemetry limitations are recorded in the architecture audit:
+
+- status and paged reads scan the JSONL file from the beginning, so repeated polling grows with accumulated file size;
+- JSON boolean fields are currently coerced with Python truthiness rather than parsed strictly;
+- duplicate files resolving to the same seed are selected by discovery order instead of being rejected as ambiguous;
+- `trade_rl.telemetry` is not yet placed inside the enforced Import Linter layer stack.
+
+These issues affect diagnostics, scaling, and architectural enforcement. They do not alter the fact that telemetry is excluded from promotion evidence.
+
+## PostgreSQL artifact catalog
+
+The optional PostgreSQL catalog stores verified artifact metadata, canonical cache keys, locations, sizes, dependency edges, lifecycle status, and persistent sealed-test reservations. Datasets, arrays, checkpoints, models, and run evidence remain immutable filesystem artifacts.
+
+Catalog registration is idempotent for identical metadata and rejects digest/cache-key conflicts. PostgreSQL is optional for ordinary filesystem operation, but the durable cross-process sealed-test uniqueness guarantee requires the persistent ledger.
+
+## Absolute-growth reward and paired inference contract
+
+The maintained environment optimizes the hybrid book's net absolute log growth. The independent shadow baseline supplies a light rolling non-inferiority hinge and sealed paired evaluation. Raw interval excess return is not added as a second primary growth objective.
+
+The baseline hinge uses a 30-day rolling window, seven-day minimum history, and 1.5% full-window log-growth tolerance. Only increases in hinge severity are penalized. Drawdown shaping is free through 5%, becomes progressively steeper through 20%, and likewise penalizes only newly worsening severity. Zero residual action produces identical hybrid and shadow books, but its reward is the baseline strategy's absolute growth rather than zero.
+
+Paired moving-block inference uses `log1p(candidate_return) - log1p(shadow_return)` for its mean, confidence interval, and p-value. That quantity is a selection/non-inferiority contract, not the primary step reward.
+
+The maintained reward contract is **Reward schema v4**.
+
+## Causal training contract
+
+Maintained finite-horizon training, behavior cloning, checkpoint validation, configuration selection, and sealed evaluation use liquidation-at-close terminal accounting. Policy observations do not include synthetic episode progress or future tradability. They do include the state required by reward, risk, and persistent execution semantics.
+
+A 20% hybrid drawdown triggers current-close liquidation of the hybrid policy book and a true `drawdown_stop` terminal transition. The independent shadow book is not charged for a policy-specific failure. Actual liquidation costs enter final wealth and reward; no fixed terminal jackpot is used.
+
+Every policy ensemble records observation schema, action identity, PPO configuration digest, requested/actual timesteps, compute device, dataset/environment identity, AUM, normalizers, and policy-member digests. Low GPU utilization for a small model is not itself a quality failure; throughput and sealed OOS evidence are the relevant criteria.
+
+The baseline reward pre-roll currently uses the compatibility execution path, while normal transitions use the stateful engine. Under non-zero latency, persistent partial fills, limit/stop semantics, or cancel-and-replace, this can create an economic-state mismatch at episode reset. Production promotion remains blocked, and this gap is prioritized in the 2026-07-22 architecture audit.
+
+## AUM and environment identity
+
+Initial capital is an explicit quote-currency research input. The environment refuses construction when AUM is omitted. Environment identity hashes dataset, timing, trend, risk, execution policy, reward, rolling windows, alpha/factor mode, action and observation schemas, sequence settings, and initial capital.
+
+Capacity conclusions must be evaluated at predeclared AUM scenarios. Performance at one capital scale does not establish performance at a larger scale.
+
+## Nested walk-forward execution
+
+The maintained workflow uses fold-local signal lineage, stage-scoped dataset capabilities, and a one-shot sealed-test access ledger. Alpha/factor artifacts identify fit/prediction ranges, generator configuration/code digests, validity masks, and row availability times.
+
+Each fold preserves execution evidence including turnover, fees, funding, borrow, dividends, cash interest, fills, participation, pending-order events, and economic termination. Candidate eligibility is computed from a fixed seed distribution. Configuration selection and sealed testing evaluate the exact deterministic mean-action ensemble that serving loads.
+
+Independent folds are summarized as a distribution with median, weighted mean, win rate, and worst fold. They are not mislabeled as one continuous portfolio return or drawdown. Continuous metrics require contiguous ranges and verified opening/closing state digests.
+
+## Serving and activation contract
+
+Serving candidate bundle schema is **v5**. The bundle binds runtime contracts and declared files but deliberately contains no private approval material. A detached `ReleaseAttestation` binds the immutable bundle to verified dataset, selection/evaluation/gate evidence, fresh confirmation, conservative execution evidence, selected policy, source commit, dependency provenance, approver, approval time, and expiry.
+
+Registry and runtime require a purpose-bound trusted public key. Unknown-key, unsigned, expired, or tampered attestations fail closed. Before activation, the runtime verifies file closure, rejects symlinks, loads shared normalizers and adapters, and executes deterministic probe observations through every policy member. Structured predictions require a monotonic identity-bound `ServingStateSnapshot` including persistent execution state.
+
 ## 2026-07-13 archived real-data result
 
-The archived result is classified as follows:
+The archived result remains classified as:
 
 ```text
 ResearchRun: COMPLETED
@@ -12,54 +121,14 @@ BaselineFallback: SELECTED_FOR_ANALYSIS
 ProductionRelease: BLOCKED
 ```
 
-Configuration A was the identity baseline and had no selected PPO model path. The signal gate failed because mean OOS IC was below its required threshold. The final production gate also failed, including the positive-return significance check. Positive holdout return and positive 2x-cost return remain evidence, but they do not override failed mandatory gates.
+Configuration A was the identity baseline and had no selected PPO path. The signal gate failed because mean OOS IC was below threshold. The final production gate also failed, including the positive-return significance check. Positive holdout return and positive 2x-cost return remain evidence, but they do not override mandatory failed gates.
 
-The migration fixture exists to prevent this evidence from being mislabeled as a selected policy ensemble or a production release.
-
-## Absolute-growth reward and paired inference contract
-
-The maintained residual environment now optimizes the hybrid book's net absolute log growth. It uses the independent shadow baseline only for a light rolling non-inferiority hinge and for sealed paired evaluation. The reward does not add raw interval excess return as a second growth objective.
-
-The baseline hinge uses a 30-day rolling window, a seven-day minimum history, and a 1.5% full-window log-growth tolerance. Only increases in the hinge level are penalized. Drawdown shaping is free through 5%, becomes progressively steeper through 20%, and likewise penalizes only newly worsening severity. Zero action still produces identical hybrid and shadow books, but its reward is the baseline strategy's absolute growth rather than zero.
-
-Paired moving-block inference continues to use `log1p(candidate_return) - log1p(shadow_return)` for its mean, confidence interval, and p-value. That paired quantity is a selection and non-inferiority contract, not the primary step reward. Arithmetic period-return differences remain diagnostic only.
-
-## Causal training contract
-
-Maintained finite-horizon training, behavior cloning, checkpoint validation, configuration selection, and sealed outer evaluation all use the same `liquidate_at_close` terminal-accounting contract. Terminal liquidation costs therefore enter both optimization and evaluation, and every stage fails closed if liquidity prevents a complete exit. Legacy bootstrap-compatible truncation remains available only through non-maintained custom configurations and is not eligible for the complete research workflow.
-
-Policy observations do not include synthetic episode progress or next-bar tradability. They do include rolling hybrid and shadow growth, their growth gap, baseline shortfall, scaled tolerance, hinge level, and emergency-deleverage state because those values determine future reward and termination semantics. Next-open execution uses the last completed bar's volume as its capacity proxy, while actual next-bar tradability remains part of transition dynamics.
-
-A 20% hybrid drawdown triggers current-close liquidation of the hybrid policy book and a true `drawdown_stop` terminal transition. The independent shadow book is preserved rather than charged for a policy failure. Actual hybrid liquidation costs are included in final wealth and reward; there is no fixed terminal jackpot or penalty. Explicit sealed end-of-window evaluation remains the separate mode that liquidates both books.
-
-Every policy ensemble records the observation schema, complete PPO configuration digest, requested timesteps, observed actual timesteps, and resolved compute device. Low GPU utilization for the current small single-environment MLP is not treated as a quality failure; throughput and sealed OOS evidence remain the relevant criteria.
-
-## AUM and environment identity contract
-
-Initial capital is an explicit quote-currency research input rather than a scale-free default. The environment refuses construction when AUM is omitted. This prevents a one-dollar simulation from silently disabling participation, impact, and liquidation constraints that matter for the intended deployment capital.
-
-The environment identity hashes the dataset, resolved timing, trend configuration, risk limits, execution costs, complete reward configuration and resolved rolling windows, alpha mode, action and observation schemas, and initial capital. Policy ensembles record the environment digest and AUM, and fail closed when seeds report inconsistent environment or capital identities.
-
-Capacity conclusions must therefore be evaluated at predeclared AUM scenarios. Performance at one capital scale does not establish performance at a larger scale.
-
-## Nested walk-forward execution contract
-
-The maintained workflow uses fold-local signal lineage, stage-scoped dataset capabilities and a one-shot sealed-test access ledger. Alpha and factor artifacts identify fit and prediction ranges, generator configuration/code digests, validity masks and per-row availability times. Training predictions must be causal inside the train capability; checkpoint, selection and test predictions must be generated from the authorized train fit.
-
-Every fold preserves execution evidence including turnover, fees, funding, borrow, dividends, cash interest, fills, participation and economic termination. Candidate eligibility is still computed from the fixed seed distribution, while configuration selection and sealed outer testing evaluate the exact deterministic mean-action ensemble that final serving loads. Independent folds are summarized as a distribution with median, weighted mean, win rate and worst fold. They are not mislabeled as one continuous portfolio return or drawdown. Continuous metrics require contiguous ranges and verified opening/closing state digests. Session-market annualization and carry use actual elapsed time.
-
-Training and walk-forward runs have separate manifest schemas, exact file closure and content-addressed provenance. Git commit, dirty state, lockfile digest, runtime/library versions, platform/hardware and deterministic seed configuration are captured automatically.
-
-## Serving and activation contract
-
-Serving candidate bundle schema v4 binds the exact runtime contract and declared files but deliberately contains no release digest. A separate external `ReleaseAttestation` binds the candidate bundle to verified dataset, selection/evaluation and evidence-bound gate digests, selected policy, source commit, dependency provenance, approver and approval time. This removes the former bundle/release circular hash.
-
-Registry and runtime activation require a detached Ed25519 external attestation issued under an explicitly trusted, purpose-bound public key ID. Unknown-key, unsigned, or tampered attestations fail closed. Before swapping live state, the runtime verifies exact file closure, rejects symlinks, loads the shared observation normalizer and executes deterministic probe observations through every policy member. Structured predictions additionally require a monotonic identity-bound `ServingStateSnapshot` so stale portfolio or pending-target state cannot be reused. Shape, finite-value, bounds, action-name, observation-schema, normalizer, and state-identity mismatches fail before activation or inference.
+The migration fixture prevents this evidence from being mislabeled as a selected policy ensemble or production release.
 
 ## Capability boundary
 
-The repository is research-ready and supports attested local/paper serving. It still does not implement direct exchange websocket ingestion, order submit/cancel/replace, broker reconciliation, production secrets, venue kill switches or operational alerting. Those capabilities remain a separate live-trading integration phase and the project makes no profitability claim.
+The repository supports research workflows and attested local/paper serving for eligible selected-final bundles. It does not implement direct exchange websocket ingestion, order submission/cancellation/replacement, broker reconciliation, production secrets, venue kill switches, or operational alerting.
 
-## Maintained reward identity
+Production remains `NO-GO` until maintained GPU verification, at least 180 OOS days, a strictly positive paired block-bootstrap lower bound on RL-minus-baseline daily log excess, signed fresh confirmation, complete conservative execution evidence, and paper-trading reconciliation all pass.
 
-The maintained reward contract is **Reward schema v4** with a complete 720-hour baseline window, fixed 1.5% tolerance, worsening-only staged drawdown shaping, and continuous economic terminal penalties.
+See [Architecture](ARCHITECTURE.md), [P0 validation evidence](verification/2026-07-21-p0-validation-baseline.md), [stateful execution verification](verification/2026-07-21-conservative-order-simulator.md), and the [2026-07-22 documentation and architecture audit](verification/2026-07-22-documentation-and-architecture-audit.md).

--- a/docs/superpowers/plans/2026-07-22-documentation-and-architecture-audit.md
+++ b/docs/superpowers/plans/2026-07-22-documentation-and-architecture-audit.md
@@ -1,0 +1,78 @@
+# Documentation and Architecture Audit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reconcile maintained explanatory Markdown with the current `main` implementation, then record a code-backed architecture audit without overstating research or production readiness.
+
+**Architecture:** Documentation is treated as a maintained contract over the repository's enforced dependency layers, artifact identities, execution semantics, evidence boundaries, and capability status. The audit compares those claims against the current import-linter contracts and concrete training, execution, telemetry, catalog, Studio, and serving paths.
+
+**Tech Stack:** Markdown, Python 3.12, Import Linter, pytest, Ruff, Mypy, GitHub Actions.
+
+## Global Constraints
+
+- Direct exchange routing remains outside the repository capability boundary.
+- Production status remains `NO-GO` and no profitability claim may be introduced.
+- Current implementation truth takes precedence over historical design documents.
+- Historical verification evidence must retain exact commit and workflow identities.
+- Architecture findings must distinguish confirmed defects, performance risks, maintenance risks, and deliberate compatibility paths.
+
+---
+
+### Task 1: Reconcile maintained entry-point documentation
+
+**Files:**
+- Modify: `README.md`
+- Modify: `README.ja.md`
+- Modify: `START.md`
+- Modify: `studio/README.md`
+
+**Interfaces:**
+- Consumes: current CLI extras, Studio telemetry contracts, PostgreSQL catalog contracts, serving bundle schema, and stateful execution defaults.
+- Produces: copy-paste setup and capability descriptions that match current code.
+
+- [ ] Correct dependency-install commands and serving schema references.
+- [ ] Add concise descriptions of the PostgreSQL metadata catalog, append-only training telemetry, and conservative stateful order simulator.
+- [ ] Keep exploratory visualization, deterministic evaluation, paper serving, and live exchange execution explicitly separated.
+- [ ] Link the architecture and research-status documents from the entry points.
+
+### Task 2: Reconcile architecture and research-status contracts
+
+**Files:**
+- Modify: `docs/ARCHITECTURE.md`
+- Modify: `docs/RESEARCH_STATUS.md`
+
+**Interfaces:**
+- Consumes: `.importlinter`, current package structure, PR #73 through PR #75 verification records, and serving bundle v5.
+- Produces: one current responsibility map, dependency-order description, execution boundary, catalog boundary, telemetry boundary, and evidence-status summary.
+
+- [ ] Make the documented layer order match `.importlinter` exactly.
+- [ ] Document packages that are not currently covered by the layer stack instead of implying enforcement.
+- [ ] Describe stateful order persistence, current-bar capacity, path assumptions, promotion evidence, and compatibility execution paths.
+- [ ] Update the current evidence status while preserving `NO-GO` and historical archived results.
+
+### Task 3: Record the architecture audit
+
+**Files:**
+- Create: `docs/verification/2026-07-22-documentation-and-architecture-audit.md`
+
+**Interfaces:**
+- Consumes: current source and maintained documentation at the audited commit.
+- Produces: prioritized findings with concrete paths, impact, and remediation direction.
+
+- [ ] Record the audited head and inspection scope.
+- [ ] Record strengths that are enforced by tests or import contracts.
+- [ ] Record confirmed gaps, including execution-path divergence, telemetry boundary enforcement, telemetry read scaling, strict parsing, ambiguous stream discovery, and duplicated canonical JSON logic.
+- [ ] Separate architecture integrity from empirical profitability and operational release authorization.
+
+### Task 4: Verify and publish
+
+**Files:**
+- Verify all modified Markdown and repository checks through the existing CI workflow.
+
+**Interfaces:**
+- Consumes: the complete documentation diff.
+- Produces: a reviewable pull request with exact-head verification status.
+
+- [ ] Review the final diff for stale schema versions, contradictory capability claims, and broken relative links.
+- [ ] Run or observe `ruff check .`, `ruff format --check .`, `mypy .`, `lint-imports`, pytest/coverage, Studio checks, platform checks, PostgreSQL checks, and training-image checks through the repository workflow.
+- [ ] Open a draft pull request and report any checks that remain pending or unavailable rather than claiming success without evidence.

--- a/docs/verification/2026-07-22-documentation-and-architecture-audit.md
+++ b/docs/verification/2026-07-22-documentation-and-architecture-audit.md
@@ -1,0 +1,227 @@
+# Documentation and Architecture Audit — 2026-07-22
+
+## Scope
+
+This audit was performed after reconciling the maintained explanatory Markdown with repository `main` at:
+
+```text
+audited main head: 5c029f0b57c0a628990f223cf8265d86fdc602f3
+latest product change: feat: add conservative stateful order simulation (#75)
+```
+
+The inspection covered:
+
+- `README.md`, `README.ja.md`, `START.md`, `studio/README.md`;
+- `docs/ARCHITECTURE.md`, `docs/RESEARCH_STATUS.md`;
+- `.importlinter`, packaging, optional dependency boundaries, and architecture tests;
+- PostgreSQL catalog and persistent sealed-test ledger;
+- training telemetry writer, reader, Studio discovery, and API boundary;
+- target reconciliation, persistent orders, OHLC path selection, liquidity allocation, stateful execution, and promotion evidence;
+- reward pre-roll, normal environment transitions, terminal liquidation, Training–Serving parity, and serving bundle v5.
+
+The audit is source-based. The prior exact-head product verification for PR #75 is preserved in `docs/verification/2026-07-21-conservative-order-simulator.md`; this documentation branch requires its own CI result before merge.
+
+## Documentation corrections completed
+
+The maintained documentation now:
+
+- uses Serving bundle **v5** instead of stale v4 references;
+- installs `train-sb3` in the Quickstart before invoking actual PPO training;
+- documents the optional PostgreSQL catalog without implying that models or arrays are stored as mutable database BLOBs;
+- distinguishes exploratory telemetry, deterministic checkpoint evidence, sealed evaluation, paper serving, and direct exchange execution;
+- documents persistent market/limit/stop orders, current-bar capacity, partial-fill carry, OHLC path assumptions, and execution-promotion evidence;
+- makes the documented Import Linter order match `.importlinter` exactly;
+- records that `trade_rl.telemetry` is currently outside the enforced layer stack;
+- preserves `NO-GO` and makes no profitability or live-routing claim.
+
+## Architecture strengths
+
+### A1 — Enforced responsibility layers
+
+`.importlinter` defines an explicit top-down dependency order from CLI and Studio through workflows, integrations, serving, learning, RL, risk, simulation, strategies, data, catalog, evaluation, release, artifacts, and domain. Additional forbidden contracts keep domain standard-library only, prevent serving from importing training/workflows, keep learning and core training framework-independent, isolate offline signers, and keep catalog contracts independent of psycopg, NumPy, model frameworks, and upper application layers.
+
+Assessment: **strong and testable**.
+
+### A2 — Immutable artifact and release identities
+
+Dataset and run artifacts use deterministic serialization, file closure, hashes, staging, and atomic publication. Serving bundle v5 separates candidate identity from detached approval, and runtime paths accept public verification material rather than offline signing secrets.
+
+Assessment: **strong trust boundary**.
+
+### A3 — Persistent sealed-test access
+
+The PostgreSQL-backed ledger reserves a unique experiment-plan, dataset, and fold tuple atomically across processes. Duplicate access fails rather than silently generating a second outer-test result.
+
+Assessment: **strong P0 research boundary**.
+
+### A4 — Training–Serving parity
+
+The environment exports the actual current observation state, including persistent-order coordinates, and serving rebuilds and verifies the same identity-bound contract. The existing P0 verification uses non-zero environment trajectories rather than synthetic zero arrays.
+
+Assessment: **strong anti-drift boundary**.
+
+### A5 — Stateful execution decomposition
+
+Order domain types, target reconciliation, admission, bar-path interpretation, liquidity allocation, accounting, promotion evidence, and deterministic replay are separated into focused modules. `BookState` remains the accounting authority, avoiding a second independent cash/PnL implementation inside the order simulator.
+
+Assessment: **strong direction with one important incomplete migration**.
+
+## Prioritized findings
+
+## P1 — Reward pre-roll still uses the compatibility execution engine
+
+**Evidence**
+
+- Normal `ResidualMarketEnv.step()` calls `_execute_stateful_target()`, reconciles target exposure against active residual orders, and carries `OrderBookState` between decisions.
+- `_baseline_reward_history()` constructs a separate `MarketExecutor` and calls `execute_interval()` directly.
+- `execute_interval()` still contains its own target-to-quantity, latency, previous-bar-capacity, touch, fill, and carry loop. It is not a thin adapter over `execute_orders()`.
+- The approved stateful-execution design says the compatibility API should convert targets to intents and execute through the new engine.
+
+**Impact**
+
+Reward history at reset can follow different economics from the episode that consumes it. The divergence is material when latency is non-zero, partial fills persist across decisions, order type is limit/stop, cancel-and-replace matters, or processing-bar capacity differs from the compatibility path's preceding-bar capacity. Because the baseline-underperformance hinge is initialized from this history, the mismatch can change reward state and therefore the MDP.
+
+**Required remediation**
+
+1. Make `execute_interval()` a real adapter over target reconciliation plus stateful execution, or remove maintained callers.
+2. Migrate `_baseline_reward_history()` to the same persistent-order path as normal baseline transitions.
+3. Add a parity test comparing pre-roll and ordinary baseline execution under non-zero latency, constrained capacity, and partial-fill carry.
+4. Bind the resulting compatibility/migration mode into evidence until the old implementation is removed.
+
+## P1 — `trade_rl.telemetry` is outside the enforced dependency layer stack
+
+**Evidence**
+
+`trade_rl.telemetry` is a first-party runtime package used by training integrations and Studio, but it is absent from `.importlinter`'s layer list and has no separate forbidden contract.
+
+**Impact**
+
+The package is currently standard-library only, but that property is not enforced. A future import from workflows, integrations, Studio, model frameworks, or serving could create an unnoticed cycle or invert a trust boundary while Import Linter still passes.
+
+**Required remediation**
+
+Choose and enforce one of these designs:
+
+- place framework-independent telemetry contracts below integrations and Studio in the layer stack, preferably near artifacts/domain-facing diagnostic contracts; or
+- split `telemetry/contracts.py` from adapter/writer code and give each part an explicit forbidden-import contract.
+
+Add an architecture test that proves the chosen placement remains enforced.
+
+## P2 — Live telemetry polling performs whole-file rescans
+
+**Evidence**
+
+`read_training_telemetry()` opens the JSONL file and iterates from the beginning even when `after_sequence` is large. `training_telemetry_status()` also scans every line. Studio calls these functions repeatedly for status and event polling.
+
+**Impact**
+
+For long multi-seed runs, cumulative polling cost grows with total file size. Repeated polling can approach quadratic total bytes read over the lifetime of a run, increase API latency, and compete with training I/O. The browser's 2,048-record cap does not limit backend scan cost.
+
+**Required remediation**
+
+- maintain a sidecar index with sequence-to-byte offsets, or persist byte cursors in the job state;
+- use a bounded tail scan for status;
+- return file generation/inode/size with the cursor so truncation or replacement fails closed;
+- add a large synthetic telemetry benchmark and assert that incremental reads scale with appended bytes.
+
+## P2 — Telemetry booleans are not parsed fail closed
+
+**Evidence**
+
+`TrainingTelemetryRecord.from_json_dict()` uses `bool(raw.get(...))` for `emergency_deleverage`, `terminated`, and `truncated`.
+
+**Impact**
+
+Strings and integers are silently coerced. For example, the JSON string `"false"` becomes `True`. This contradicts the otherwise strict typed artifact boundary and can display incorrect risk or terminal state.
+
+**Required remediation**
+
+Add a strict `_required_bool()` parser and reject missing or non-boolean values. Add malformed-record tests for strings, integers, null, and omitted fields.
+
+## P2 — Duplicate seed telemetry streams are resolved by discovery order
+
+**Evidence**
+
+Studio recursively discovers `training-telemetry.jsonl` files and stores them with `streams.setdefault(seed, resolved)`. A second path for the same seed is ignored.
+
+**Impact**
+
+If staging, published, failed, or nested directories contain ambiguous copies, the UI may show an arbitrary stream while appearing authoritative. This is especially risky around interrupted publication or manual artifact copying.
+
+**Required remediation**
+
+- reject multiple distinct files for one seed as `artifact_invalid` unless an explicit namespace precedence and identical content digest are verified;
+- bind stream discovery to the job's declared current run namespace/state rather than recursive first-match behavior;
+- add tests for duplicate staging/runs/failed copies and symlink variants.
+
+## P2 — `ResidualMarketEnv` remains a large orchestration hotspot
+
+**Evidence**
+
+The environment owns provider resolution, action migration, sequence setup, episode sampling, initial books, reward pre-roll, stateful reconciliation, risk, execution, liquidation, observation snapshots, diagnostics, and reward transitions in one large module. Configuration and economic transition helpers have been extracted, but the main class remains highly coupled.
+
+**Impact**
+
+Changes to execution, reward, serving parity, and episode reset can interact through shared mutable state. The P1 pre-roll divergence is an example of a cross-cutting concern that is hard to see inside the facade.
+
+**Required remediation**
+
+Extract focused collaborators with explicit state contracts:
+
+- episode initialization and causal pre-roll;
+- portfolio/order transition engine;
+- terminal liquidation coordinator;
+- observation snapshot/export adapter.
+
+Keep Gymnasium adaptation in the facade and test collaborators independently.
+
+## P3 — Canonical JSON logic is duplicated
+
+**Evidence**
+
+`trade_rl.artifacts.codec` and `trade_rl.catalog.contracts` each define canonical JSON conversion/encoding and JSON value types.
+
+**Impact**
+
+The implementations currently agree for ordinary catalog payloads, but they support different object types and container freezing behavior. Future changes can make cache-key digests diverge from artifact digests or create two definitions of "canonical".
+
+**Required remediation**
+
+Move the smallest framework-independent canonical JSON primitive to one lower-level module and make both artifact and catalog code depend on it. Add cross-module digest vectors for nested mappings, tuples/lists, Unicode, floats, and invalid non-finite values.
+
+## P3 — PostgreSQL adapter combines generic catalog and evaluation-specific ledger operations
+
+**Evidence**
+
+`PostgresArtifactCatalog` implements generic artifact registration and directly accepts `SealedTestAccessRecord` from the evaluation package.
+
+**Impact**
+
+This is allowed by the current layer order, but it couples a reusable catalog adapter to one evaluation workflow and makes migration/testing responsibilities broader than the `ArtifactCatalog` protocol suggests.
+
+**Required remediation**
+
+Prefer a shared PostgreSQL connection/migration service with separate `PostgresArtifactCatalog` and `PostgresSealedTestReservationStore` adapters. Keep the generic protocol unaware of evaluation records.
+
+## Documentation drift prevention
+
+The documentation branch adds tests that should fail when:
+
+- maintained documents regress to Serving bundle v4;
+- the Quickstart invokes training without installing the `train-sb3` extra;
+- the architecture document omits a currently enforced Import Linter layer.
+
+These tests do not replace code review. They cover high-value claims that previously drifted.
+
+## Recommended remediation order
+
+1. **Unify reward pre-roll and `execute_interval` with stateful execution.** This is the only finding that can change training reward state and evaluation economics.
+2. **Put telemetry inside an enforced architecture boundary.** Do this before more telemetry dependencies are added.
+3. **Replace full-file telemetry polling and reject ambiguous streams.** This protects long-running 12M-step use cases.
+4. **Make telemetry parsing strict.** Small change, high confidence.
+5. **Decompose the environment around episode/pre-roll and transition collaborators.** Perform after semantic parity tests exist.
+6. **Unify canonical JSON and split PostgreSQL adapter roles.** Maintenance hardening after the behavioral P1/P2 items.
+
+## Verification interpretation
+
+A successful CI result for this branch will establish that the documentation and contract tests integrate with the repository at the branch head. It will not close the findings above unless code changes explicitly remediate them. It also will not establish profitable trading or authorize direct exchange execution.

--- a/studio/README.md
+++ b/studio/README.md
@@ -1,37 +1,39 @@
 # Trade RL Studio
 
-ローカル優先の `trade_rl` 研究コンソールです。Vite、React、strict TypeScript と FastAPI を使い、既存の正本artifactとworkflowを操作します。
+ローカル優先の`trade_rl`研究コンソールです。Vite、React、Strict TypeScript、FastAPIを使い、既存の正本ArtifactとWorkflowを操作します。
+
+> Studioは探索を理解し、証拠を読み取るための画面です。Checkpoint選択、Sealed-test、Release承認、Bundle activation、取引所注文は実行しません。Production statusは常に`NO-GO`です。
 
 ## 実装済み
 
-- 固定トップバー、サイドバー、ワークスペース、ステータスバー
-- 1536×1024／1440×900でブラウザページ全体の縦スクロールなし
-- システム、dataset、job、run、baseline、fold安定性、`NO-GO`を集約したダッシュボード
-- Data Labで正本dataset artifactを検証して一覧・詳細表示
-- 実験画面から検証済みconfigとdatasetを選び、exploratory trainingを開始
-- Run Centerで永続job状態、PID、終了コード、ログを表示し、所有プロセスを安全停止
-- Live Trainingで学習中の探索行動をseed単位の市場リプレイとして表示
-- Live Trainingの「ほぼライブ」／「バッファ再生」と「ローソク足ごと」／「イベント圧縮」の切替
-- 価格チャート、position変更マーカー、再生カーソル、現在weight、探索区間損益、reward、drawdown、最新イベントの同期表示
-- 複数seedのストリームを独立選択し、カーソルとブラウザバッファを混在させずに再生
-- 既存の決定論的`checkpoint-selection.json`から、選択seed・明示foldの評価return、評価range、digest、finalist状態を読み取り表示
-- Compareで検証済みrunの指標、設定差、fold、累積wealthを比較
-- Evidence Explorerでrun manifest、identity、authorization、artifact file closureを監査
-- Serving Monitorでactive bundleとpaper推論スナップショットを読み取り専用表示
-- FastAPIによるdataset・run・config・job・training telemetry・checkpoint評価証拠の型付きAPI
-- API未起動時は明示的な`DEMO DATA`へフォールバック
-- 直接取引所注文、APIキー入力、ライブ資金操作は未実装
+- 固定Top bar、Sidebar、Workspace、Status bar
+- 1536×1024／1440×900でBrowser page全体の縦Scrollなし
+- System、Dataset、Job、Run、Baseline、Fold安定性、`NO-GO`を集約したDashboard
+- Data Labで正本Dataset artifactを検証して一覧・詳細表示
+- 実験画面から検証済みConfigとDatasetを選び、Exploratory trainingを開始
+- Run Centerで永続Job状態、PID、終了Code、Logを表示し、所有Processを安全停止
+- Live Trainingで学習中の探索行動をSeed単位の市場Replayとして表示
+- 「ほぼライブ」／「バッファ再生」と「ローソク足ごと」／「イベント圧縮」の切替
+- Price chart、Position変更Marker、再生Cursor、現在Weight、探索区間PnL、Reward、Drawdown、Risk eventの同期表示
+- 複数SeedのStreamを独立選択し、CursorとBrowser bufferを混在させず再生
+- 決定論的`checkpoint-selection.json`から、選択Seed、明示Fold、評価Return、Range、Digest、Finalist状態を表示
+- Compareで検証済みRunの指標、設定差、Fold、累積Wealthを比較
+- Evidence ExplorerでRun manifest、Identity、Authorization、Artifact file closureを監査
+- Serving MonitorでActive bundleとPaper inference snapshotをRead-only表示
+- FastAPIによるDataset、Run、Config、Job、Training telemetry、Checkpoint評価証拠の型付きAPI
+- API未起動時は明示的な`DEMO DATA`へFallback
+- 直接取引所注文、API key入力、Live資金操作は未実装
 
 ## 起動
 
-リポジトリ直下でPython APIを起動します。
+Repository rootでPython APIを起動します。
 
 ```bash
 uv sync --extra studio --extra train-sb3
 uv run trade-rl studio start --project-root .
 ```
 
-別ターミナルでReactを起動します。
+別TerminalでReactを起動します。
 
 ```bash
 npm ci --prefix studio
@@ -42,35 +44,35 @@ npm run dev --prefix studio
 
 ## Live Training
 
-1. `実験`ワークスペースからexploratory training jobを開始します。
-2. サイドバーの`Live Training`を開きます。
-3. 実行中または保存済みジョブを選択します。
-4. 複数seedがある場合は`Seed`セレクタで表示対象を選びます。seed変更時は受信カーソルとブラウザバッファを初期化し、別seedのレコードを混ぜません。
-5. 初期状態の`バッファ再生`では、受信を継続しながら人間が追える速度でリプレイします。
+1. `実験`WorkspaceからExploratory training jobを開始します。
+2. Sidebarの`Live Training`を開きます。
+3. 実行中または保存済みJobを選択します。
+4. 複数Seedがある場合は`Seed`Selectorで表示対象を選びます。Seed変更時は受信CursorとBrowser bufferを初期化し、別SeedのRecordを混ぜません。
+5. 初期状態の`バッファ再生`では、受信を継続しながら人間が追える速度でReplayします。
 6. `ほぼライブ`へ切り替えると、最新受信位置へ追従します。
-7. `ローソク足ごと`と`イベント圧縮`を切り替え、通常サンプルまたは重要なposition・risk・episodeイベントを観察します。
-8. 同じseedの決定論的Checkpoint評価証拠が存在する場合、`Checkpoint evidence`セレクタで確認するfoldを明示的に選択します。
-9. 選択したfoldの評価return、`checkpoint_range`、evaluation digest、finalist状態を探索リプレイとは別枠で確認します。
+7. `ローソク足ごと`と`イベント圧縮`を切り替え、通常Sampleまたは重要なPosition、Risk、Episode eventを観察します。
+8. 同じSeedの決定論的Checkpoint評価証拠がある場合、`Checkpoint evidence`SelectorでFoldを明示選択します。
+9. 選択Foldの評価Return、`checkpoint_range`、Evaluation digest、Finalist状態を探索Replayとは別枠で確認します。
 
-再生中に一時停止しても、ブラウザはバックエンドからの受信を継続します。`最新へ`を押すと最新位置へ戻ります。受信済みレコードは選択seedごとにブラウザ内で最大2,048件に制限されます。
+一時停止中もBackendからの受信を継続します。`最新へ`で最新位置へ戻ります。Browser内Recordは選択Seedごとに最大2,048件です。
 
-Stable-Baselines3の学習コールバックは、通常区間を既定32 decisionごとに間引き、position変化、risk、emergency deleverage、episode終了を優先して保存します。保存対象イベントでは、vector environmentから実際のprimary symbol、時刻、判断区間OHLCを取得します。自動reset後のterminal eventでも旧episodeの明示market indexからOHLCを復元します。学習再開時は既存JSONLの最終sequenceを引き継ぎます。テレメトリ書き込みで例外が発生した場合、可視化だけを停止し、学習自体は停止しません。
+Stable-Baselines3 Callbackは通常区間を既定32 decisionごとに間引き、Position変化、Risk、Emergency deleverage、Episode終了を優先して保存します。保存EventではVector environmentからPrimary symbol、時刻、判断区間OHLCを取得します。Auto-reset後のTerminal eventでも旧Episodeの明示Market indexからOHLCを復元します。学習再開時は既存JSONLの最終Sequenceを引き継ぎます。Telemetry書込例外は可視化だけを停止し、学習自体を停止しません。
 
-各seedのストリームは、学習中は次の場所へappend-only JSON Linesとして作成されます。
+各SeedのStreamは学習中に次の場所へAppend-only JSONLとして作成されます。
 
 ```text
 <run-root>/.staging/<run-id>/seed-<seed>/telemetry/training-telemetry.jsonl
 ```
 
-runが公開または失敗隔離された後は、同じrunディレクトリとともに`runs/`または`failed/`配下へ移動します。Studio APIは既知のjobと宣言済みartifact rootを経由してのみ読み取り、プロジェクト外へのパス、symlink、未知のjob、stream identityとrecord seedの不一致を拒否します。
+Runが公開または失敗隔離された後は、同じRun directoryとともに`runs/`または`failed/`へ移動します。Studio APIは既知Jobと宣言済みArtifact rootを経由してのみ読み取り、Project外Path、Symlink、未知Job、Stream identityとRecord seedの不一致を拒否します。
 
-Checkpoint比較は、maintained walk-forward workflowが既に生成した次の証拠を読み取ります。Studio自身はCheckpoint評価、candidate ranking、seed finalist選択、fold間ranking、再学習を実行しません。
+Checkpoint比較は、維持対象Walk-forward workflowが生成した次の証拠を読み取ります。Studio自身はCheckpoint評価、Candidate ranking、Seed finalist選択、Fold間Ranking、再学習を実行しません。
 
 ```text
 <run-root>/{.staging,runs,failed}/<run-id>/**/checkpoint-selection.json
 ```
 
-readerは`checkpoint_selection_v2_seed_aware`、fold identity、評価range、有限score、policy/evaluation digest、candidateとfinalistのidentity、重複、finalist score一致を検証します。UIは最高scoreのfoldを自動選択せず、foldを辞書順で提示して明示選択させます。不正な証拠は推測表示せず、`artifact_invalid`としてfail closedします。証拠がまだなければ`未生成`と表示します。
+Readerは`checkpoint_selection_v2_seed_aware`、Fold identity、評価Range、有限Score、Policy/Evaluation digest、Candidate/Finalist identity、重複、Finalist score一致を検証します。UIは最高ScoreのFoldを自動選択せず、明示選択させます。不正な証拠は推測表示せず、`artifact_invalid`としてFail closedします。
 
 主なAPI:
 
@@ -80,20 +82,33 @@ GET /api/studio/jobs/{job_id}/telemetry/events?seed=7&after_sequence=0&limit=512
 GET /api/studio/jobs/{job_id}/checkpoint-evaluations
 ```
 
-Live Trainingは学習中の探索行動を理解するための画面です。表示されたBUY／SELLはweight変化を視覚化したもので、取引所注文ではありません。探索区間の損益と決定論的Checkpoint評価は異なる過程・rangeの証拠であり、どちらも本番性能や収益性を保証しません。production statusは常に`NO-GO`です。
+Live Trainingは学習中の探索を理解する画面です。BUY／SELLはWeight変化の可視化であり、取引所注文ではありません。探索区間PnLと決定論的Checkpoint評価は異なるRangeと過程の証拠であり、どちらも本番性能を保証しません。
 
-## artifact探索範囲
+## Telemetryの信頼境界と既知制約
 
-既定では次を探索します。
+Telemetryは診断用で、Model selection、Run identity、Serving approval、Release、Order executionから明示的に除外します。表示が停止または遅延しても、学習Artifactの正当性をTelemetryから推測しません。
 
-- dataset: `artifacts/datasets`, `var/quickstart/dataset`
-- run store: `artifacts/research`, `var/quickstart/artifacts`
-- training config: `configs`, `examples`
-- job state: `var/studio/jobs`
-- serving registry: `var/serving`
-- paper inference snapshot: `var/studio/paper-inference.json`
+2026-07-22時点の既知制約:
 
-環境変数`TRADE_RL_STUDIO_DATASET_ROOTS`、`TRADE_RL_STUDIO_RUN_ROOTS`、`TRADE_RL_STUDIO_CONFIG_ROOTS`、`TRADE_RL_STUDIO_JOB_ROOT`、`TRADE_RL_STUDIO_SERVING_ROOT`、`TRADE_RL_STUDIO_PAPER_SNAPSHOT`で、プロジェクト配下の相対パスに変更できます。プロジェクト外へのパスは拒否されます。
+- BackendのStatus/Event readerはJSONLを先頭から走査するため、長時間Runの高頻度Pollingでは総File sizeに比例してRead costが増えます。
+- Boolean fieldのParserは、Artifact境界としてより厳格な型検証へ変更する余地があります。
+- 同一Seedへ複数Streamが見つかった場合、現在はDiscovery順の最初を使用します。将来はAmbiguous artifactとして拒否する方針です。
+- `trade_rl.telemetry`は現在のImport Linter layer stackへ明示配置されていません。
+
+これらは[2026-07-22アーキテクチャ監査](../docs/verification/2026-07-22-documentation-and-architecture-audit.md)で優先度と修正方向を記録しています。
+
+## Artifact探索範囲
+
+既定:
+
+- Dataset: `artifacts/datasets`, `var/quickstart/dataset`
+- Run store: `artifacts/research`, `var/quickstart/artifacts`
+- Training config: `configs`, `examples`
+- Job state: `var/studio/jobs`
+- Serving registry: `var/serving`
+- Paper inference snapshot: `var/studio/paper-inference.json`
+
+環境変数`TRADE_RL_STUDIO_DATASET_ROOTS`、`TRADE_RL_STUDIO_RUN_ROOTS`、`TRADE_RL_STUDIO_CONFIG_ROOTS`、`TRADE_RL_STUDIO_JOB_ROOT`、`TRADE_RL_STUDIO_SERVING_ROOT`、`TRADE_RL_STUDIO_PAPER_SNAPSHOT`でProject配下の相対Pathへ変更できます。Project外Pathは拒否されます。
 
 ## 検証
 
@@ -106,6 +121,7 @@ npm run check:layout --prefix studio
 uv run ruff check .
 uv run ruff format --check .
 uv run mypy .
+uv run lint-imports
 ```
 
-Studioは常に研究状態を`NO-GO`として表示します。UIから開始できるのは既存の`trade-rl train run`を使うexploratory trainingだけです。Serving Monitorは読み取り専用で、bundle activation、取引所注文、APIキー入力、ライブ資金操作を行いません。
+UIから開始できるのは既存の`trade-rl train run`を使うExploratory trainingだけです。Serving MonitorはRead-onlyで、Bundle activation、取引所注文、API key入力、Live資金操作を行いません。

--- a/tests/test_architecture_contract.py
+++ b/tests/test_architecture_contract.py
@@ -98,7 +98,8 @@ def test_architecture_doc_matches_enforced_layer_order() -> None:
     )
 
     marker = "The enforced Import Linter layer order is exactly:"
-    documented_block = architecture.split(marker, maxsplit=1)[1].split("```", maxsplit=2)[1]
+    documented_section = architecture.split(marker, maxsplit=1)[1]
+    documented_block = documented_section.split("```", maxsplit=2)[1]
     documented_layers = tuple(
         line.strip().removeprefix("-> ")
         for line in documented_block.splitlines()
@@ -136,19 +137,13 @@ def test_large_facades_delegate_configuration_to_focused_modules() -> None:
 def test_sb3_and_torch_are_optional_training_dependencies() -> None:
     config = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
     core = set(config["project"]["dependencies"])
-    training = set(config["tool"]["setuptools"]["packages"]["find"]["include"])
-    training_dependencies = set(
-        config["project"]["optional-dependencies"]["train-sb3"]
-    )
+    training = set(config["project"]["optional-dependencies"]["train-sb3"])
 
-    assert training == {"trade_rl*"}
     assert not any(item.startswith("stable-baselines3") for item in core)
     assert not any(item.startswith("sb3-contrib") for item in core)
     assert not any(item.startswith("torch") for item in core)
-    assert any(
-        item.startswith("stable-baselines3") for item in training_dependencies
-    )
-    assert any(item.startswith("torch") for item in training_dependencies)
+    assert any(item.startswith("stable-baselines3") for item in training)
+    assert any(item.startswith("torch") for item in training)
 
 
 def test_core_training_contract_does_not_import_gym_or_model_frameworks() -> None:

--- a/tests/test_architecture_contract.py
+++ b/tests/test_architecture_contract.py
@@ -85,7 +85,7 @@ def test_quickstart_installs_training_dependencies_before_training() -> None:
     assert "uv run trade-rl train run" in text
 
 
-def test_architecture_doc_names_every_enforced_layer() -> None:
+def test_architecture_doc_matches_enforced_layer_order() -> None:
     architecture = Path("docs/ARCHITECTURE.md").read_text(encoding="utf-8")
     import_linter = Path(".importlinter").read_text(encoding="utf-8")
     layer_block = import_linter.split("layers =", maxsplit=1)[1].split(
@@ -97,9 +97,16 @@ def test_architecture_doc_names_every_enforced_layer() -> None:
         if line.strip().startswith("trade_rl.")
     )
 
+    marker = "The enforced Import Linter layer order is exactly:"
+    documented_block = architecture.split(marker, maxsplit=1)[1].split("```", maxsplit=2)[1]
+    documented_layers = tuple(
+        line.strip().removeprefix("-> ")
+        for line in documented_block.splitlines()
+        if line.strip()
+    )
+
     assert enforced_layers
-    for layer in enforced_layers:
-        assert layer in architecture, layer
+    assert documented_layers == enforced_layers
 
 
 def test_critical_modules_do_not_disable_index_typing_file_wide() -> None:
@@ -129,13 +136,19 @@ def test_large_facades_delegate_configuration_to_focused_modules() -> None:
 def test_sb3_and_torch_are_optional_training_dependencies() -> None:
     config = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
     core = set(config["project"]["dependencies"])
-    training = set(config["project"]["optional-dependencies"]["train-sb3"])
+    training = set(config["tool"]["setuptools"]["packages"]["find"]["include"])
+    training_dependencies = set(
+        config["project"]["optional-dependencies"]["train-sb3"]
+    )
 
+    assert training == {"trade_rl*"}
     assert not any(item.startswith("stable-baselines3") for item in core)
     assert not any(item.startswith("sb3-contrib") for item in core)
     assert not any(item.startswith("torch") for item in core)
-    assert any(item.startswith("stable-baselines3") for item in training)
-    assert any(item.startswith("torch") for item in training)
+    assert any(
+        item.startswith("stable-baselines3") for item in training_dependencies
+    )
+    assert any(item.startswith("torch") for item in training_dependencies)
 
 
 def test_core_training_contract_does_not_import_gym_or_model_frameworks() -> None:

--- a/tests/test_architecture_contract.py
+++ b/tests/test_architecture_contract.py
@@ -15,7 +15,9 @@ def test_only_trade_rl_is_packaged() -> None:
     config = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
     assert config["project"]["name"] == "trade-rl"
-    assert config["tool"]["setuptools"]["packages"]["find"]["include"] == ["trade_rl*"]
+    assert config["tool"]["setuptools"]["packages"]["find"]["include"] == [
+        "trade_rl*"
+    ]
     assert config["project"]["scripts"] == {"trade-rl": "trade_rl.cli:main"}
 
 
@@ -63,6 +65,41 @@ def test_maintained_docs_reference_reward_schema_v4() -> None:
         text = path.read_text(encoding="utf-8").lower()
         assert "reward schema v3" not in text
         assert "reward schema v4" in text
+
+
+def test_maintained_docs_reference_serving_bundle_v5() -> None:
+    for path in (
+        Path("README.md"),
+        Path("README.ja.md"),
+        Path("docs/ARCHITECTURE.md"),
+        Path("docs/RESEARCH_STATUS.md"),
+    ):
+        text = path.read_text(encoding="utf-8").lower()
+        assert "bundle v4" not in text, path
+        assert "bundle v5" in text, path
+
+
+def test_quickstart_installs_training_dependencies_before_training() -> None:
+    text = Path("START.md").read_text(encoding="utf-8")
+    assert "uv sync --extra dev --extra train-sb3" in text
+    assert "uv run trade-rl train run" in text
+
+
+def test_architecture_doc_names_every_enforced_layer() -> None:
+    architecture = Path("docs/ARCHITECTURE.md").read_text(encoding="utf-8")
+    import_linter = Path(".importlinter").read_text(encoding="utf-8")
+    layer_block = import_linter.split("layers =", maxsplit=1)[1].split(
+        "[importlinter:contract:domain]", maxsplit=1
+    )[0]
+    enforced_layers = tuple(
+        line.strip().removeprefix("trade_rl.")
+        for line in layer_block.splitlines()
+        if line.strip().startswith("trade_rl.")
+    )
+
+    assert enforced_layers
+    for layer in enforced_layers:
+        assert layer in architecture, layer
 
 
 def test_critical_modules_do_not_disable_index_typing_file_wide() -> None:

--- a/tests/test_architecture_contract.py
+++ b/tests/test_architecture_contract.py
@@ -74,7 +74,7 @@ def test_maintained_docs_reference_serving_bundle_v5() -> None:
     ):
         text = path.read_text(encoding="utf-8").lower()
         assert "bundle v4" not in text, path
-        assert "bundle v5" in text, path
+        assert "bundle v5" in text or "bundle schema is **v5**" in text, path
 
 
 def test_quickstart_installs_training_dependencies_before_training() -> None:
@@ -101,7 +101,7 @@ def test_architecture_doc_matches_enforced_layer_order() -> None:
     documented_layers = tuple(
         line.strip().removeprefix("-> ")
         for line in documented_block.splitlines()
-        if line.strip()
+        if line.strip() and line.strip() != "text"
     )
 
     assert enforced_layers

--- a/tests/test_architecture_contract.py
+++ b/tests/test_architecture_contract.py
@@ -15,9 +15,7 @@ def test_only_trade_rl_is_packaged() -> None:
     config = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
     assert config["project"]["name"] == "trade-rl"
-    assert config["tool"]["setuptools"]["packages"]["find"]["include"] == [
-        "trade_rl*"
-    ]
+    assert config["tool"]["setuptools"]["packages"]["find"]["include"] == ["trade_rl*"]
     assert config["project"]["scripts"] == {"trade-rl": "trade_rl.cli:main"}
 
 


### PR DESCRIPTION
Superseded by merged PR #82.

PR #82 synchronized the maintained documentation against the later post-PR #78 implementation, added executable documentation contracts, and published the newer evidence-backed architecture audit. Subsequent remediation PRs #79, #85, #92, and #95 have also resolved several findings that this older draft still described as open.