### PR TITLE
test: stabilize sequence projection equivalence

### DIFF
--- a/.github/scripts/apply_sequence_projection_test.py
+++ b/.github/scripts/apply_sequence_projection_test.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+PATH = Path("tests/rl/test_sequence_policy_core.py")
+
+
+def replace_once(source: str, old: str, new: str) -> str:
+    count = source.count(old)
+    if count != 1:
+        raise RuntimeError(f"expected one projection test block, found {count}")
+    return source.replace(old, new, 1)
+
+
+def main() -> None:
+    source = PATH.read_text(encoding="utf-8")
+    if "from dataclasses import dataclass\n" not in source:
+        source = source.replace(
+            "from __future__ import annotations\n\nimport torch\n",
+            "from __future__ import annotations\n\nfrom dataclasses import dataclass\n\nimport torch\n",
+            1,
+        )
+
+    old = '''def test_projection_after_selection_matches_legacy_outputs_and_gradients() -> None:
+    from trade_rl.rl.sequence_policy import CausalTimeframeEncoder
+
+    torch.manual_seed(23)
+    encoder = CausalTimeframeEncoder(
+        4,
+        8,
+        window_length=12,
+        widths=(8, 8, 8, 8),
+        dropout=0.0,
+    )
+    available = torch.tensor(
+        [
+            [True] * 12,
+            [True] * 7 + [False] * 5,
+            [False] * 12,
+        ]
+    )
+    legacy_input = torch.randn(3, 12, 4, requires_grad=True)
+    optimized_input = legacy_input.detach().clone().requires_grad_(True)
+
+    legacy_sequence = encoder.projection(encoder.forward_sequence(legacy_input))
+    positions = torch.arange(12).expand_as(available)
+    indices = positions.masked_fill(~available, -1).max(dim=1).values
+    safe = indices.clamp_min(0)
+    legacy_selected = legacy_sequence[torch.arange(3), safe]
+    legacy = torch.where(
+        (indices >= 0).unsqueeze(1),
+        legacy_selected,
+        torch.zeros_like(legacy_selected),
+    )
+    legacy.square().sum().backward()
+    legacy_parameter_gradients = {
+        name: parameter.grad.detach().clone()
+        for name, parameter in encoder.named_parameters()
+        if parameter.grad is not None
+    }
+
+    encoder.zero_grad(set_to_none=True)
+    optimized = encoder(optimized_input, available)
+    optimized.square().sum().backward()
+
+    torch.testing.assert_close(optimized, legacy, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(
+        optimized_input.grad, legacy_input.grad, rtol=1e-5, atol=1e-6
+    )
+    for name, parameter in encoder.named_parameters():
+        assert parameter.grad is not None
+        torch.testing.assert_close(
+            parameter.grad,
+            legacy_parameter_gradients[name],
+            rtol=1e-5,
+            atol=1e-6,
+        )
+'''
+
+    new = '''@dataclass(frozen=True)
+class _ProjectionEquivalenceCase:
+    legacy: torch.Tensor
+    optimized: torch.Tensor
+    legacy_input_gradient: torch.Tensor
+    optimized_input_gradient: torch.Tensor
+    legacy_parameter_gradients: dict[str, torch.Tensor]
+    optimized_parameter_gradients: dict[str, torch.Tensor]
+
+
+def _projection_equivalence_case(dtype: torch.dtype) -> _ProjectionEquivalenceCase:
+    from trade_rl.rl.sequence_policy import CausalTimeframeEncoder
+
+    torch.manual_seed(23)
+    encoder = CausalTimeframeEncoder(
+        4,
+        8,
+        window_length=12,
+        widths=(8, 8, 8, 8),
+        dropout=0.0,
+    ).to(dtype=dtype)
+    available = torch.tensor(
+        [
+            [True] * 12,
+            [True] * 7 + [False] * 5,
+            [False] * 12,
+        ]
+    )
+    legacy_input = torch.randn(3, 12, 4, dtype=dtype, requires_grad=True)
+    optimized_input = legacy_input.detach().clone().requires_grad_(True)
+
+    legacy_sequence = encoder.projection(encoder.forward_sequence(legacy_input))
+    positions = torch.arange(12).expand_as(available)
+    indices = positions.masked_fill(~available, -1).max(dim=1).values
+    safe = indices.clamp_min(0)
+    legacy_selected = legacy_sequence[torch.arange(3), safe]
+    legacy = torch.where(
+        (indices >= 0).unsqueeze(1),
+        legacy_selected,
+        torch.zeros_like(legacy_selected),
+    )
+    legacy.square().sum().backward()
+    assert legacy_input.grad is not None
+    legacy_input_gradient = legacy_input.grad.detach().clone()
+    legacy_parameter_gradients = {
+        name: parameter.grad.detach().clone()
+        for name, parameter in encoder.named_parameters()
+        if parameter.grad is not None
+    }
+
+    encoder.zero_grad(set_to_none=True)
+    optimized = encoder(optimized_input, available)
+    optimized.square().sum().backward()
+    assert optimized_input.grad is not None
+    optimized_input_gradient = optimized_input.grad.detach().clone()
+    optimized_parameter_gradients = {
+        name: parameter.grad.detach().clone()
+        for name, parameter in encoder.named_parameters()
+        if parameter.grad is not None
+    }
+
+    return _ProjectionEquivalenceCase(
+        legacy=legacy.detach().clone(),
+        optimized=optimized.detach().clone(),
+        legacy_input_gradient=legacy_input_gradient,
+        optimized_input_gradient=optimized_input_gradient,
+        legacy_parameter_gradients=legacy_parameter_gradients,
+        optimized_parameter_gradients=optimized_parameter_gradients,
+    )
+
+
+def _relative_l2(left: torch.Tensor, right: torch.Tensor) -> float:
+    denominator = max(
+        float(torch.linalg.vector_norm(left)),
+        float(torch.linalg.vector_norm(right)),
+        1e-12,
+    )
+    return float(torch.linalg.vector_norm(left - right)) / denominator
+
+
+def _assert_gradient_semantics(left: torch.Tensor, right: torch.Tensor) -> None:
+    assert left.shape == right.shape
+    assert left.dtype == right.dtype
+    assert torch.isfinite(left).all()
+    assert torch.isfinite(right).all()
+    left_flat = left.reshape(-1)
+    right_flat = right.reshape(-1)
+    left_norm = float(torch.linalg.vector_norm(left_flat))
+    right_norm = float(torch.linalg.vector_norm(right_flat))
+    if left_norm == 0.0 or right_norm == 0.0:
+        assert left_norm == right_norm == 0.0
+        return
+    cosine = float(
+        torch.nn.functional.cosine_similarity(left_flat, right_flat, dim=0)
+    )
+    assert cosine >= 0.999999
+    assert _relative_l2(left, right) <= 2e-5
+
+
+def test_projection_after_selection_matches_legacy_in_float64() -> None:
+    case = _projection_equivalence_case(torch.float64)
+
+    torch.testing.assert_close(case.optimized, case.legacy, rtol=1e-9, atol=1e-10)
+    torch.testing.assert_close(
+        case.optimized_input_gradient,
+        case.legacy_input_gradient,
+        rtol=1e-9,
+        atol=1e-10,
+    )
+    assert case.optimized_parameter_gradients.keys() == (
+        case.legacy_parameter_gradients.keys()
+    )
+    for name, gradient in case.optimized_parameter_gradients.items():
+        torch.testing.assert_close(
+            gradient,
+            case.legacy_parameter_gradients[name],
+            rtol=1e-9,
+            atol=1e-10,
+        )
+    assert torch.count_nonzero(case.optimized[2]) == 0
+    assert torch.count_nonzero(case.optimized_input_gradient[2]) == 0
+
+
+def test_projection_after_selection_preserves_float32_gradient_semantics() -> None:
+    case = _projection_equivalence_case(torch.float32)
+
+    torch.testing.assert_close(case.optimized, case.legacy, rtol=1e-5, atol=2e-6)
+    _assert_gradient_semantics(
+        case.optimized_input_gradient,
+        case.legacy_input_gradient,
+    )
+    assert case.optimized_parameter_gradients.keys() == (
+        case.legacy_parameter_gradients.keys()
+    )
+    for name, gradient in case.optimized_parameter_gradients.items():
+        _assert_gradient_semantics(gradient, case.legacy_parameter_gradients[name])
+    assert torch.count_nonzero(case.optimized[2]) == 0
+    assert torch.count_nonzero(case.optimized_input_gradient[2]) == 0
+    assert torch.count_nonzero(case.optimized_input_gradient[:2]) > 0
+'''
+
+    source = replace_once(source, old, new)
+    PATH.write_text(source, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/tmp-apply-sequence-projection-test.yml
+++ b/.github/workflows/tmp-apply-sequence-projection-test.yml
@@ -1,0 +1,55 @@
+name: Apply Sequence Projection Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/scripts/apply_sequence_projection_test.py'
+      - '.github/workflows/tmp-apply-sequence-projection-test.yml'
+
+permissions:
+  contents: write
+
+jobs:
+  apply-test:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch head
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: test/stabilize-sequence-projection-equivalence-20260723
+          persist-credentials: true
+      - name: Set up uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86
+        with:
+          python-version: '3.12'
+          enable-cache: true
+      - name: Install
+        run: uv sync --extra dev --extra export --extra train-sb3 --extra studio
+      - name: Apply reviewed test patch
+        run: uv run python .github/scripts/apply_sequence_projection_test.py
+      - name: Format test
+        run: uv run ruff format tests/rl/test_sequence_policy_core.py
+      - name: Ruff
+        run: uv run ruff check tests/rl/test_sequence_policy_core.py tests/architecture/test_sequence_projection_stability.py
+      - name: Mypy
+        run: uv run mypy .
+      - name: Focused tests
+        run: >-
+          uv run pytest
+          tests/architecture/test_sequence_projection_stability.py
+          tests/rl/test_sequence_policy_core.py
+          -k 'sequence_projection_equivalence_uses_stable_contracts or projection_after_selection'
+          -q
+      - name: Commit verified test
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add tests/rl/test_sequence_policy_core.py
+          git diff --cached --check
+          git commit -m 'test: stabilize sequence projection equivalence'
+          git push origin HEAD:test/stabilize-sequence-projection-equivalence-20260723

--- a/docs/superpowers/plans/2026-07-23-sequence-projection-equivalence.md
+++ b/docs/superpowers/plans/2026-07-23-sequence-projection-equivalence.md
@@ -1,0 +1,107 @@
+# Sequence Projection Equivalence Stability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the backend-sensitive float32 elementwise gradient test with strict float64 historical equivalence and bounded float32 semantic-gradient contracts.
+
+**Architecture:** Production code remains unchanged. One test helper captures outputs, input gradients, and named parameter gradients for historical and maintained graphs. A permanent architecture contract and narrowly triggered cross-platform workflow prevent the flaky assertion from returning.
+
+**Tech Stack:** Python 3.12, PyTorch, pytest, AST, GitHub Actions, Ubuntu, Windows.
+
+## Global Constraints
+
+- Base the independent PR on current `main` commit `b39103aee26f9f80ab3b908fbf374c21ca1604a0`.
+- Do not modify any file under `trade_rl/`.
+- Use float64 `rtol=1e-9`, `atol=1e-10` for strict historical equivalence.
+- Use float32 cosine similarity `>= 0.999999` and relative L2 error `<= 2e-5` for nonzero gradients.
+- Require exact zero output and input gradient for the fully unavailable row.
+- Preserve the prior RED, focused GREEN, and 100x2 stability evidence by immutable run and artifact IDs.
+- Keep permanent CI narrowly path-filtered.
+- Keep the PR Draft and unmerged.
+
+---
+
+### Task 1: Replace the unstable equivalence test
+
+**Files:**
+- Modify: `tests/rl/test_sequence_policy_core.py`
+
+**Interfaces:**
+- Produce `_ProjectionEquivalenceCase`.
+- Produce `_projection_equivalence_case(dtype: torch.dtype)`.
+- Produce `_relative_l2(left, right)` and `_assert_gradient_semantics(left, right)`.
+- Produce `test_projection_after_selection_matches_legacy_in_float64`.
+- Produce `test_projection_after_selection_preserves_float32_gradient_semantics`.
+
+- [ ] Add `dataclass` import.
+- [ ] Replace the old test block with the reviewed helper and two contracts.
+- [ ] Run Ruff formatting and checking.
+- [ ] Run repository-wide Mypy.
+- [ ] Run `pytest tests/rl/test_sequence_policy_core.py -k projection_after_selection -q`.
+- [ ] Commit only after every check passes.
+
+Expected focused result: two passing tests.
+
+---
+
+### Task 2: Preserve the stable test structure
+
+**Files:**
+- Create: `tests/architecture/test_sequence_projection_stability.py`
+
+**Interface:**
+
+```python
+def test_sequence_projection_equivalence_uses_stable_contracts() -> None:
+    tree = ast.parse(Path("tests/rl/test_sequence_policy_core.py").read_text())
+    names = {
+        node.name
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    assert {
+        "test_projection_after_selection_matches_legacy_in_float64",
+        "test_projection_after_selection_preserves_float32_gradient_semantics",
+    } <= names
+    assert "test_projection_after_selection_matches_legacy_outputs_and_gradients" not in names
+```
+
+- [ ] Add the AST contract.
+- [ ] Run the new architecture test with both focused projection tests.
+- [ ] Commit after GREEN.
+
+---
+
+### Task 3: Add a narrowly targeted permanent matrix
+
+**Files:**
+- Create: `.github/workflows/sequence-projection-stability.yml`
+
+**Workflow contract:**
+
+- Trigger on `push` and `pull_request` to `main` only when one of four relevant paths changes.
+- Use pinned `actions/checkout`, `astral-sh/setup-uv`, and `actions/upload-artifact` SHAs.
+- Use read-only contents permission.
+- Matrix: Ubuntu and Windows.
+- Repeat the architecture contract and two projection tests 10 times.
+- Upload one log artifact per OS.
+
+- [ ] Add the workflow.
+- [ ] Verify workflow-security checks.
+- [ ] Confirm 10/10 repetitions on both operating systems.
+
+---
+
+### Task 4: Record and verify the independent PR
+
+**Files:**
+- Create: `docs/verification/2026-07-23-sequence-projection-equivalence.md`
+
+- [ ] Record original failure and unchanged-rerun behavior.
+- [ ] Record RED run `29953598828` and artifact `8543101802`.
+- [ ] Record focused GREEN run `29953725692` and artifact `8543175208`.
+- [ ] Record 100x2 run `29953836687` and Linux/Windows artifact digests.
+- [ ] Confirm effective diff contains no production file and no temporary workflow/script.
+- [ ] Run normal exact-head CI, PostgreSQL Catalog, and targeted stability workflow.
+- [ ] Record final head, run IDs, test counts, coverage, and artifact digests in the PR body.
+- [ ] Keep the PR Draft and unmerged.

--- a/docs/superpowers/specs/2026-07-23-sequence-projection-equivalence-design.md
+++ b/docs/superpowers/specs/2026-07-23-sequence-projection-equivalence-design.md
@@ -1,0 +1,86 @@
+# Sequence Projection Equivalence Stability Design
+
+## Status
+
+Approved remediation for `AUD-CI-002` on current `main` baseline `b39103aee26f9f80ab3b908fbf374c21ca1604a0`.
+
+## Problem
+
+`tests/rl/test_sequence_policy_core.py::test_projection_after_selection_matches_legacy_outputs_and_gradients` compares two mathematically equivalent implementations:
+
+1. project every encoded timestep and select the last available output;
+2. select the last available encoded timestep and project once.
+
+The test uses float32 and requires every parameter-gradient element to match with `atol=1e-6`. A previous CI attempt failed once with a maximum difference of `4.112720489501953e-06`, while an unchanged rerun passed. The two graphs use different matrix shapes, so backend accumulation order can introduce a few float32 ULPs without changing selection, masking, output, or gradient semantics.
+
+## Goals
+
+- Preserve direct historical graph-equivalence coverage.
+- Detect wrong availability selection, projection order, mask behavior, input-gradient routing, and parameter-gradient direction.
+- Remove backend-sensitive float32 per-element equality as the sole invariant.
+- Keep Linux and Windows CPU verification deterministic and bounded.
+- Change tests, targeted CI, and documentation only.
+
+## Non-goals
+
+- Changing `CausalTimeframeEncoder` or another production module.
+- Increasing global Torch tolerances.
+- Claiming GPU bitwise determinism.
+- Hiding numerical drift with an unexplained tolerance.
+
+## Selected design
+
+The old test is replaced by two complementary contracts.
+
+### Float64 historical equivalence
+
+A small dropout-free encoder and cloned inputs are converted to float64. The historical and maintained paths compare:
+
+- outputs;
+- input gradients;
+- every named parameter gradient;
+- exact zero output and input gradient for a fully unavailable row.
+
+Tolerance:
+
+```text
+rtol = 1e-9
+atol = 1e-10
+```
+
+This is stricter than the former float32 assertion and retains direct mathematical equivalence coverage.
+
+### Float32 semantic-gradient equivalence
+
+The float32 contract checks:
+
+- outputs with `rtol=1e-5`, `atol=2e-6`;
+- finite matching gradient shapes and dtypes;
+- cosine similarity `>= 0.999999` for nonzero gradient pairs;
+- relative L2 error `<= 2e-5`;
+- exact zero output and input gradient for a fully unavailable row;
+- nonzero causal input-gradient flow for selected rows;
+- identical named parameter-gradient sets.
+
+These limits remain far below meaningful model drift while covering the observed backend accumulation noise.
+
+## Continuous protection
+
+A permanent architecture test requires both stable test names and forbids restoration of the old flaky test name.
+
+A targeted workflow runs only when the sequence encoder, its focused tests, the architecture contract, or the workflow itself changes. It repeats the focused contracts 10 times on Ubuntu and Windows. Unrelated pull requests do not incur this cost.
+
+## Evidence strategy
+
+- Preserve the earlier expected RED source-contract run and artifact.
+- Preserve the earlier focused GREEN run.
+- Preserve the 100-repetition Ubuntu and Windows matrix.
+- Reapply the same reviewed patch to the current `main` baseline.
+- Run exact-head normal CI, PostgreSQL verification, and the permanent targeted workflow.
+
+## Safety boundary
+
+- Production remains `NO-GO`.
+- No model, policy, observation, reward, environment, execution, selection, serving, promotion, release, or artifact behavior changes.
+- No direct exchange routing is added.
+- The pull request remains Draft and unmerged.

--- a/tests/architecture/test_sequence_projection_stability.py
+++ b/tests/architecture/test_sequence_projection_stability.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_SEQUENCE_POLICY_TEST = Path("tests/rl/test_sequence_policy_core.py")
+_REQUIRED_TESTS = {
+    "test_projection_after_selection_matches_legacy_in_float64",
+    "test_projection_after_selection_preserves_float32_gradient_semantics",
+}
+_FORBIDDEN_TEST = "test_projection_after_selection_matches_legacy_outputs_and_gradients"
+
+
+def test_sequence_projection_equivalence_uses_stable_contracts() -> None:
+    tree = ast.parse(_SEQUENCE_POLICY_TEST.read_text(encoding="utf-8"))
+    test_names = {
+        node.name
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+    assert _REQUIRED_TESTS <= test_names
+    assert _FORBIDDEN_TEST not in test_names


### PR DESCRIPTION
## Superseded

This Draft PR was created while `main` was advancing and became redundant when the numerical remediation landed on `main` at `464c14669bd2355b6922e6813870030bcf6cc745`.

The remaining follow-up is the independent, production-free CI guard in PR #94:

- permanent AST contract
- narrowly path-filtered Ubuntu/Windows repetition workflow
- no file under `trade_rl/` changes

Original RED, focused GREEN, and 100x2 stability evidence remain preserved in PR #86 and the verification documents.

This PR is closed without merge.