### PR TITLE
refactor: decompose environment step runtime

### DIFF
--- a/docs/superpowers/plans/2026-07-22-environment-runtime-decomposition.md
+++ b/docs/superpowers/plans/2026-07-22-environment-runtime-decomposition.md
@@ -1,0 +1,401 @@
+# Environment Runtime Decomposition Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract action planning, risk projection, reward transition, and information construction from `ResidualMarketEnv.step()` into independently tested services without changing runtime behavior or public contracts.
+
+**Architecture:** Four stateless or narrowly stateful services consume immutable request dataclasses and return immutable results. `ResidualMarketEnv` remains the sole owner of Gymnasium state and applies service results in the existing order.
+
+**Tech Stack:** Python 3.12, NumPy, Gymnasium, dataclasses, Pytest, Ruff, Mypy, coverage.py, GitHub Actions.
+
+## Global Constraints
+
+- Preserve the `ResidualMarketEnv` constructor, public properties, Gymnasium tuple contract, schema versions, and environment digest payload.
+- Preserve target identity, signal-delay, risk reason ordering, reward ordering, terminal accounting, and every existing `info` key and optional-key condition.
+- Keep books, order books, pending targets, indices, action history, position ages, and diagnostics mutable only in `ResidualMarketEnv`.
+- Do not add direct exchange routing or change production `NO-GO` status.
+- Use TDD: architecture and service tests must fail before production modules are added.
+- Do not lower the existing `environment_runtime` critical branch-coverage threshold of `64.0`.
+
+---
+
+## File map
+
+- Create `trade_rl/rl/environment_decision.py`: action parsing, composition, signal delay, and decision-bar planning.
+- Create `trade_rl/rl/environment_risk.py`: emergency, pre-trade, and portfolio risk projection.
+- Create `trade_rl/rl/environment_reward.py`: reward transition input mapping.
+- Create `trade_rl/rl/environment_info.py`: stable step and terminal information dictionaries.
+- Modify `trade_rl/rl/environment.py`: instantiate and orchestrate the four services; retain thin private delegates where compatibility requires them.
+- Create `tests/architecture/test_environment_step_decomposition.py`: source and ownership contracts.
+- Create `tests/rl/test_environment_decision_service.py`: action migration, delay, and bar-count tests.
+- Create `tests/rl/test_environment_risk_service.py`: shape, emergency, and advanced-risk tests.
+- Create `tests/rl/test_environment_reward_service.py`: reward input-mapping tests.
+- Create `tests/rl/test_environment_info_service.py`: stable optional and terminal key tests.
+- Modify `pyproject.toml`: add a separate measured branch-coverage group for the new step services.
+- Create `docs/verification/2026-07-22-environment-runtime-decomposition.md`: RED/GREEN and exact-head evidence.
+
+---
+
+### Task 1: Add RED architecture contracts
+
+**Files:**
+- Create: `tests/architecture/test_environment_step_decomposition.py`
+
+**Interfaces:**
+- Consumes: current `trade_rl/rl/environment.py` source.
+- Produces: failing contracts requiring `EnvironmentDecisionPlanner`, `EnvironmentRiskProjector`, `EnvironmentRewardCoordinator`, and `EnvironmentInfoBuilder`.
+
+- [ ] **Step 1: Write failing source contracts**
+
+Require the four module paths, assert `ResidualMarketEnv` imports and constructs all four services, and assert the facade no longer directly calls `composer.compose`, `emergency_risk_monitor.assess`, `reward_tracker.step`, or constructs the large step `info` literal.
+
+- [ ] **Step 2: Run RED test**
+
+Run:
+
+```bash
+uv run pytest -q tests/architecture/test_environment_step_decomposition.py
+```
+
+Expected: FAIL because the four service modules and delegates do not yet exist.
+
+- [ ] **Step 3: Commit RED evidence**
+
+```bash
+git add tests/architecture/test_environment_step_decomposition.py
+git commit -m "test: require environment step services"
+```
+
+### Task 2: Implement decision planning service
+
+**Files:**
+- Create: `trade_rl/rl/environment_decision.py`
+- Create: `tests/rl/test_environment_decision_service.py`
+
+**Interfaces:**
+- Produces:
+
+```python
+@dataclass(frozen=True, slots=True)
+class EnvironmentDecisionRequest:
+    action: np.ndarray
+    trends: TrendTargets
+    alpha: np.ndarray
+    factor_basis: np.ndarray
+    hybrid_weights: np.ndarray
+    shadow_weights: np.ndarray
+    pending_hybrid_target: np.ndarray | None
+    pending_shadow_target: np.ndarray | None
+    current_index: int
+    end_index: int
+
+@dataclass(frozen=True, slots=True)
+class EnvironmentDecisionPlan:
+    parsed_action: ResidualAction | ResidualActionV2 | TargetWeightAction
+    maintained_action: np.ndarray
+    saturated_count: int
+    raw_max_abs: float
+    submitted_hybrid_target: np.ndarray
+    submitted_shadow_target: np.ndarray
+    executed_hybrid_target: np.ndarray
+    executed_shadow_target: np.ndarray
+    next_pending_hybrid_target: np.ndarray | None
+    next_pending_shadow_target: np.ndarray | None
+    execution_delay_warmup: bool
+    bars: int
+
+class EnvironmentDecisionPlanner:
+    def plan(self, request: EnvironmentDecisionRequest) -> EnvironmentDecisionPlan: ...
+```
+
+- [ ] **Step 1: Write failing unit tests**
+
+Cover maintained actions, legacy two-value migration, zero-delay targets, one-decision delay warm-up, pending-target execution, regular cadence, irregular cadence, invalid ended intervals, and returned-array copy isolation.
+
+- [ ] **Step 2: Run tests and confirm RED**
+
+```bash
+uv run pytest -q tests/rl/test_environment_decision_service.py
+```
+
+Expected: import failure for `trade_rl.rl.environment_decision`.
+
+- [ ] **Step 3: Implement minimal planner**
+
+Constructor dependencies are `dataset`, `action_spec`, `composer`, `pre_trade_max_gross`, `alpha_enabled`, `accept_legacy_actions`, `signal_delay_decisions`, `decision_every`, and `decision_hours`. Reuse existing action classes and `BaselineResidualComposer` without changing their behavior.
+
+- [ ] **Step 4: Run focused tests**
+
+```bash
+uv run pytest -q tests/rl/test_environment_decision_service.py tests/rl/test_target_weight_action.py tests/rl/test_environment_time_config.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add trade_rl/rl/environment_decision.py tests/rl/test_environment_decision_service.py
+git commit -m "refactor: extract environment decision planner"
+```
+
+### Task 3: Implement risk projection service
+
+**Files:**
+- Create: `trade_rl/rl/environment_risk.py`
+- Create: `tests/rl/test_environment_risk_service.py`
+
+**Interfaces:**
+- Produces:
+
+```python
+@dataclass(frozen=True, slots=True)
+class EnvironmentRiskRequest:
+    proposal: np.ndarray
+    book: BookState
+    current_index: int
+
+class EnvironmentRiskProjector:
+    def project(self, request: EnvironmentRiskRequest) -> RiskConstrainedTarget: ...
+```
+
+- [ ] **Step 1: Write failing unit tests**
+
+Cover symbol-shape rejection, non-finite rejection, quote-notional and base-volume conversion, emergency flattening, pre-trade reason ordering, advanced covariance/beta/stress input forwarding, missing-provider failure, and projection-distance calculation.
+
+- [ ] **Step 2: Run tests and confirm RED**
+
+```bash
+uv run pytest -q tests/rl/test_environment_risk_service.py
+```
+
+Expected: import failure for `trade_rl.rl.environment_risk`.
+
+- [ ] **Step 3: Implement minimal projector**
+
+Constructor dependencies are `dataset`, `emergency_risk_monitor`, `pre_trade_risk`, `portfolio_risk`, and `portfolio_risk_inputs_provider`. Move `_market_notional` and `_constrain_target` behavior without changing reason order.
+
+- [ ] **Step 4: Run focused tests**
+
+```bash
+uv run pytest -q tests/rl/test_environment_risk_service.py tests/risk tests/rl/test_emergency_drawdown.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add trade_rl/rl/environment_risk.py tests/rl/test_environment_risk_service.py
+git commit -m "refactor: extract environment risk projector"
+```
+
+### Task 4: Implement reward coordinator
+
+**Files:**
+- Create: `trade_rl/rl/environment_reward.py`
+- Create: `tests/rl/test_environment_reward_service.py`
+
+**Interfaces:**
+- Produces:
+
+```python
+@dataclass(frozen=True, slots=True)
+class EnvironmentRewardRequest:
+    hybrid_log_return: float
+    shadow_log_return: float
+    hybrid: BookState
+    shadow: BookState
+    projection_distance: float
+    hybrid_terminated: bool
+    shadow_terminated: bool
+
+class EnvironmentRewardCoordinator:
+    def step(self, request: EnvironmentRewardRequest) -> RewardBreakdown: ...
+```
+
+- [ ] **Step 1: Write failing mapping tests**
+
+Use a recording reward tracker and assert exact drawdown, margin-deficit fraction, equity fractions, projection distance, returns, and termination flags.
+
+- [ ] **Step 2: Run tests and confirm RED**
+
+```bash
+uv run pytest -q tests/rl/test_environment_reward_service.py
+```
+
+Expected: import failure for `trade_rl.rl.environment_reward`.
+
+- [ ] **Step 3: Implement minimal coordinator**
+
+Constructor dependencies are `RewardTracker` and `initial_capital`. Keep drawdown computation numerically identical to the facade implementation.
+
+- [ ] **Step 4: Run focused tests**
+
+```bash
+uv run pytest -q tests/rl/test_environment_reward_service.py tests/rl/test_reward_design.py tests/rl/test_reward_time_scaling.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add trade_rl/rl/environment_reward.py tests/rl/test_environment_reward_service.py
+git commit -m "refactor: extract environment reward coordinator"
+```
+
+### Task 5: Implement information builder
+
+**Files:**
+- Create: `trade_rl/rl/environment_info.py`
+- Create: `tests/rl/test_environment_info_service.py`
+
+**Interfaces:**
+- Produces immutable request dataclasses for step and terminal data plus:
+
+```python
+class EnvironmentInfoBuilder:
+    def step_info(self, request: EnvironmentStepInfoRequest) -> dict[str, object]: ...
+    def terminal_info(self, request: EnvironmentTerminalInfoRequest) -> dict[str, object]: ...
+```
+
+- [ ] **Step 1: Write failing contract tests**
+
+Assert the complete existing key set, reward-context fields, optional discarded target, optional hybrid/shadow liquidation, terminal metric fields, fresh dictionary creation, and copied NumPy targets.
+
+- [ ] **Step 2: Run tests and confirm RED**
+
+```bash
+uv run pytest -q tests/rl/test_environment_info_service.py
+```
+
+Expected: import failure for `trade_rl.rl.environment_info`.
+
+- [ ] **Step 3: Implement minimal builder**
+
+Move `_book_metrics`, `_terminal_info`, and the step `info` literal. Use `evaluate_performance` and `ReturnSeries` exactly as before.
+
+- [ ] **Step 4: Run focused tests**
+
+```bash
+uv run pytest -q tests/rl/test_environment_info_service.py tests/rl/test_environment_timing.py tests/rl/test_pending_order_environment.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add trade_rl/rl/environment_info.py tests/rl/test_environment_info_service.py
+git commit -m "refactor: extract environment info builder"
+```
+
+### Task 6: Integrate services into `ResidualMarketEnv`
+
+**Files:**
+- Modify: `trade_rl/rl/environment.py`
+- Modify: `tests/architecture/test_environment_step_decomposition.py`
+
+**Interfaces:**
+- Consumes all service interfaces from Tasks 2-5.
+- Preserves existing private compatibility methods as thin delegates where tests call them.
+
+- [ ] **Step 1: Add service construction in `__init__`**
+
+Instantiate the planner, projector, reward coordinator, and info builder after their dependencies are validated.
+
+- [ ] **Step 2: Replace direct step logic with orchestration**
+
+Call services in the existing order, apply mutable state only in the facade, and preserve pending-target discard and terminal-liquidation ordering.
+
+- [ ] **Step 3: Run architecture and environment regression tests**
+
+```bash
+uv run pytest -q \
+  tests/architecture/test_environment_step_decomposition.py \
+  tests/rl \
+  tests/serving/test_observation_parity.py \
+  tests/serving/test_observation_snapshot_fail_closed.py \
+  tests/e2e/test_stateful_order_replay.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run static checks**
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy .
+uv run lint-imports
+```
+
+Expected: all commands exit `0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add trade_rl/rl/environment.py tests/architecture/test_environment_step_decomposition.py
+git commit -m "refactor: delegate environment step responsibilities"
+```
+
+### Task 7: Add coverage ratchet and exact-head verification
+
+**Files:**
+- Modify: `pyproject.toml`
+- Create: `docs/verification/2026-07-22-environment-runtime-decomposition.md`
+
+- [ ] **Step 1: Run full coverage before setting threshold**
+
+```bash
+uv run pytest -q --cov=trade_rl --cov-branch --cov-report=json:coverage.json
+```
+
+Expected: full suite passes and writes `coverage.json`.
+
+- [ ] **Step 2: Calculate aggregate branch percentage**
+
+Aggregate covered and total branches for:
+
+```text
+trade_rl/rl/environment_decision.py
+trade_rl/rl/environment_risk.py
+trade_rl/rl/environment_reward.py
+trade_rl/rl/environment_info.py
+```
+
+Set `[tool.trade_rl.critical_coverage.groups.environment_step_services]` to the measured percentage rounded down to a safe tenth. Do not change the existing `environment_runtime` group.
+
+- [ ] **Step 3: Run complete local-equivalent checks**
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy .
+uv run lint-imports
+uv run pytest -q --cov=trade_rl --cov-branch --cov-report=json:coverage.json
+uv run python .github/check_critical_coverage.py coverage.json pyproject.toml
+uv run trade-rl --help
+```
+
+Expected: every command exits `0`.
+
+- [ ] **Step 4: Record RED and GREEN evidence**
+
+Document commit SHAs, workflow run IDs, test count, coverage, new ratchet, artifact IDs/digests, compatibility jobs, training image, and PostgreSQL run.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pyproject.toml docs/verification/2026-07-22-environment-runtime-decomposition.md
+git commit -m "test: ratchet environment step service coverage"
+```
+
+- [ ] **Step 6: Create stacked Draft PR**
+
+Base: `agent/fix-architecture-followup-20260722`
+
+Head: `agent/decompose-environment-runtime-20260722`
+
+The PR body must state that it is stacked on PR #79, remains `NO-GO`, and will be retargeted to `main` after PR #79 merges.

--- a/docs/superpowers/specs/2026-07-22-environment-runtime-decomposition-design.md
+++ b/docs/superpowers/specs/2026-07-22-environment-runtime-decomposition-design.md
@@ -1,0 +1,166 @@
+# Environment Runtime Decomposition Design
+
+## Context
+
+`ResidualMarketEnv` is now a Gymnasium facade over dedicated episode, execution,
+observation, and termination services. Its `step()` path still owns four distinct
+responsibilities:
+
+1. action parsing, composition, signal-delay planning, and decision-bar selection;
+2. emergency, pre-trade, and portfolio risk projection;
+3. reward transition calculation;
+4. step and terminal `info` construction.
+
+Keeping these responsibilities in the facade makes execution-sensitive changes
+hard to review and forces tests to exercise a large mutable object even when only
+one policy boundary changes.
+
+## Approaches considered
+
+### A. Private-method extraction only
+
+Split `step()` into more private methods on `ResidualMarketEnv`.
+
+This is the smallest diff, but it leaves the same ownership problem. The methods
+would still read and mutate broad environment state and would not be independently
+reusable or testable.
+
+### B. Immutable request/result services
+
+Introduce four focused services and immutable request/result dataclasses. Keep
+all Gymnasium state mutation in `ResidualMarketEnv`, while each service receives
+only the inputs required for one decision.
+
+This is the selected approach. It establishes explicit contracts without changing
+public schemas, action semantics, execution ordering, or mutable state ownership.
+
+### C. Full step state machine
+
+Represent the entire step lifecycle as a state machine with persisted phases.
+
+This could support resumable execution later, but it is unnecessarily broad for
+the current local research environment and would increase compatibility risk.
+
+## Selected architecture
+
+### `EnvironmentDecisionPlanner`
+
+Owns:
+
+- legacy and maintained action parsing;
+- baseline/residual composition;
+- submitted hybrid and shadow target creation;
+- one-decision signal-delay resolution;
+- decision-bar count calculation.
+
+It returns an immutable `EnvironmentDecisionPlan` containing the parsed action,
+maintained action vector, diagnostics inputs, submitted targets, executed targets,
+next pending targets, warm-up status, and bar count.
+
+It does not mutate environment pending targets or books.
+
+### `EnvironmentRiskProjector`
+
+Owns:
+
+- proposal shape and finiteness validation;
+- emergency-risk assessment;
+- pre-trade risk constraint;
+- causal advanced portfolio-risk input resolution;
+- portfolio-risk projection;
+- merged reason and projection-distance construction.
+
+It returns the existing `RiskConstrainedTarget`. Dataset and risk models are
+constructor dependencies; current index and book are explicit call inputs.
+
+### `EnvironmentRewardCoordinator`
+
+Owns one reward transition. It receives interval returns, current books,
+projection distance, and termination flags, and delegates to `RewardTracker`.
+It returns the existing reward breakdown. Reward-history pre-roll and reset remain
+in the facade because they belong to episode initialization rather than step
+transition planning.
+
+### `EnvironmentInfoBuilder`
+
+Owns the stable `info` contract:
+
+- per-step action, execution, risk, reward, delay, and termination fields;
+- optional discarded-target and liquidation fields;
+- terminal performance metrics and action diagnostics.
+
+It returns a new dictionary on every call and does not mutate books, reward state,
+or diagnostics. Existing key names and value types remain unchanged.
+
+### `ResidualMarketEnv`
+
+Remains responsible for:
+
+- Gymnasium `reset()` and `step()` methods;
+- mutable books, order books, pending targets, indices, action history, position
+  ages, and diagnostics;
+- ordering the planner, risk, execution, termination, reward, observation, and
+  info services;
+- environment identity and compatibility properties.
+
+The facade applies service results in the same order as the current implementation.
+
+## Step data flow
+
+1. Resolve market inputs.
+2. Ask `EnvironmentDecisionPlanner` for an immutable decision plan.
+3. Project hybrid and shadow executed targets through `EnvironmentRiskProjector`.
+4. Execute both constrained targets through `EnvironmentExecutionCoordinator`.
+5. Apply book, order-book, index, and pending-target state changes in the facade.
+6. Resolve economic and time-limit termination.
+7. Calculate reward through `EnvironmentRewardCoordinator`.
+8. Update execution observation state, previous action, and diagnostics.
+9. Build stable step/terminal information through `EnvironmentInfoBuilder`.
+10. Return the next observation and unchanged Gymnasium tuple contract.
+
+## Compatibility constraints
+
+The implementation must not change:
+
+- `ResidualMarketEnv` constructor or public properties;
+- action, observation, reward, or environment schema versions;
+- environment digest payload;
+- target identity construction or execution order;
+- signal-delay semantics;
+- risk reason ordering;
+- reward calculation order;
+- terminal accounting behavior;
+- any existing `info` key, optional-key condition, or value type;
+- direct exchange routing or production readiness status.
+
+Private compatibility methods may remain as thin delegates where tests or internal
+callers still use them.
+
+## Error handling
+
+Services fail closed on invalid action vectors, target dimensions, non-finite
+values, missing advanced risk inputs, exhausted episode intervals, and invalid
+bar counts. No service catches or downgrades existing domain exceptions.
+
+## Testing strategy
+
+1. Add architecture contracts before production code. They require the four new
+   services and delegation from `ResidualMarketEnv`.
+2. Add focused unit tests for action migration, signal delay, irregular-calendar
+   bar calculation, emergency/portfolio risk merging, reward input mapping, and
+   optional/terminal `info` fields.
+3. Run existing environment, simulation, serving-parity, telemetry, and training
+   integration tests as regression evidence.
+4. Run Ruff, format, Mypy, Import Linter, dead-code analysis, full Pytest with
+   branch coverage, critical coverage, CLI smoke, compatibility jobs, training
+   image build, and PostgreSQL Catalog workflow on the exact PR head.
+5. Add a new branch-coverage ratchet for the extracted step services using the
+   measured post-refactor coverage without reducing the existing environment
+   runtime group threshold.
+
+## Pull-request structure
+
+This is a stacked Draft PR based on
+`agent/fix-architecture-followup-20260722` because PR #79 is not yet merged. Once
+PR #79 lands, this PR can be retargeted to `main` without carrying unrelated
+changes.

--- a/docs/verification/2026-07-22-environment-runtime-decomposition.md
+++ b/docs/verification/2026-07-22-environment-runtime-decomposition.md
@@ -1,0 +1,174 @@
+# Environment Runtime Decomposition Verification
+
+Date: 2026-07-22
+
+Branch: `agent/decompose-environment-runtime-20260722`
+
+Pull request: #80
+
+Dependency base: PR #79 head
+`edaa6930ffb0b351ae5a8aa9afa6c80d47ca5e27`
+
+## Scope
+
+This change extracts four responsibilities from `ResidualMarketEnv.step()` while
+keeping all Gymnasium mutable state in the facade:
+
+- `EnvironmentDecisionPlanner`: action parsing, residual/target composition,
+  signal-delay handling, and decision-bar planning;
+- `EnvironmentRiskProjector`: emergency, pre-trade, and portfolio-risk
+  projection;
+- `EnvironmentRewardCoordinator`: reward-transition input mapping;
+- `EnvironmentInfoBuilder`: stable step and terminal information construction.
+
+The constructor, public properties, schema versions, environment digest payload,
+target identity, execution order, signal-delay semantics, risk-reason order,
+reward order, terminal accounting, and existing information keys remain unchanged.
+
+## TDD RED evidence
+
+Architecture contracts were committed before production services existed.
+
+Initial architecture RED:
+
+- head: `dc49660eb386eabcd5762ec2317c503f48a56dfd`
+- workflow run: `29906923608`
+- result: failed as intended
+- artifact: `8524221206`
+- artifact digest:
+  `sha256:daa32bbb061a793879adf8a42cd52a8331f2b53e2738f77c6cf4f325abd92d1d`
+
+The failures required the four service modules, facade construction and
+delegation, removal of direct composition/reward/info ownership from `step()`,
+and terminal information delegation.
+
+Expanded service-contract RED:
+
+- head: `29f2e6468d8e7f53e5c89beb06af3576e32cb766`
+- workflow run: `29907379481`
+- result: failed as intended with `ModuleNotFoundError` for all four service
+  modules
+- artifact: `8524403476`
+- artifact digest:
+  `sha256:2008b8ac18aa45ee08e71e4fdb27bd9578882057a39c5c8d556e467f3fe2fe1e`
+
+The RED failures were caused by missing production modules rather than malformed
+test fixtures.
+
+## Focused GREEN evidence
+
+Service implementation verification:
+
+- workflow run: `29908220862`
+- job: `88884667478`
+- Ruff formatting: passed
+- Mypy across the repository: passed
+- focused service tests: 18 passed
+- source and tests committed and pushed by the verified job
+
+Facade integration verification:
+
+- workflow run: `29909051489`, rerun attempt
+- job: `88887782701`
+- strict source transformation anchors: passed
+- Ruff/static integration: passed
+- Mypy: passed
+- environment, serving-parity, and stateful-replay regression tests: passed
+- integration commit and push: passed
+
+The first integration attempt exposed a pre-existing nondeterministic Torch
+gradient comparison outside the modified environment code. The exact same job was
+rerun without code changes and passed. No production tolerance or test threshold
+was changed.
+
+## Exact-head full verification
+
+Code and coverage-ratchet head:
+
+`549e5b9870931364caabb5d0ad00ffdfcd653c92`
+
+GitHub Actions CI run `29909971144`: success.
+
+- exact-head checkout: passed
+- Studio tests, TypeScript checking, production build, and fixed-viewport layout:
+  passed
+- workflow-security validation: passed
+- Ruff and format check: passed
+- Mypy: passed
+- Import Linter architecture contracts: passed
+- dead-code report: passed
+- recovery and structured Serving smoke: passed
+- full Pytest: `1184 passed, 2 skipped, 11 warnings`
+- full-suite duration: 89.61 seconds
+- total coverage: `83.55%`
+- total branch coverage: `70.46%`
+- critical branch-coverage checker: passed
+- CLI smoke: passed
+- Ubuntu compatibility: passed
+- Windows compatibility: passed
+- complete training-image build and packaged non-root runtime probe: passed
+
+Pytest diagnostics artifact:
+
+- artifact: `8525525728`
+- digest:
+  `sha256:ecf7e7f8e362927aca7fd018602328c83865ff260fb6c65121643a7a227ef738`
+
+PostgreSQL Catalog run `29909971171`: success.
+
+- exact-head checkout: passed
+- Compose validation: passed
+- PostgreSQL startup and readiness: passed
+- migration: passed
+- unit and integration tests: passed
+- volume cleanup: passed
+
+## Coverage ratchet
+
+The new service group contains:
+
+- `trade_rl/rl/environment_decision.py`
+- `trade_rl/rl/environment_risk.py`
+- `trade_rl/rl/environment_reward.py`
+- `trade_rl/rl/environment_info.py`
+
+Observed aggregate branch coverage:
+
+- covered branches: 33
+- total branches: 38
+- observed: `86.8421%`
+- configured minimum: `86.8%`
+
+The existing `environment_runtime` minimum remains `64.0%`; it was not reduced.
+
+## Compatibility review
+
+A commit comparison from PR #79 head to the ratchet head showed the P2-specific
+change is limited to the four service modules, `ResidualMarketEnv`, focused tests,
+coverage configuration, and design/plan documentation.
+
+Review conclusions:
+
+- books, order books, pending targets, indices, position age, previous action, and
+  diagnostics remain mutable only in `ResidualMarketEnv`;
+- services return new dataclass results or dictionaries and do not mutate facade
+  state;
+- legacy two-value residual action migration is preserved;
+- zero-delay and one-decision-delay target semantics are preserved;
+- emergency, pre-trade, and portfolio-risk reason ordering is preserved;
+- reward inputs remain numerically identical to the previous facade code;
+- optional discarded-target and liquidation information conditions are
+  preserved;
+- terminal performance metrics use the same return-series and evaluation
+  functions as before;
+- no temporary patch script or temporary verification workflow remains in the
+  pull-request diff.
+
+No critical or important review issue remained at this checkpoint.
+
+## Safety boundary
+
+- production remains `NO-GO`;
+- direct exchange routing is not implemented;
+- no profitability or exchange-equivalent fill claim is introduced;
+- PR #80 remains Draft and is not merged.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,3 +155,12 @@ paths = [
     "trade_rl/rl/environment_observation.py",
     "trade_rl/rl/environment_transition.py",
 ]
+
+[tool.trade_rl.critical_coverage.groups.environment_step_services]
+minimum = 86.8
+paths = [
+    "trade_rl/rl/environment_decision.py",
+    "trade_rl/rl/environment_risk.py",
+    "trade_rl/rl/environment_reward.py",
+    "trade_rl/rl/environment_info.py",
+]

--- a/tests/architecture/test_environment_step_decomposition.py
+++ b/tests/architecture/test_environment_step_decomposition.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+ENVIRONMENT = ROOT / "trade_rl" / "rl" / "environment.py"
+SERVICE_PATHS = (
+    ROOT / "trade_rl" / "rl" / "environment_decision.py",
+    ROOT / "trade_rl" / "rl" / "environment_risk.py",
+    ROOT / "trade_rl" / "rl" / "environment_reward.py",
+    ROOT / "trade_rl" / "rl" / "environment_info.py",
+)
+SERVICE_ATTRIBUTES = (
+    ("EnvironmentDecisionPlanner", "self._decision_planner"),
+    ("EnvironmentRiskProjector", "self._risk_projector"),
+    ("EnvironmentRewardCoordinator", "self._reward_coordinator"),
+    ("EnvironmentInfoBuilder", "self._info_builder"),
+)
+
+
+def _source(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_environment_step_services_have_dedicated_modules() -> None:
+    missing = [
+        path.relative_to(ROOT).as_posix()
+        for path in SERVICE_PATHS
+        if not path.is_file()
+    ]
+
+    assert missing == []
+
+
+def test_environment_constructs_all_step_services() -> None:
+    source = _source(ENVIRONMENT)
+
+    for symbol, attribute in SERVICE_ATTRIBUTES:
+        assert symbol in source
+        assert attribute in source
+
+
+def test_environment_step_delegates_action_risk_reward_and_info() -> None:
+    source = _source(ENVIRONMENT)
+    step_source = source.split("    def step(\n", maxsplit=1)[1]
+
+    assert "self._decision_planner.plan(" in step_source
+    assert "self._risk_projector.project(" in step_source
+    assert "self._reward_coordinator.step(" in step_source
+    assert "self._info_builder.step_info(" in step_source
+
+
+def test_environment_step_no_longer_owns_extracted_policy_logic() -> None:
+    source = _source(ENVIRONMENT)
+    step_source = source.split("    def step(\n", maxsplit=1)[1]
+
+    assert "self.composer.compose(" not in step_source
+    assert "self.reward_tracker.step(" not in step_source
+    assert "self.emergency_risk_monitor.assess(" not in step_source
+    assert "info: dict[str, object] = {" not in step_source
+
+
+def test_terminal_information_is_built_by_info_service() -> None:
+    source = _source(ENVIRONMENT)
+
+    assert "self._info_builder.terminal_info(" in source
+    assert "def _book_metrics(" not in source

--- a/tests/rl/test_environment_decision_service.py
+++ b/tests/rl/test_environment_decision_service.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from trade_rl.rl.actions import (
+    ActionMode,
+    ActionSpec,
+    BaselineResidualComposer,
+    ResidualAction,
+)
+from trade_rl.rl.environment_decision import (
+    EnvironmentDecisionPlanner,
+    EnvironmentDecisionRequest,
+)
+from trade_rl.strategies.trend import TrendTargets
+
+
+class _RegularDataset:
+    regular_cadence = True
+
+    @staticmethod
+    def bars_for_hours(hours: float) -> int:
+        return int(hours)
+
+    @staticmethod
+    def bars_until(start: int, hours: float, *, maximum_index: int) -> int:
+        del start, hours, maximum_index
+        raise AssertionError("regular cadence must not call bars_until")
+
+
+class _IrregularDataset:
+    regular_cadence = False
+
+    @staticmethod
+    def bars_for_hours(hours: float) -> int:
+        del hours
+        raise AssertionError("irregular cadence must not call bars_for_hours")
+
+    @staticmethod
+    def bars_until(start: int, hours: float, *, maximum_index: int) -> int:
+        assert start == 3
+        assert hours == 2.0
+        assert maximum_index == 9
+        return 4
+
+
+def _trends() -> TrendTargets:
+    return TrendTargets(
+        fast=np.array([0.4, -0.1]),
+        base=np.array([0.2, -0.1]),
+        slow=np.array([0.1, -0.2]),
+    )
+
+
+def _target_planner(*, delay: int = 0) -> EnvironmentDecisionPlanner:
+    return EnvironmentDecisionPlanner(
+        _RegularDataset(),
+        action_spec=ActionSpec(
+            mode=ActionMode.TARGET_WEIGHT,
+            risk_tilt_enabled=False,
+            target_weight_count=2,
+        ),
+        composer=BaselineResidualComposer(),
+        max_gross=1.0,
+        alpha_enabled=False,
+        accept_legacy_actions=False,
+        signal_delay_decisions=delay,
+        decision_every=2,
+        decision_hours=2.0,
+    )
+
+
+def _request(
+    action: np.ndarray,
+    *,
+    pending_hybrid: np.ndarray | None = None,
+    pending_shadow: np.ndarray | None = None,
+) -> EnvironmentDecisionRequest:
+    return EnvironmentDecisionRequest(
+        action=action,
+        trends=_trends(),
+        alpha=np.zeros(2),
+        factor_basis=np.empty((0, 2)),
+        hybrid_weights=np.array([0.05, -0.05]),
+        shadow_weights=np.array([0.1, -0.1]),
+        pending_hybrid_target=pending_hybrid,
+        pending_shadow_target=pending_shadow,
+        current_index=3,
+        end_index=9,
+    )
+
+
+def test_target_weight_plan_preserves_maintained_action_and_composes_target() -> None:
+    plan = _target_planner().plan(_request(np.array([1.4, -0.25])))
+
+    np.testing.assert_allclose(plan.maintained_action, np.array([1.0, -0.25]))
+    np.testing.assert_allclose(plan.submitted_hybrid_target, np.array([0.8, -0.2]))
+    np.testing.assert_allclose(plan.executed_hybrid_target, np.array([0.8, -0.2]))
+    np.testing.assert_allclose(plan.submitted_shadow_target, _trends().base)
+    assert plan.saturated_count == 1
+    assert plan.raw_max_abs == pytest.approx(1.4)
+    assert plan.execution_delay_warmup is False
+    assert plan.bars == 2
+
+
+def test_signal_delay_warmup_executes_current_weights_and_queues_submission() -> None:
+    plan = _target_planner(delay=1).plan(_request(np.array([0.3, -0.2])))
+
+    np.testing.assert_allclose(plan.executed_hybrid_target, np.array([0.05, -0.05]))
+    np.testing.assert_allclose(plan.executed_shadow_target, np.array([0.1, -0.1]))
+    np.testing.assert_allclose(plan.next_pending_hybrid_target, np.array([0.3, -0.2]))
+    np.testing.assert_allclose(plan.next_pending_shadow_target, _trends().base)
+    assert plan.execution_delay_warmup is True
+
+
+def test_signal_delay_executes_previous_pending_targets() -> None:
+    pending_hybrid = np.array([-0.2, 0.4])
+    pending_shadow = np.array([0.05, -0.05])
+
+    plan = _target_planner(delay=1).plan(
+        _request(
+            np.array([0.3, -0.2]),
+            pending_hybrid=pending_hybrid,
+            pending_shadow=pending_shadow,
+        )
+    )
+
+    np.testing.assert_allclose(plan.executed_hybrid_target, pending_hybrid)
+    np.testing.assert_allclose(plan.executed_shadow_target, pending_shadow)
+    assert plan.execution_delay_warmup is False
+    assert plan.executed_hybrid_target is not pending_hybrid
+    assert plan.executed_shadow_target is not pending_shadow
+
+
+def test_legacy_action_is_migrated_to_maintained_layout() -> None:
+    planner = EnvironmentDecisionPlanner(
+        _RegularDataset(),
+        action_spec=ActionSpec(alpha_enabled=True),
+        composer=BaselineResidualComposer(),
+        max_gross=1.0,
+        alpha_enabled=True,
+        accept_legacy_actions=True,
+        signal_delay_decisions=0,
+        decision_every=2,
+        decision_hours=2.0,
+    )
+
+    plan = planner.plan(
+        EnvironmentDecisionRequest(
+            action=np.array([0.5, 0.25]),
+            trends=_trends(),
+            alpha=np.array([0.3, -0.3]),
+            factor_basis=np.empty((0, 2)),
+            hybrid_weights=np.zeros(2),
+            shadow_weights=np.zeros(2),
+            pending_hybrid_target=None,
+            pending_shadow_target=None,
+            current_index=3,
+            end_index=9,
+        )
+    )
+
+    assert isinstance(plan.parsed_action, ResidualAction)
+    np.testing.assert_allclose(plan.maintained_action, np.array([0.5, 0.0, 0.0, 0.25]))
+
+
+def test_irregular_calendar_uses_dataset_bar_boundary() -> None:
+    planner = EnvironmentDecisionPlanner(
+        _IrregularDataset(),
+        action_spec=ActionSpec(
+            mode=ActionMode.TARGET_WEIGHT,
+            risk_tilt_enabled=False,
+            target_weight_count=2,
+        ),
+        composer=BaselineResidualComposer(),
+        max_gross=1.0,
+        alpha_enabled=False,
+        accept_legacy_actions=False,
+        signal_delay_decisions=0,
+        decision_every=None,
+        decision_hours=2.0,
+    )
+
+    assert planner.decision_bar_count(current_index=3, end_index=9) == 4
+
+
+def test_decision_bar_count_fails_after_episode_end() -> None:
+    with pytest.raises(RuntimeError, match="step called after the episode ended"):
+        _target_planner().decision_bar_count(current_index=9, end_index=9)

--- a/tests/rl/test_environment_info_service.py
+++ b/tests/rl/test_environment_info_service.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from trade_rl.rl.environment_info import (
+    EnvironmentInfoBuilder,
+    EnvironmentStepInfoRequest,
+    EnvironmentTerminalInfoRequest,
+)
+from trade_rl.rl.rewards import RewardBreakdown, RewardConfig, RewardContext
+from trade_rl.simulation.accounting import BookState
+
+
+class _Dataset:
+    periods_per_year = 365
+
+
+class _RewardTracker:
+    config = RewardConfig(baseline_underperformance_weight=0.1)
+    last_context_before = RewardContext(
+        rolling_hybrid_log_growth=0.01,
+        rolling_shadow_log_growth=0.02,
+        baseline_shortfall=0.01,
+        baseline_tolerance=0.015,
+        baseline_penalty=0.0,
+        hybrid_drawdown=0.1,
+        drawdown_severity=0.05,
+        history_bars=3,
+    )
+    last_context_after = RewardContext(
+        rolling_hybrid_log_growth=0.03,
+        rolling_shadow_log_growth=0.025,
+        baseline_shortfall=0.0,
+        baseline_tolerance=0.015,
+        baseline_penalty=0.0,
+        hybrid_drawdown=0.08,
+        drawdown_severity=0.03,
+        history_bars=4,
+    )
+
+
+def _reward() -> RewardBreakdown:
+    return RewardBreakdown(
+        absolute_log_growth=0.02,
+        excess_log_growth=0.01,
+        incremental_drawdown=0.03,
+        rolling_baseline_underperformance=0.0,
+        projection_distance=0.4,
+        terminal_equity_shortfall=0.0,
+        margin_deficit=0.0,
+        absolute_component=0.02,
+        excess_component=0.0,
+        drawdown_penalty=0.004,
+        baseline_penalty=0.002,
+        projection_penalty=0.0,
+        terminal_penalty=0.0,
+        margin_penalty=0.0,
+        unscaled_total=0.014,
+        scaled_total=1.4,
+    )
+
+
+def _book(*, cash: float = 100.0) -> BookState:
+    book = BookState.zero(2, 100.0, np.array([10.0, 20.0]))
+    book.cash = cash
+    return book
+
+
+def _execution() -> SimpleNamespace:
+    return SimpleNamespace(
+        bars_advanced=2,
+        interval_cost=0.5,
+        interval_funding=-0.1,
+        interval_gross_return=0.03,
+        interval_net_return=0.02,
+    )
+
+
+def _step_request(**overrides: object) -> EnvironmentStepInfoRequest:
+    values: dict[str, object] = {
+        "action_delta_l1": 0.3,
+        "raw_max_abs": 1.2,
+        "saturated_count": 1,
+        "composition": SimpleNamespace(proposal=np.array([0.4, -0.2])),
+        "decision_step_index": 4,
+        "hybrid_log_return": 0.02,
+        "shadow_log_return": 0.01,
+        "emergency_deleverage": False,
+        "execution_delay_warmup": True,
+        "submitted_target": np.array([0.4, -0.2]),
+        "executed_target": np.array([0.1, -0.1]),
+        "hybrid": _book(cash=95.0),
+        "reward_breakdown": _reward(),
+        "hybrid_execution": _execution(),
+        "hybrid_risk": SimpleNamespace(projection_l1=0.4),
+        "hybrid_terminated": False,
+        "shadow_execution": _execution(),
+        "shadow_risk": SimpleNamespace(projection_l1=0.0),
+        "shadow_terminated": False,
+        "liquidation_complete": True,
+        "liquidation_terminal": False,
+        "termination_reason": None,
+        "terminal_accounting_mode": "mark_to_market",
+        "terminal_liquidation_cost": 0.0,
+        "pending_target_discarded": False,
+        "discarded_pending_target": None,
+        "hybrid_liquidation": None,
+        "shadow_liquidation": None,
+    }
+    values.update(overrides)
+    return EnvironmentStepInfoRequest(**values)  # type: ignore[arg-type]
+
+
+def test_step_info_preserves_complete_stable_key_set() -> None:
+    builder = EnvironmentInfoBuilder(_Dataset(), _RewardTracker())
+
+    info = builder.step_info(_step_request())
+
+    assert set(info) == {
+        "action_delta_l1",
+        "action_raw_max_abs",
+        "action_saturated_count",
+        "bars_advanced",
+        "composition",
+        "decision_step_index",
+        "excess_log_return",
+        "emergency_deleverage",
+        "execution_delay_warmup",
+        "submitted_target",
+        "executed_target",
+        "drawdown_after",
+        "portfolio_value_after",
+        "reward_growth_raw",
+        "reward_baseline_penalty_delta",
+        "reward_baseline_penalty_weighted",
+        "reward_drawdown_penalty_delta",
+        "reward_drawdown_penalty_weighted",
+        "reward_total_raw",
+        "reward_total_scaled",
+        "reward_context_before",
+        "reward_context_after",
+        "rolling_hybrid_log_growth",
+        "rolling_baseline_log_growth",
+        "rolling_growth_gap",
+        "hybrid_execution",
+        "hybrid_risk",
+        "hybrid_terminated",
+        "interval_cost",
+        "interval_funding",
+        "interval_gross_return",
+        "interval_net_return",
+        "liquidation_complete",
+        "liquidation_terminal",
+        "projection_distance_l1",
+        "reward_breakdown",
+        "shadow_execution",
+        "shadow_interval_net_return",
+        "shadow_risk",
+        "shadow_terminated",
+        "termination_reason",
+        "terminal_accounting_mode",
+        "terminal_liquidation_cost",
+        "pending_target_discarded",
+    }
+    assert info["reward_baseline_penalty_delta"] == 0.02
+    assert info["rolling_growth_gap"] == pytest.approx(0.005)
+
+
+def test_step_info_copies_targets_and_adds_optional_fields() -> None:
+    submitted = np.array([0.4, -0.2])
+    executed = np.array([0.1, -0.1])
+    discarded = np.array([0.2, 0.0])
+    hybrid_liquidation = object()
+    shadow_liquidation = object()
+    builder = EnvironmentInfoBuilder(_Dataset(), _RewardTracker())
+
+    info = builder.step_info(
+        _step_request(
+            submitted_target=submitted,
+            executed_target=executed,
+            discarded_pending_target=discarded,
+            hybrid_liquidation=hybrid_liquidation,
+            shadow_liquidation=shadow_liquidation,
+        )
+    )
+
+    np.testing.assert_allclose(info["submitted_target"], submitted)
+    np.testing.assert_allclose(info["executed_target"], executed)
+    np.testing.assert_allclose(info["discarded_pending_target"], discarded)
+    assert info["submitted_target"] is not submitted
+    assert info["executed_target"] is not executed
+    assert info["discarded_pending_target"] is not discarded
+    assert info["hybrid_liquidation"] is hybrid_liquidation
+    assert info["shadow_liquidation"] is shadow_liquidation
+
+
+def test_terminal_info_builds_metrics_and_diagnostics() -> None:
+    hybrid = _book()
+    shadow = _book()
+    hybrid.returns_history.extend([0.01, -0.005])
+    shadow.returns_history.extend([0.005, -0.002])
+    hybrid.turnover_total = 0.4
+    shadow.turnover_total = 0.2
+    hybrid.total_cost = 0.01
+    shadow.total_cost = 0.005
+    diagnostics = object()
+    builder = EnvironmentInfoBuilder(_Dataset(), _RewardTracker())
+
+    info = builder.terminal_info(
+        EnvironmentTerminalInfoRequest(
+            episode_hours=48.0,
+            episode_seed=7,
+            action_diagnostics=diagnostics,
+            hybrid=hybrid,
+            shadow=shadow,
+            initial_state_mode="cash",
+        )
+    )
+
+    assert info["episode_hours"] == 48.0
+    assert info["episode_seed"] == 7
+    assert info["action_diagnostics"] is diagnostics
+    assert info["initial_state_mode"] == "cash"
+    assert info["hybrid_metrics"].turnover_total == 0.4
+    assert info["shadow_metrics"].turnover_total == 0.2
+    assert info["excess_total_return"] == (
+        info["hybrid_metrics"].total_return - info["shadow_metrics"].total_return
+    )

--- a/tests/rl/test_environment_reward_service.py
+++ b/tests/rl/test_environment_reward_service.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from trade_rl.rl.environment_reward import (
+    EnvironmentRewardCoordinator,
+    EnvironmentRewardRequest,
+)
+from trade_rl.rl.rewards import RewardBreakdown
+from trade_rl.simulation.accounting import BookState
+
+
+def _breakdown() -> RewardBreakdown:
+    return RewardBreakdown(
+        absolute_log_growth=0.01,
+        excess_log_growth=0.005,
+        incremental_drawdown=0.0,
+        rolling_baseline_underperformance=0.0,
+        projection_distance=0.2,
+        terminal_equity_shortfall=0.0,
+        margin_deficit=0.05,
+        absolute_component=0.01,
+        excess_component=0.0,
+        drawdown_penalty=0.0,
+        baseline_penalty=0.0,
+        projection_penalty=0.0,
+        terminal_penalty=0.0,
+        margin_penalty=0.05,
+        unscaled_total=-0.04,
+        scaled_total=-4.0,
+    )
+
+
+class _RecordingTracker:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.result = _breakdown()
+
+    def step(self, **kwargs: Any) -> RewardBreakdown:
+        self.calls.append(kwargs)
+        return self.result
+
+
+def _book(*, cash: float, peak: float, margin_deficit: float = 0.0) -> BookState:
+    book = BookState.zero(2, 100.0, np.array([10.0, 20.0]))
+    book.cash = cash
+    book.peak_value = peak
+    book.margin_deficit = margin_deficit
+    return book
+
+
+def test_reward_coordinator_maps_books_to_tracker_inputs() -> None:
+    tracker = _RecordingTracker()
+    coordinator = EnvironmentRewardCoordinator(tracker, initial_capital=100.0)
+    hybrid = _book(cash=50.0, peak=100.0, margin_deficit=5.0)
+    shadow = _book(cash=80.0, peak=100.0)
+
+    result = coordinator.step(
+        EnvironmentRewardRequest(
+            hybrid_log_return=0.01,
+            shadow_log_return=0.005,
+            hybrid=hybrid,
+            shadow=shadow,
+            projection_distance=0.2,
+            hybrid_terminated=True,
+            shadow_terminated=False,
+        )
+    )
+
+    assert result is tracker.result
+    assert tracker.calls == [
+        {
+            "hybrid_log_return": 0.01,
+            "shadow_log_return": 0.005,
+            "hybrid_drawdown": 0.5,
+            "shadow_drawdown": pytest.approx(0.2),
+            "projection_distance": 0.2,
+            "hybrid_margin_deficit_fraction": 0.05,
+            "hybrid_equity_fraction": 0.5,
+            "shadow_equity_fraction": 0.8,
+            "hybrid_terminated": True,
+            "shadow_terminated": False,
+        }
+    ]
+
+
+def test_reward_coordinator_clamps_negative_equity_fraction_to_zero() -> None:
+    tracker = _RecordingTracker()
+    coordinator = EnvironmentRewardCoordinator(tracker, initial_capital=100.0)
+    hybrid = _book(cash=-1.0, peak=100.0)
+    shadow = _book(cash=100.0, peak=100.0)
+
+    coordinator.step(
+        EnvironmentRewardRequest(
+            hybrid_log_return=-0.1,
+            shadow_log_return=0.0,
+            hybrid=hybrid,
+            shadow=shadow,
+            projection_distance=0.0,
+            hybrid_terminated=True,
+            shadow_terminated=False,
+        )
+    )
+
+    assert tracker.calls[0]["hybrid_equity_fraction"] == 0.0
+    assert tracker.calls[0]["hybrid_drawdown"] == 1.0
+
+
+def test_reward_coordinator_requires_positive_initial_capital() -> None:
+    with pytest.raises(ValueError, match="initial_capital must be positive"):
+        EnvironmentRewardCoordinator(_RecordingTracker(), initial_capital=0.0)

--- a/tests/rl/test_environment_risk_service.py
+++ b/tests/rl/test_environment_risk_service.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from trade_rl.risk.inputs import PortfolioRiskInputs
+from trade_rl.risk.portfolio import PortfolioRiskConfig, PortfolioRiskModel
+from trade_rl.risk.pretrade import PreTradeRisk, PreTradeRiskConfig
+from trade_rl.rl.environment_risk import (
+    EnvironmentRiskProjector,
+    EnvironmentRiskRequest,
+)
+from trade_rl.simulation.accounting import BookState
+
+
+class _Dataset:
+    n_symbols = 2
+    close = np.array([[10.0, 20.0], [11.0, 25.0]])
+    volume = np.array([[100.0, 5.0], [120.0, 4.0]])
+    volume_units = ("quote_notional", "base_units")
+
+
+class _EmergencyMonitor:
+    def __init__(self, *, flatten: tuple[bool, bool], reasons: tuple[str, ...]) -> None:
+        self.flatten = np.asarray(flatten, dtype=np.bool_)
+        self.reasons = reasons
+
+    def assess(
+        self,
+        dataset: object,
+        *,
+        index: int,
+        weights: np.ndarray,
+    ) -> SimpleNamespace:
+        assert dataset is not None
+        assert index == 1
+        assert weights.shape == (2,)
+        return SimpleNamespace(flatten_mask=self.flatten, reasons=self.reasons)
+
+
+class _AdvancedProvider:
+    identity_digest = "0" * 64
+    minimum_index = 1
+
+    def __init__(self) -> None:
+        self.calls: list[int] = []
+
+    def inputs(self, dataset: object, *, index: int) -> PortfolioRiskInputs:
+        assert dataset is not None
+        self.calls.append(index)
+        return PortfolioRiskInputs(
+            covariance=np.eye(2) * 0.04,
+            beta=np.array([1.0, -0.5]),
+            stress_losses=np.array([-0.2, -0.1]),
+            as_of_index=index,
+            provider_digest=self.identity_digest,
+            observation_count=10,
+        )
+
+
+def _book() -> BookState:
+    return BookState.from_weights(
+        weights=np.array([0.2, -0.2]),
+        capital=100.0,
+        prices=np.array([11.0, 25.0]),
+        max_gross=1.0,
+    )
+
+
+def test_market_notional_respects_quote_and_base_volume_units() -> None:
+    projector = EnvironmentRiskProjector(
+        _Dataset(),
+        emergency_risk_monitor=_EmergencyMonitor(flatten=(False, False), reasons=()),
+        pre_trade_risk=PreTradeRisk(),
+        portfolio_risk=PortfolioRiskModel(),
+        portfolio_risk_inputs_provider=None,
+    )
+
+    np.testing.assert_allclose(projector.market_notional(1), np.array([120.0, 100.0]))
+
+
+def test_projection_preserves_reason_order_and_projection_distance() -> None:
+    projector = EnvironmentRiskProjector(
+        _Dataset(),
+        emergency_risk_monitor=_EmergencyMonitor(
+            flatten=(False, True),
+            reasons=("market_halt",),
+        ),
+        pre_trade_risk=PreTradeRisk(
+            PreTradeRiskConfig(
+                max_gross=1.0,
+                max_abs_weight=0.4,
+                max_turnover=2.0,
+            )
+        ),
+        portfolio_risk=PortfolioRiskModel(PortfolioRiskConfig(max_net_exposure=0.2)),
+        portfolio_risk_inputs_provider=None,
+    )
+
+    result = projector.project(
+        EnvironmentRiskRequest(
+            proposal=np.array([0.8, 0.3]),
+            book=_book(),
+            current_index=1,
+        )
+    )
+
+    np.testing.assert_allclose(result.weights, np.array([0.2, 0.0]))
+    assert result.reasons == (
+        "emergency_flatten",
+        "max_abs_weight",
+        "emergency_turnover_override",
+        "market_halt",
+        "portfolio:max_net_exposure",
+    )
+    assert result.projection_l1 == pytest.approx(0.9)
+    assert result.was_constrained is True
+
+
+@pytest.mark.parametrize(
+    "proposal",
+    [np.array([0.1]), np.array([0.1, np.nan])],
+)
+def test_projection_rejects_invalid_proposals(proposal: np.ndarray) -> None:
+    projector = EnvironmentRiskProjector(
+        _Dataset(),
+        emergency_risk_monitor=_EmergencyMonitor(flatten=(False, False), reasons=()),
+        pre_trade_risk=PreTradeRisk(),
+        portfolio_risk=PortfolioRiskModel(),
+        portfolio_risk_inputs_provider=None,
+    )
+
+    with pytest.raises(ValueError, match="proposal does not match dataset symbols"):
+        projector.project(
+            EnvironmentRiskRequest(
+                proposal=proposal,
+                book=_book(),
+                current_index=1,
+            )
+        )
+
+
+def test_advanced_risk_fails_closed_without_causal_provider() -> None:
+    projector = EnvironmentRiskProjector(
+        _Dataset(),
+        emergency_risk_monitor=_EmergencyMonitor(flatten=(False, False), reasons=()),
+        pre_trade_risk=PreTradeRisk(),
+        portfolio_risk=PortfolioRiskModel(PortfolioRiskConfig(volatility_target=0.1)),
+        portfolio_risk_inputs_provider=None,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="advanced portfolio risk requires a causal input provider",
+    ):
+        projector.project(
+            EnvironmentRiskRequest(
+                proposal=np.array([0.2, -0.1]),
+                book=_book(),
+                current_index=1,
+            )
+        )
+
+
+def test_advanced_risk_uses_inputs_from_current_index() -> None:
+    provider = _AdvancedProvider()
+    projector = EnvironmentRiskProjector(
+        _Dataset(),
+        emergency_risk_monitor=_EmergencyMonitor(flatten=(False, False), reasons=()),
+        pre_trade_risk=PreTradeRisk(
+            PreTradeRiskConfig(max_abs_weight=1.0, max_turnover=2.0)
+        ),
+        portfolio_risk=PortfolioRiskModel(
+            PortfolioRiskConfig(
+                volatility_target=0.1,
+                max_abs_beta=0.2,
+                max_stress_loss=0.03,
+            )
+        ),
+        portfolio_risk_inputs_provider=provider,
+    )
+
+    result = projector.project(
+        EnvironmentRiskRequest(
+            proposal=np.array([0.5, -0.25]),
+            book=_book(),
+            current_index=1,
+        )
+    )
+
+    assert provider.calls == [1]
+    assert any(reason.startswith("portfolio:") for reason in result.reasons)

--- a/trade_rl/rl/environment.py
+++ b/trade_rl/rl/environment.py
@@ -14,8 +14,6 @@ from gymnasium import spaces
 from trade_rl.artifacts.hashing import content_digest
 from trade_rl.data.market import MarketCalendarKind, MarketDataset
 from trade_rl.domain.common import require_sha256
-from trade_rl.evaluation.metrics import PerformanceMetrics, evaluate_performance
-from trade_rl.evaluation.series import ReturnKind, ReturnSeries
 from trade_rl.risk.emergency import CausalEmergencyRiskMonitor
 from trade_rl.risk.inputs import (
     PortfolioRiskInputsProvider,
@@ -41,14 +39,31 @@ from trade_rl.rl.environment_config import (
 from trade_rl.rl.environment_config import (
     ResidualMarketEnvConfig,
 )
+from trade_rl.rl.environment_decision import (
+    EnvironmentDecisionPlanner,
+    EnvironmentDecisionRequest,
+)
 from trade_rl.rl.environment_episode import EpisodeContractSampler
 from trade_rl.rl.environment_execution import (
     EnvironmentExecutionCoordinator,
     TargetExecutionRequest,
 )
+from trade_rl.rl.environment_info import (
+    EnvironmentInfoBuilder,
+    EnvironmentStepInfoRequest,
+    EnvironmentTerminalInfoRequest,
+)
 from trade_rl.rl.environment_observation import (
     EnvironmentObservationAssembler,
     EnvironmentObservationRuntime,
+)
+from trade_rl.rl.environment_reward import (
+    EnvironmentRewardCoordinator,
+    EnvironmentRewardRequest,
+)
+from trade_rl.rl.environment_risk import (
+    EnvironmentRiskProjector,
+    EnvironmentRiskRequest,
 )
 from trade_rl.rl.environment_transition import EnvironmentTerminationCoordinator
 from trade_rl.rl.episode import (
@@ -554,6 +569,32 @@ class ResidualMarketEnv(gym.Env[np.ndarray | dict[str, np.ndarray], np.ndarray])
             action_size=self.action_spec.size,
             n_factors=self.action_spec.n_factors,
             finite_horizon=self.config.finite_horizon_observation,
+        )
+        self._decision_planner = EnvironmentDecisionPlanner(
+            dataset,
+            action_spec=self.action_spec,
+            composer=self.composer,
+            max_gross=self.pre_trade_risk.config.max_gross,
+            alpha_enabled=self.alpha_enabled,
+            accept_legacy_actions=self.config.accept_legacy_actions,
+            signal_delay_decisions=self.config.signal_delay_decisions,
+            decision_every=self.config.decision_every,
+            decision_hours=self.config.decision_hours,
+        )
+        self._risk_projector = EnvironmentRiskProjector(
+            dataset,
+            emergency_risk_monitor=self.emergency_risk_monitor,
+            pre_trade_risk=self.pre_trade_risk,
+            portfolio_risk=self.portfolio_risk,
+            portfolio_risk_inputs_provider=(self.portfolio_risk_inputs_provider),
+        )
+        self._reward_coordinator = EnvironmentRewardCoordinator(
+            self.reward_tracker,
+            initial_capital=self.config.initial_capital,
+        )
+        self._info_builder = EnvironmentInfoBuilder(
+            dataset,
+            self.reward_tracker,
         )
         self._termination_coordinator = EnvironmentTerminationCoordinator(
             config=self.config,
@@ -1184,75 +1225,19 @@ class ResidualMarketEnv(gym.Env[np.ndarray | dict[str, np.ndarray], np.ndarray])
         }
 
     def _market_notional(self, index: int) -> np.ndarray:
-        prices = self.dataset.close[index]
-        volume = self.dataset.volume[index]
-        return np.asarray(
-            [
-                float(value)
-                if str(getattr(unit, "value", unit)) == "quote_notional"
-                else float(price * value)
-                for price, value, unit in zip(
-                    prices, volume, self.dataset.volume_units, strict=True
-                )
-            ],
-            dtype=np.float64,
-        )
+        return self._risk_projector.market_notional(index)
 
     def _constrain_target(
         self,
         proposal: np.ndarray,
         book: BookState,
     ) -> RiskConstrainedTarget:
-        target = np.asarray(proposal, dtype=np.float64).reshape(-1).copy()
-        if target.shape != (self.dataset.n_symbols,) or not np.isfinite(target).all():
-            raise ValueError("proposal does not match dataset symbols")
-        assessment = self.emergency_risk_monitor.assess(
-            self.dataset,
-            index=self.current_index,
-            weights=book.weights,
-        )
-        pretrade = self.pre_trade_risk.constrain(
-            target,
-            current=book.weights,
-            drawdown=self._drawdown(book),
-            emergency_flatten_mask=assessment.flatten_mask,
-        )
-        risk_inputs = None
-        if self.portfolio_risk.requires_advanced_inputs:
-            provider = self.portfolio_risk_inputs_provider
-            if provider is None:
-                raise RuntimeError(
-                    "advanced portfolio risk requires a causal input provider"
-                )
-            risk_inputs = provider.inputs(self.dataset, index=self.current_index)
-        portfolio = self.portfolio_risk.constrain(
-            pretrade.weights,
-            portfolio_value=max(book.portfolio_value, 1e-12),
-            market_notional=self._market_notional(self.current_index),
-            covariance=None if risk_inputs is None else risk_inputs.covariance,
-            beta=None if risk_inputs is None else risk_inputs.beta,
-            stress_losses=None if risk_inputs is None else risk_inputs.stress_losses,
-        )
-        final_weights = np.asarray(portfolio.weights, dtype=np.float64)
-        constrained_turnover = float(np.abs(final_weights - book.weights).sum())
-        reasons = tuple(
-            dict.fromkeys(
-                (
-                    *pretrade.reasons,
-                    *assessment.reasons,
-                    *(f"portfolio:{item}" for item in portfolio.reasons),
-                )
+        return self._risk_projector.project(
+            EnvironmentRiskRequest(
+                proposal=proposal,
+                book=book,
+                current_index=self.current_index,
             )
-        )
-        return RiskConstrainedTarget(
-            weights=final_weights,
-            requested_turnover=pretrade.requested_turnover,
-            constrained_turnover=constrained_turnover,
-            was_constrained=bool(reasons),
-            reasons=reasons,
-            risk_scale=pretrade.risk_scale,
-            projection_l1=float(np.abs(target - final_weights).sum()),
-            turnover_overridden=pretrade.turnover_overridden,
         )
 
     def _parse_action(
@@ -1264,58 +1249,12 @@ class ResidualMarketEnv(gym.Env[np.ndarray | dict[str, np.ndarray], np.ndarray])
         int,
         float,
     ]:
-        vector = np.asarray(value, dtype=np.float64).reshape(-1)
-        if (
-            self.action_spec.mode is ActionMode.RESIDUAL
-            and vector.shape == (2,)
-            and self.config.accept_legacy_actions
-        ):
-            legacy = ResidualAction.from_array(vector)
-            migrated = np.zeros(self.action_spec.size, dtype=np.float32)
-            if legacy.trend_mix >= 0.0:
-                migrated[0] = legacy.trend_mix
-            else:
-                migrated[1] = -legacy.trend_mix
-            if self.alpha_enabled:
-                migrated[self.action_spec.names.index("alpha_scale")] = (
-                    legacy.alpha_budget
-                )
-            saturated = int(np.count_nonzero(np.abs(vector) > 1.0))
-            return (
-                legacy,
-                migrated,
-                saturated,
-                float(np.max(np.abs(vector), initial=0.0)),
-            )
-        parsed = self.action_spec.parse(value)
-        if isinstance(parsed, TargetWeightAction):
-            maintained = parsed.as_array()
-        else:
-            maintained = parsed.as_array(
-                alpha_enabled=self.alpha_enabled,
-                risk_tilt_enabled=self.action_spec.risk_tilt_enabled,
-            )
-        return (
-            parsed,
-            maintained,
-            parsed.saturated_count,
-            parsed.raw_max_abs,
-        )
+        return self._decision_planner.parse_action(value)
 
     def _decision_bar_count(self) -> int:
-        remaining = self.end_index - self.current_index
-        if remaining <= 0:
-            raise RuntimeError("step called after the episode ended")
-        if self.config.decision_every is not None:
-            return min(self.config.decision_every, remaining)
-        if self.dataset.regular_cadence:
-            return min(
-                self.dataset.bars_for_hours(self.config.decision_hours), remaining
-            )
-        return self.dataset.bars_until(
-            self.current_index,
-            self.config.decision_hours,
-            maximum_index=self.end_index,
+        return self._decision_planner.decision_bar_count(
+            current_index=self.current_index,
+            end_index=self.end_index,
         )
 
     @staticmethod
@@ -1372,49 +1311,43 @@ class ResidualMarketEnv(gym.Env[np.ndarray | dict[str, np.ndarray], np.ndarray])
         if self.current_index >= self.end_index:
             raise RuntimeError("step called after the episode ended")
         trends, alpha, factor_basis = self._market_inputs()
-        parsed_action, maintained_action, saturated_count, raw_max_abs = (
-            self._parse_action(action)
-        )
-        composition = self.composer.compose(
-            parsed_action,
-            trends,
-            alpha,
-            alpha_enabled=self.alpha_enabled,
-            factor_basis=factor_basis,
-            max_gross=self.pre_trade_risk.config.max_gross,
-        )
-        submitted_hybrid_target = np.asarray(
-            composition.proposal, dtype=np.float64
-        ).copy()
-        submitted_shadow_target = np.asarray(trends.base, dtype=np.float64).copy()
-        execution_delay_warmup = False
-        if self.config.signal_delay_decisions == 0:
-            executed_hybrid_target = submitted_hybrid_target
-            executed_shadow_target = submitted_shadow_target
-        else:
-            execution_delay_warmup = self._pending_hybrid_target is None
-            executed_hybrid_target = (
-                self.hybrid.weights.copy()
-                if self._pending_hybrid_target is None
-                else self._pending_hybrid_target.copy()
+        decision = self._decision_planner.plan(
+            EnvironmentDecisionRequest(
+                action=action,
+                trends=trends,
+                alpha=alpha,
+                factor_basis=factor_basis,
+                hybrid_weights=self.hybrid.weights,
+                shadow_weights=self.shadow.weights,
+                pending_hybrid_target=self._pending_hybrid_target,
+                pending_shadow_target=self._pending_shadow_target,
+                current_index=self.current_index,
+                end_index=self.end_index,
             )
-            executed_shadow_target = (
-                self.shadow.weights.copy()
-                if self._pending_shadow_target is None
-                else self._pending_shadow_target.copy()
+        )
+        self._pending_hybrid_target = decision.next_pending_hybrid_target
+        self._pending_shadow_target = decision.next_pending_shadow_target
+        hybrid_risk = self._risk_projector.project(
+            EnvironmentRiskRequest(
+                proposal=decision.executed_hybrid_target,
+                book=self.hybrid,
+                current_index=self.current_index,
             )
-            self._pending_hybrid_target = submitted_hybrid_target
-            self._pending_shadow_target = submitted_shadow_target
-        hybrid_risk = self._constrain_target(executed_hybrid_target, self.hybrid)
-        shadow_risk = self._constrain_target(executed_shadow_target, self.shadow)
-        bars = self._decision_bar_count()
+        )
+        shadow_risk = self._risk_projector.project(
+            EnvironmentRiskRequest(
+                proposal=decision.executed_shadow_target,
+                book=self.shadow,
+                current_index=self.current_index,
+            )
+        )
         previous_hybrid_weights = self.hybrid.weights.copy()
         hybrid_execution = self._execute_stateful_target(
             executor=self.hybrid_executor,
             book=self.hybrid,
             order_book=self._hybrid_order_book,
             target=hybrid_risk.weights,
-            bars=bars,
+            bars=decision.bars,
             book_kind="hybrid",
         )
         shadow_execution = self._execute_stateful_target(
@@ -1422,7 +1355,7 @@ class ResidualMarketEnv(gym.Env[np.ndarray | dict[str, np.ndarray], np.ndarray])
             book=self.shadow,
             order_book=self._shadow_order_book,
             target=shadow_risk.weights,
-            bars=bars,
+            bars=decision.bars,
             book_kind="shadow",
         )
         if hybrid_execution.bars_advanced != shadow_execution.bars_advanced:
@@ -1471,33 +1404,30 @@ class ResidualMarketEnv(gym.Env[np.ndarray | dict[str, np.ndarray], np.ndarray])
         economic_transition = transition.economic_transition
         terminated = economic_transition.terminated
         truncated = economic_transition.truncated
-        action_delta_l1 = float(np.abs(maintained_action - self._previous_action).sum())
+        action_delta_l1 = float(
+            np.abs(decision.maintained_action - self._previous_action).sum()
+        )
         projection_distance = hybrid_risk.projection_l1
-        reward_breakdown = self.reward_tracker.step(
-            hybrid_log_return=hybrid_log_return,
-            shadow_log_return=shadow_log_return,
-            hybrid_drawdown=self._drawdown(self.hybrid),
-            shadow_drawdown=self._drawdown(self.shadow),
-            projection_distance=projection_distance,
-            hybrid_margin_deficit_fraction=(
-                self.hybrid.margin_deficit / self.config.initial_capital
-            ),
-            hybrid_equity_fraction=max(self.hybrid.portfolio_value, 0.0)
-            / self.config.initial_capital,
-            shadow_equity_fraction=max(self.shadow.portfolio_value, 0.0)
-            / self.config.initial_capital,
-            hybrid_terminated=hybrid_terminated,
-            shadow_terminated=shadow_terminated,
+        reward_breakdown = self._reward_coordinator.step(
+            EnvironmentRewardRequest(
+                hybrid_log_return=hybrid_log_return,
+                shadow_log_return=shadow_log_return,
+                hybrid=self.hybrid,
+                shadow=self.shadow,
+                projection_distance=projection_distance,
+                hybrid_terminated=hybrid_terminated,
+                shadow_terminated=shadow_terminated,
+            )
         )
         self._execution_state = self._execution_observation_state(
             requested_weights=hybrid_risk.weights,
             result=hybrid_execution,
             previous_weights=previous_hybrid_weights,
         )
-        self._previous_action = maintained_action.copy()
+        self._previous_action = decision.maintained_action.copy()
         self._action_diagnostics.update(
-            action=maintained_action,
-            saturated_count=saturated_count,
+            action=decision.maintained_action,
+            saturated_count=decision.saturated_count,
             action_delta_l1=action_delta_l1,
             projection_l1=projection_distance,
             constrained=hybrid_risk.was_constrained,
@@ -1516,69 +1446,38 @@ class ResidualMarketEnv(gym.Env[np.ndarray | dict[str, np.ndarray], np.ndarray])
             if liquidation_terminal and hybrid_liquidation is not None
             else 0.0
         )
-        info: dict[str, object] = {
-            "action_delta_l1": action_delta_l1,
-            "action_raw_max_abs": raw_max_abs,
-            "action_saturated_count": saturated_count,
-            "bars_advanced": hybrid_execution.bars_advanced,
-            "composition": composition,
-            "decision_step_index": self._decision_step_index,
-            "excess_log_return": hybrid_log_return - shadow_log_return,
-            "emergency_deleverage": emergency_deleverage,
-            "execution_delay_warmup": execution_delay_warmup,
-            "submitted_target": submitted_hybrid_target.copy(),
-            "executed_target": executed_hybrid_target.copy(),
-            "drawdown_after": self._drawdown(self.hybrid),
-            "portfolio_value_after": self.hybrid.portfolio_value,
-            "reward_growth_raw": reward_breakdown.absolute_log_growth,
-            "reward_baseline_penalty_delta": (
-                0.0
-                if self.reward_tracker.config.baseline_underperformance_weight == 0.0
-                else reward_breakdown.baseline_penalty
-                / self.reward_tracker.config.baseline_underperformance_weight
-            ),
-            "reward_baseline_penalty_weighted": reward_breakdown.baseline_penalty,
-            "reward_drawdown_penalty_delta": reward_breakdown.incremental_drawdown,
-            "reward_drawdown_penalty_weighted": reward_breakdown.drawdown_penalty,
-            "reward_total_raw": reward_breakdown.unscaled_total,
-            "reward_total_scaled": reward_breakdown.scaled_total,
-            "reward_context_before": self.reward_tracker.last_context_before,
-            "reward_context_after": self.reward_tracker.last_context_after,
-            "rolling_hybrid_log_growth": (
-                self.reward_tracker.last_context_after.rolling_hybrid_log_growth
-            ),
-            "rolling_baseline_log_growth": (
-                self.reward_tracker.last_context_after.rolling_shadow_log_growth
-            ),
-            "rolling_growth_gap": (
-                self.reward_tracker.last_context_after.rolling_growth_gap
-            ),
-            "hybrid_execution": hybrid_execution,
-            "hybrid_risk": hybrid_risk,
-            "hybrid_terminated": hybrid_terminated,
-            "interval_cost": hybrid_execution.interval_cost,
-            "interval_funding": hybrid_execution.interval_funding,
-            "interval_gross_return": hybrid_execution.interval_gross_return,
-            "interval_net_return": hybrid_execution.interval_net_return,
-            "liquidation_complete": liquidation_complete,
-            "liquidation_terminal": liquidation_terminal,
-            "projection_distance_l1": projection_distance,
-            "reward_breakdown": reward_breakdown,
-            "shadow_execution": shadow_execution,
-            "shadow_interval_net_return": shadow_execution.interval_net_return,
-            "shadow_risk": shadow_risk,
-            "shadow_terminated": shadow_terminated,
-            "termination_reason": termination_reason,
-            "terminal_accounting_mode": terminal_accounting_mode,
-            "terminal_liquidation_cost": terminal_liquidation_cost,
-            "pending_target_discarded": pending_target_discarded,
-        }
-        if discarded_pending_target is not None:
-            info["discarded_pending_target"] = discarded_pending_target
-        if hybrid_liquidation is not None:
-            info["hybrid_liquidation"] = hybrid_liquidation
-        if shadow_liquidation is not None:
-            info["shadow_liquidation"] = shadow_liquidation
+        info = self._info_builder.step_info(
+            EnvironmentStepInfoRequest(
+                action_delta_l1=action_delta_l1,
+                raw_max_abs=decision.raw_max_abs,
+                saturated_count=decision.saturated_count,
+                composition=decision.composition,
+                decision_step_index=self._decision_step_index,
+                hybrid_log_return=hybrid_log_return,
+                shadow_log_return=shadow_log_return,
+                emergency_deleverage=emergency_deleverage,
+                execution_delay_warmup=decision.execution_delay_warmup,
+                submitted_target=decision.submitted_hybrid_target,
+                executed_target=decision.executed_hybrid_target,
+                hybrid=self.hybrid,
+                reward_breakdown=reward_breakdown,
+                hybrid_execution=hybrid_execution,
+                hybrid_risk=hybrid_risk,
+                hybrid_terminated=hybrid_terminated,
+                shadow_execution=shadow_execution,
+                shadow_risk=shadow_risk,
+                shadow_terminated=shadow_terminated,
+                liquidation_complete=liquidation_complete,
+                liquidation_terminal=liquidation_terminal,
+                termination_reason=termination_reason,
+                terminal_accounting_mode=terminal_accounting_mode,
+                terminal_liquidation_cost=terminal_liquidation_cost,
+                pending_target_discarded=pending_target_discarded,
+                discarded_pending_target=discarded_pending_target,
+                hybrid_liquidation=hybrid_liquidation,
+                shadow_liquidation=shadow_liquidation,
+            )
+        )
         if terminated or truncated:
             info.update(self._terminal_info())
         return (
@@ -1589,32 +1488,14 @@ class ResidualMarketEnv(gym.Env[np.ndarray | dict[str, np.ndarray], np.ndarray])
             info,
         )
 
-    def _book_metrics(self, book: BookState) -> PerformanceMetrics:
-        return evaluate_performance(
-            ReturnSeries(
-                values=tuple(book.returns_history),
-                kind=ReturnKind.BASE_BAR,
-                periods_per_year=self.dataset.periods_per_year,
-            ),
-            turnover_total=book.turnover_total,
-            total_cost=book.total_cost,
-            funding_pnl=book.funding_pnl - book.borrow_cost,
-            n_trades=book.fill_count,
-        )
-
     def _terminal_info(self) -> dict[str, object]:
-        hybrid_metrics = self._book_metrics(self.hybrid)
-        shadow_metrics = self._book_metrics(self.shadow)
-        return {
-            "episode_hours": self._episode_hours,
-            "episode_seed": self._episode_seed,
-            "action_diagnostics": self._action_diagnostics.snapshot(),
-            "hybrid_metrics": hybrid_metrics,
-            "hybrid_rebalance_events": self.hybrid.rebalance_events,
-            "initial_state_mode": self._initial_state_mode,
-            "shadow_metrics": shadow_metrics,
-            "shadow_rebalance_events": self.shadow.rebalance_events,
-            "excess_total_return": (
-                hybrid_metrics.total_return - shadow_metrics.total_return
-            ),
-        }
+        return self._info_builder.terminal_info(
+            EnvironmentTerminalInfoRequest(
+                episode_hours=self._episode_hours,
+                episode_seed=self._episode_seed,
+                action_diagnostics=self._action_diagnostics.snapshot(),
+                hybrid=self.hybrid,
+                shadow=self.shadow,
+                initial_state_mode=self._initial_state_mode,
+            )
+        )

--- a/trade_rl/rl/environment_decision.py
+++ b/trade_rl/rl/environment_decision.py
@@ -1,0 +1,228 @@
+"""Immutable action and execution-delay planning for one environment decision."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import numpy as np
+
+from trade_rl.rl.actions import (
+    ActionMode,
+    ActionSpec,
+    BaselineResidualComposer,
+    ResidualAction,
+    ResidualActionV2,
+    ResidualComposition,
+    TargetWeightAction,
+)
+from trade_rl.strategies.trend import TrendTargets
+
+
+class DecisionCalendar(Protocol):
+    @property
+    def regular_cadence(self) -> bool: ...
+
+    def bars_for_hours(self, hours: float) -> int: ...
+
+    def bars_until(
+        self,
+        start: int,
+        hours: float,
+        *,
+        maximum_index: int,
+    ) -> int: ...
+
+
+@dataclass(frozen=True, slots=True)
+class EnvironmentDecisionRequest:
+    action: np.ndarray
+    trends: TrendTargets
+    alpha: np.ndarray
+    factor_basis: np.ndarray
+    hybrid_weights: np.ndarray
+    shadow_weights: np.ndarray
+    pending_hybrid_target: np.ndarray | None
+    pending_shadow_target: np.ndarray | None
+    current_index: int
+    end_index: int
+
+
+@dataclass(frozen=True, slots=True)
+class EnvironmentDecisionPlan:
+    parsed_action: ResidualAction | ResidualActionV2 | TargetWeightAction
+    maintained_action: np.ndarray
+    saturated_count: int
+    raw_max_abs: float
+    composition: ResidualComposition
+    submitted_hybrid_target: np.ndarray
+    submitted_shadow_target: np.ndarray
+    executed_hybrid_target: np.ndarray
+    executed_shadow_target: np.ndarray
+    next_pending_hybrid_target: np.ndarray | None
+    next_pending_shadow_target: np.ndarray | None
+    execution_delay_warmup: bool
+    bars: int
+
+
+class EnvironmentDecisionPlanner:
+    """Parse actions and resolve causal targets without mutating environment state."""
+
+    def __init__(
+        self,
+        dataset: DecisionCalendar,
+        *,
+        action_spec: ActionSpec,
+        composer: BaselineResidualComposer,
+        max_gross: float,
+        alpha_enabled: bool,
+        accept_legacy_actions: bool,
+        signal_delay_decisions: int,
+        decision_every: int | None,
+        decision_hours: float,
+    ) -> None:
+        if not np.isfinite(max_gross) or max_gross <= 0.0:
+            raise ValueError("max_gross must be finite and positive")
+        if signal_delay_decisions not in (0, 1):
+            raise ValueError("signal_delay_decisions must be zero or one")
+        if decision_every is not None and decision_every <= 0:
+            raise ValueError("decision_every must be positive")
+        if not np.isfinite(decision_hours) or decision_hours <= 0.0:
+            raise ValueError("decision_hours must be finite and positive")
+        self.dataset = dataset
+        self.action_spec = action_spec
+        self.composer = composer
+        self.max_gross = float(max_gross)
+        self.alpha_enabled = bool(alpha_enabled)
+        self.accept_legacy_actions = bool(accept_legacy_actions)
+        self.signal_delay_decisions = signal_delay_decisions
+        self.decision_every = decision_every
+        self.decision_hours = float(decision_hours)
+
+    def parse_action(
+        self,
+        value: np.ndarray,
+    ) -> tuple[
+        ResidualAction | ResidualActionV2 | TargetWeightAction,
+        np.ndarray,
+        int,
+        float,
+    ]:
+        vector = np.asarray(value, dtype=np.float64).reshape(-1)
+        if (
+            self.action_spec.mode is ActionMode.RESIDUAL
+            and vector.shape == (2,)
+            and self.accept_legacy_actions
+        ):
+            legacy = ResidualAction.from_array(vector)
+            migrated = np.zeros(self.action_spec.size, dtype=np.float32)
+            if legacy.trend_mix >= 0.0:
+                migrated[0] = legacy.trend_mix
+            else:
+                migrated[1] = -legacy.trend_mix
+            if self.alpha_enabled:
+                migrated[self.action_spec.names.index("alpha_scale")] = (
+                    legacy.alpha_budget
+                )
+            return (
+                legacy,
+                migrated,
+                int(np.count_nonzero(np.abs(vector) > 1.0)),
+                float(np.max(np.abs(vector), initial=0.0)),
+            )
+        parsed = self.action_spec.parse(value)
+        if isinstance(parsed, TargetWeightAction):
+            maintained = parsed.as_array()
+        else:
+            maintained = parsed.as_array(
+                alpha_enabled=self.alpha_enabled,
+                risk_tilt_enabled=self.action_spec.risk_tilt_enabled,
+            )
+        return (
+            parsed,
+            maintained,
+            parsed.saturated_count,
+            parsed.raw_max_abs,
+        )
+
+    def decision_bar_count(self, *, current_index: int, end_index: int) -> int:
+        remaining = end_index - current_index
+        if remaining <= 0:
+            raise RuntimeError("step called after the episode ended")
+        if self.decision_every is not None:
+            return min(self.decision_every, remaining)
+        if self.dataset.regular_cadence:
+            return min(self.dataset.bars_for_hours(self.decision_hours), remaining)
+        return self.dataset.bars_until(
+            current_index,
+            self.decision_hours,
+            maximum_index=end_index,
+        )
+
+    def plan(self, request: EnvironmentDecisionRequest) -> EnvironmentDecisionPlan:
+        parsed, maintained, saturated_count, raw_max_abs = self.parse_action(
+            request.action
+        )
+        composition = self.composer.compose(
+            parsed,
+            request.trends,
+            request.alpha,
+            alpha_enabled=self.alpha_enabled,
+            factor_basis=request.factor_basis,
+            max_gross=self.max_gross,
+        )
+        submitted_hybrid = (
+            np.asarray(composition.proposal, dtype=np.float64).reshape(-1).copy()
+        )
+        submitted_shadow = (
+            np.asarray(request.trends.base, dtype=np.float64).reshape(-1).copy()
+        )
+        execution_delay_warmup = False
+        next_pending_hybrid: np.ndarray | None = None
+        next_pending_shadow: np.ndarray | None = None
+        if self.signal_delay_decisions == 0:
+            executed_hybrid = submitted_hybrid.copy()
+            executed_shadow = submitted_shadow.copy()
+        else:
+            execution_delay_warmup = request.pending_hybrid_target is None
+            executed_hybrid = (
+                np.asarray(request.hybrid_weights, dtype=np.float64).reshape(-1).copy()
+                if request.pending_hybrid_target is None
+                else np.asarray(request.pending_hybrid_target, dtype=np.float64)
+                .reshape(-1)
+                .copy()
+            )
+            executed_shadow = (
+                np.asarray(request.shadow_weights, dtype=np.float64).reshape(-1).copy()
+                if request.pending_shadow_target is None
+                else np.asarray(request.pending_shadow_target, dtype=np.float64)
+                .reshape(-1)
+                .copy()
+            )
+            next_pending_hybrid = submitted_hybrid.copy()
+            next_pending_shadow = submitted_shadow.copy()
+        return EnvironmentDecisionPlan(
+            parsed_action=parsed,
+            maintained_action=np.asarray(maintained, dtype=np.float32).copy(),
+            saturated_count=saturated_count,
+            raw_max_abs=raw_max_abs,
+            composition=composition,
+            submitted_hybrid_target=submitted_hybrid,
+            submitted_shadow_target=submitted_shadow,
+            executed_hybrid_target=executed_hybrid,
+            executed_shadow_target=executed_shadow,
+            next_pending_hybrid_target=next_pending_hybrid,
+            next_pending_shadow_target=next_pending_shadow,
+            execution_delay_warmup=execution_delay_warmup,
+            bars=self.decision_bar_count(
+                current_index=request.current_index,
+                end_index=request.end_index,
+            ),
+        )
+
+
+__all__ = [
+    "EnvironmentDecisionPlan",
+    "EnvironmentDecisionPlanner",
+    "EnvironmentDecisionRequest",
+]

--- a/trade_rl/rl/environment_info.py
+++ b/trade_rl/rl/environment_info.py
@@ -1,0 +1,224 @@
+"""Stable step and terminal information construction for the market environment."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import numpy as np
+
+from trade_rl.evaluation.metrics import PerformanceMetrics, evaluate_performance
+from trade_rl.evaluation.series import ReturnKind, ReturnSeries
+from trade_rl.rl.rewards import RewardBreakdown, RewardConfig, RewardContext
+from trade_rl.simulation.accounting import BookState
+
+
+class InfoDataset(Protocol):
+    @property
+    def periods_per_year(self) -> int: ...
+
+
+class RewardInfoSource(Protocol):
+    @property
+    def config(self) -> RewardConfig: ...
+
+    @property
+    def last_context_before(self) -> RewardContext: ...
+
+    @property
+    def last_context_after(self) -> RewardContext: ...
+
+
+class ExecutionInfo(Protocol):
+    @property
+    def bars_advanced(self) -> int: ...
+
+    @property
+    def interval_cost(self) -> float: ...
+
+    @property
+    def interval_funding(self) -> float: ...
+
+    @property
+    def interval_gross_return(self) -> float: ...
+
+    @property
+    def interval_net_return(self) -> float: ...
+
+
+class RiskInfo(Protocol):
+    @property
+    def projection_l1(self) -> float: ...
+
+
+@dataclass(frozen=True, slots=True)
+class EnvironmentStepInfoRequest:
+    action_delta_l1: float
+    raw_max_abs: float
+    saturated_count: int
+    composition: object
+    decision_step_index: int
+    hybrid_log_return: float
+    shadow_log_return: float
+    emergency_deleverage: bool
+    execution_delay_warmup: bool
+    submitted_target: np.ndarray
+    executed_target: np.ndarray
+    hybrid: BookState
+    reward_breakdown: RewardBreakdown
+    hybrid_execution: ExecutionInfo
+    hybrid_risk: RiskInfo
+    hybrid_terminated: bool
+    shadow_execution: ExecutionInfo
+    shadow_risk: RiskInfo
+    shadow_terminated: bool
+    liquidation_complete: bool
+    liquidation_terminal: bool
+    termination_reason: object | None
+    terminal_accounting_mode: str
+    terminal_liquidation_cost: float
+    pending_target_discarded: bool
+    discarded_pending_target: np.ndarray | None
+    hybrid_liquidation: object | None
+    shadow_liquidation: object | None
+
+
+@dataclass(frozen=True, slots=True)
+class EnvironmentTerminalInfoRequest:
+    episode_hours: float
+    episode_seed: int
+    action_diagnostics: object
+    hybrid: BookState
+    shadow: BookState
+    initial_state_mode: str
+
+
+class EnvironmentInfoBuilder:
+    """Build fresh audit dictionaries while preserving the stable key contract."""
+
+    def __init__(
+        self,
+        dataset: InfoDataset,
+        reward_tracker: RewardInfoSource,
+    ) -> None:
+        self.dataset = dataset
+        self.reward_tracker = reward_tracker
+
+    @staticmethod
+    def drawdown(book: BookState) -> float:
+        value = max(book.portfolio_value, 0.0)
+        return min(
+            1.0,
+            max(0.0, 1.0 - value / max(book.peak_value, value, 1e-12)),
+        )
+
+    def step_info(self, request: EnvironmentStepInfoRequest) -> dict[str, object]:
+        reward = request.reward_breakdown
+        before = self.reward_tracker.last_context_before
+        after = self.reward_tracker.last_context_after
+        baseline_weight = self.reward_tracker.config.baseline_underperformance_weight
+        info: dict[str, object] = {
+            "action_delta_l1": request.action_delta_l1,
+            "action_raw_max_abs": request.raw_max_abs,
+            "action_saturated_count": request.saturated_count,
+            "bars_advanced": request.hybrid_execution.bars_advanced,
+            "composition": request.composition,
+            "decision_step_index": request.decision_step_index,
+            "excess_log_return": (
+                request.hybrid_log_return - request.shadow_log_return
+            ),
+            "emergency_deleverage": request.emergency_deleverage,
+            "execution_delay_warmup": request.execution_delay_warmup,
+            "submitted_target": np.asarray(
+                request.submitted_target, dtype=np.float64
+            ).copy(),
+            "executed_target": np.asarray(
+                request.executed_target, dtype=np.float64
+            ).copy(),
+            "drawdown_after": self.drawdown(request.hybrid),
+            "portfolio_value_after": request.hybrid.portfolio_value,
+            "reward_growth_raw": reward.absolute_log_growth,
+            "reward_baseline_penalty_delta": (
+                0.0
+                if baseline_weight == 0.0
+                else reward.baseline_penalty / baseline_weight
+            ),
+            "reward_baseline_penalty_weighted": reward.baseline_penalty,
+            "reward_drawdown_penalty_delta": reward.incremental_drawdown,
+            "reward_drawdown_penalty_weighted": reward.drawdown_penalty,
+            "reward_total_raw": reward.unscaled_total,
+            "reward_total_scaled": reward.scaled_total,
+            "reward_context_before": before,
+            "reward_context_after": after,
+            "rolling_hybrid_log_growth": after.rolling_hybrid_log_growth,
+            "rolling_baseline_log_growth": after.rolling_shadow_log_growth,
+            "rolling_growth_gap": after.rolling_growth_gap,
+            "hybrid_execution": request.hybrid_execution,
+            "hybrid_risk": request.hybrid_risk,
+            "hybrid_terminated": request.hybrid_terminated,
+            "interval_cost": request.hybrid_execution.interval_cost,
+            "interval_funding": request.hybrid_execution.interval_funding,
+            "interval_gross_return": request.hybrid_execution.interval_gross_return,
+            "interval_net_return": request.hybrid_execution.interval_net_return,
+            "liquidation_complete": request.liquidation_complete,
+            "liquidation_terminal": request.liquidation_terminal,
+            "projection_distance_l1": request.hybrid_risk.projection_l1,
+            "reward_breakdown": reward,
+            "shadow_execution": request.shadow_execution,
+            "shadow_interval_net_return": request.shadow_execution.interval_net_return,
+            "shadow_risk": request.shadow_risk,
+            "shadow_terminated": request.shadow_terminated,
+            "termination_reason": request.termination_reason,
+            "terminal_accounting_mode": request.terminal_accounting_mode,
+            "terminal_liquidation_cost": request.terminal_liquidation_cost,
+            "pending_target_discarded": request.pending_target_discarded,
+        }
+        if request.discarded_pending_target is not None:
+            info["discarded_pending_target"] = np.asarray(
+                request.discarded_pending_target, dtype=np.float64
+            ).copy()
+        if request.hybrid_liquidation is not None:
+            info["hybrid_liquidation"] = request.hybrid_liquidation
+        if request.shadow_liquidation is not None:
+            info["shadow_liquidation"] = request.shadow_liquidation
+        return info
+
+    def book_metrics(self, book: BookState) -> PerformanceMetrics:
+        return evaluate_performance(
+            ReturnSeries(
+                values=tuple(book.returns_history),
+                kind=ReturnKind.BASE_BAR,
+                periods_per_year=self.dataset.periods_per_year,
+            ),
+            turnover_total=book.turnover_total,
+            total_cost=book.total_cost,
+            funding_pnl=book.funding_pnl - book.borrow_cost,
+            n_trades=book.fill_count,
+        )
+
+    def terminal_info(
+        self,
+        request: EnvironmentTerminalInfoRequest,
+    ) -> dict[str, object]:
+        hybrid_metrics = self.book_metrics(request.hybrid)
+        shadow_metrics = self.book_metrics(request.shadow)
+        return {
+            "episode_hours": request.episode_hours,
+            "episode_seed": request.episode_seed,
+            "action_diagnostics": request.action_diagnostics,
+            "hybrid_metrics": hybrid_metrics,
+            "hybrid_rebalance_events": request.hybrid.rebalance_events,
+            "initial_state_mode": request.initial_state_mode,
+            "shadow_metrics": shadow_metrics,
+            "shadow_rebalance_events": request.shadow.rebalance_events,
+            "excess_total_return": (
+                hybrid_metrics.total_return - shadow_metrics.total_return
+            ),
+        }
+
+
+__all__ = [
+    "EnvironmentInfoBuilder",
+    "EnvironmentStepInfoRequest",
+    "EnvironmentTerminalInfoRequest",
+]

--- a/trade_rl/rl/environment_reward.py
+++ b/trade_rl/rl/environment_reward.py
@@ -1,0 +1,88 @@
+"""Reward transition coordination for one environment decision."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import numpy as np
+
+from trade_rl.rl.rewards import RewardBreakdown
+from trade_rl.simulation.accounting import BookState
+
+
+class RewardTrackerLike(Protocol):
+    def step(
+        self,
+        *,
+        hybrid_log_return: float,
+        shadow_log_return: float,
+        hybrid_drawdown: float,
+        shadow_drawdown: float,
+        projection_distance: float = 0.0,
+        hybrid_margin_deficit_fraction: float = 0.0,
+        hybrid_equity_fraction: float = 1.0,
+        shadow_equity_fraction: float = 1.0,
+        hybrid_terminated: bool = False,
+        shadow_terminated: bool = False,
+    ) -> RewardBreakdown: ...
+
+
+@dataclass(frozen=True, slots=True)
+class EnvironmentRewardRequest:
+    hybrid_log_return: float
+    shadow_log_return: float
+    hybrid: BookState
+    shadow: BookState
+    projection_distance: float
+    hybrid_terminated: bool
+    shadow_terminated: bool
+
+
+class EnvironmentRewardCoordinator:
+    """Map environment account state into the stable reward-tracker contract."""
+
+    def __init__(
+        self,
+        reward_tracker: RewardTrackerLike,
+        *,
+        initial_capital: float,
+    ) -> None:
+        if not np.isfinite(initial_capital) or initial_capital <= 0.0:
+            raise ValueError("initial_capital must be positive")
+        self.reward_tracker = reward_tracker
+        self.initial_capital = float(initial_capital)
+
+    @staticmethod
+    def drawdown(book: BookState) -> float:
+        value = max(book.portfolio_value, 0.0)
+        return min(
+            1.0,
+            max(0.0, 1.0 - value / max(book.peak_value, value, 1e-12)),
+        )
+
+    def step(self, request: EnvironmentRewardRequest) -> RewardBreakdown:
+        return self.reward_tracker.step(
+            hybrid_log_return=request.hybrid_log_return,
+            shadow_log_return=request.shadow_log_return,
+            hybrid_drawdown=self.drawdown(request.hybrid),
+            shadow_drawdown=self.drawdown(request.shadow),
+            projection_distance=request.projection_distance,
+            hybrid_margin_deficit_fraction=(
+                request.hybrid.margin_deficit / self.initial_capital
+            ),
+            hybrid_equity_fraction=(
+                max(request.hybrid.portfolio_value, 0.0) / self.initial_capital
+            ),
+            shadow_equity_fraction=(
+                max(request.shadow.portfolio_value, 0.0) / self.initial_capital
+            ),
+            hybrid_terminated=request.hybrid_terminated,
+            shadow_terminated=request.shadow_terminated,
+        )
+
+
+__all__ = [
+    "EnvironmentRewardCoordinator",
+    "EnvironmentRewardRequest",
+]

--- a/trade_rl/rl/environment_risk.py
+++ b/trade_rl/rl/environment_risk.py
@@ -1,0 +1,128 @@
+"""Causal emergency, pre-trade, and portfolio risk projection services."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from trade_rl.data.market import MarketDataset
+from trade_rl.risk.emergency import CausalEmergencyRiskMonitor
+from trade_rl.risk.inputs import PortfolioRiskInputsProvider
+from trade_rl.risk.portfolio import PortfolioRiskModel
+from trade_rl.risk.pretrade import PreTradeRisk, RiskConstrainedTarget
+from trade_rl.simulation.accounting import BookState
+
+
+@dataclass(frozen=True, slots=True)
+class EnvironmentRiskRequest:
+    proposal: np.ndarray
+    book: BookState
+    current_index: int
+
+
+class EnvironmentRiskProjector:
+    """Apply risk controls in the maintained emergency-to-portfolio order."""
+
+    def __init__(
+        self,
+        dataset: MarketDataset,
+        *,
+        emergency_risk_monitor: CausalEmergencyRiskMonitor,
+        pre_trade_risk: PreTradeRisk,
+        portfolio_risk: PortfolioRiskModel,
+        portfolio_risk_inputs_provider: PortfolioRiskInputsProvider | None,
+    ) -> None:
+        self.dataset = dataset
+        self.emergency_risk_monitor = emergency_risk_monitor
+        self.pre_trade_risk = pre_trade_risk
+        self.portfolio_risk = portfolio_risk
+        self.portfolio_risk_inputs_provider = portfolio_risk_inputs_provider
+
+    @staticmethod
+    def drawdown(book: BookState) -> float:
+        value = max(book.portfolio_value, 0.0)
+        return min(
+            1.0,
+            max(0.0, 1.0 - value / max(book.peak_value, value, 1e-12)),
+        )
+
+    def market_notional(self, index: int) -> np.ndarray:
+        prices = self.dataset.close[index]
+        volume = self.dataset.volume[index]
+        return np.asarray(
+            [
+                float(value)
+                if str(getattr(unit, "value", unit)) == "quote_notional"
+                else float(price * value)
+                for price, value, unit in zip(
+                    prices,
+                    volume,
+                    self.dataset.volume_units,
+                    strict=True,
+                )
+            ],
+            dtype=np.float64,
+        )
+
+    def project(self, request: EnvironmentRiskRequest) -> RiskConstrainedTarget:
+        target = np.asarray(request.proposal, dtype=np.float64).reshape(-1).copy()
+        if target.shape != (self.dataset.n_symbols,) or not np.isfinite(target).all():
+            raise ValueError("proposal does not match dataset symbols")
+        assessment = self.emergency_risk_monitor.assess(
+            self.dataset,
+            index=request.current_index,
+            weights=request.book.weights,
+        )
+        pretrade = self.pre_trade_risk.constrain(
+            target,
+            current=request.book.weights,
+            drawdown=self.drawdown(request.book),
+            emergency_flatten_mask=assessment.flatten_mask,
+        )
+        risk_inputs = None
+        if self.portfolio_risk.requires_advanced_inputs:
+            provider = self.portfolio_risk_inputs_provider
+            if provider is None:
+                raise RuntimeError(
+                    "advanced portfolio risk requires a causal input provider"
+                )
+            risk_inputs = provider.inputs(
+                self.dataset,
+                index=request.current_index,
+            )
+        portfolio = self.portfolio_risk.constrain(
+            pretrade.weights,
+            portfolio_value=max(request.book.portfolio_value, 1e-12),
+            market_notional=self.market_notional(request.current_index),
+            covariance=None if risk_inputs is None else risk_inputs.covariance,
+            beta=None if risk_inputs is None else risk_inputs.beta,
+            stress_losses=None if risk_inputs is None else risk_inputs.stress_losses,
+        )
+        final_weights = np.asarray(portfolio.weights, dtype=np.float64)
+        constrained_turnover = float(np.abs(final_weights - request.book.weights).sum())
+        reasons = tuple(
+            dict.fromkeys(
+                (
+                    *pretrade.reasons,
+                    *assessment.reasons,
+                    *(f"portfolio:{item}" for item in portfolio.reasons),
+                )
+            )
+        )
+        return RiskConstrainedTarget(
+            weights=final_weights,
+            requested_turnover=pretrade.requested_turnover,
+            constrained_turnover=constrained_turnover,
+            was_constrained=bool(reasons),
+            reasons=reasons,
+            risk_scale=pretrade.risk_scale,
+            projection_l1=float(np.abs(target - final_weights).sum()),
+            turnover_overridden=pretrade.turnover_overridden,
+        )
+
+
+__all__ = [
+    "EnvironmentRiskProjector",
+    "EnvironmentRiskRequest",
+]


### PR DESCRIPTION
## Summary

Recreates the already-verified PR #80 environment-runtime decomposition directly from current `main`, after PR #79 and PR #88 were merged independently.

- extracts action parsing, target composition, delay handling, and decision-bar planning into `EnvironmentDecisionPlanner`
- extracts emergency, pre-trade, and portfolio-risk projection into `EnvironmentRiskProjector`
- extracts reward-transition input mapping into `EnvironmentRewardCoordinator`
- extracts stable step and terminal information construction into `EnvironmentInfoBuilder`
- keeps mutable books, pending targets, indices, position ages, previous action, and diagnostics owned by `ResidualMarketEnv`
- preserves the public environment interface, schemas, digest payload, execution ordering, target identity, risk-reason ordering, reward ordering, terminal accounting, and existing `info` keys

## Clean scope

Base: `464c14669bd2355b6922e6813870030bcf6cc745`

Final head: `86874d7122beef9247c67f89d41a3266a1164492`

The effective diff is exactly 14 files:

- four new environment runtime services
- `ResidualMarketEnv` orchestration changes
- one architecture ownership contract
- four focused service test modules
- one measured branch-coverage group
- design, implementation plan, and verification documentation

No PR #79 implementation files are repeated in this PR.

## Original TDD evidence

The original PR #80 branch recorded:

- architecture RED run `29906923608`, artifact `8524221206`
- expanded service RED run `29907379481`, artifact `8524403476`
- focused GREEN run `29908220862`
- integration GREEN run `29909051489`
- original exact-head CI run `29910332827`
- original PostgreSQL Catalog run `29910332866`

## Clean exact-head verification

GitHub Actions CI run `29955899116`: **success**

- Studio Vitest, TypeScript, production build, and fixed viewport: passed
- workflow security: passed
- Ruff and format: passed
- Mypy: passed
- Import Linter: passed
- dead-code report: passed
- recovery and structured Serving smoke: passed
- full Pytest: `1193 passed, 2 skipped, 11 warnings`
- total coverage: `83.55%`
- total branch coverage: `70.46%`
- environment-step service branches: `33/38 = 86.84% >= 86.8%`
- existing environment-runtime coverage threshold remains unchanged
- critical branch-coverage ratchets: passed
- CLI smoke: passed
- Ubuntu compatibility: passed
- Windows compatibility: passed
- complete training-image build and packaged non-root runtime probe: passed

PostgreSQL Catalog run `29955899222`: **success**

- exact-head checkout: passed
- Compose validation: passed
- PostgreSQL startup/readiness: passed
- installation and migration: passed
- unit and integration tests: passed
- shutdown and cleanup: passed

Exact-head artifacts:

- pytest diagnostics `8544086297`, digest `sha256:f44664ca5384e1d7335e5501b9d6aa84fb58397778d1dca1637f954dd8e1a0e9`
- architecture diagnostics `8544044684`, digest `sha256:08af2ea2c1e9e3ba1d7ad77845ddff083d8e15191979126fe89f41e1886050b2`
- static diagnostics `8544044262`, digest `sha256:fed4e3ed151393f7e2950916761bdbc9a03a37a966f290fbf9c08a2b274d6b91`
- training-image evidence `8544037302`, digest `sha256:e4311e0ef41c348d88b764c40a205b2ee554c4cb3c66f0c6ddf4feeeaa42589c`
- Studio layout diagnostics `8544033273`, digest `sha256:a6c369cd0ffd0617d1154cff2a92f7f23a4a18b8a1e47c3f6e9aae465f4c7cdf`
- Windows compatibility `8544028938`, digest `sha256:9a68f30cc46cf0c84a3d37056c79a9ae43e0df8f5b1b22ee49f3c6160bc6185e`
- Ubuntu compatibility `8544024734`, digest `sha256:6f87cfa29f825a4a6c13c626ae54e1f9dcd2d2b5bf42f44d41c248c97f9cbaa4`

## Review result

The clean comparison contains only the intended decomposition. `ResidualMarketEnv` remains the sole mutable Gymnasium-state owner; the extracted services consume explicit request dataclasses and return results which the facade applies in the existing order. No critical or important review issue remains.

## Safety boundary

- production remains `NO-GO`
- direct exchange routing is not implemented
- no profitability or exchange-equivalent fill claim is introduced
