### PR TITLE
fix: harden telemetry process concurrency

### DIFF
--- a/docs/superpowers/plans/2026-07-22-telemetry-process-concurrency.md
+++ b/docs/superpowers/plans/2026-07-22-telemetry-process-concurrency.md
@@ -1,0 +1,101 @@
+# Telemetry Process Concurrency Hardening Plan
+
+**Goal:** Make indexed telemetry append, index refresh, page read, and status read
+safe across cooperating Linux and Windows processes without changing public
+schemas or Studio APIs.
+
+**Architecture:** A private cross-platform OS file lock protects one append or one
+index/read snapshot. The indexed writer uses append-only binary writes and
+process-visible sequence validation. Index writes use unique durable temporary
+files and atomic replacement.
+
+## Constraints
+
+- Preserve public telemetry imports and JSON/index schema versions.
+- Preserve the writer constructor and context-manager methods.
+- Preserve duplicate-sequence and closed-writer error behavior.
+- Do not lock for the writer lifetime.
+- Do not silently truncate incomplete evidence.
+- Use spawn-based multiprocessing tests.
+- Keep Windows compatibility green.
+
+## Task 1: Commit RED concurrency contracts
+
+Create `tests/telemetry/test_indexed_process_concurrency.py`.
+
+Tests:
+
+- two already-open writers race sequence `1`; exactly one must succeed;
+- final JSONL contains one valid record and indexed status reports one record;
+- concurrent status/page readers complete without process errors while a writer
+  appends ordered records;
+- incomplete trailing bytes reject a subsequent append;
+- index JSON remains valid and identity-bound.
+
+Run the focused tests before production changes and record the failing workflow
+artifact.
+
+## Task 2: Implement cross-platform process lock
+
+Modify `trade_rl/telemetry/indexed_training.py`.
+
+Add:
+
+- lock sidecar path helper;
+- private context manager using `fcntl.flock` or `msvcrt.locking`;
+- symlink rejection and reliable release;
+- unlocked internal refresh helper to avoid nested lock acquisition.
+
+Add focused tests for lock release after exceptions and repeated acquisition.
+
+## Task 3: Implement process-safe writer
+
+Replace the inherited no-op indexed writer with an API-compatible implementation
+that:
+
+- validates `flush_every`;
+- owns a thread lock and append-only binary descriptor;
+- refreshes latest index under the process lock on every append;
+- rejects duplicate/regressing sequence across processes;
+- rejects incomplete trailing records;
+- writes the complete encoded line with a partial-write loop;
+- uses `fsync` at `flush_every`, explicit `flush`, and `close`.
+
+Run writer, training telemetry, and integration tests.
+
+## Task 4: Make index refresh and reads transactional
+
+Refactor index refresh into `_refresh_index_unlocked()` and a locked wrapper.
+
+- unique PID/token index temporary;
+- write/flush/fsync before `os.replace`;
+- cleanup temporary in `finally`;
+- optional POSIX parent-directory fsync;
+- page read holds lock and stops at snapshot `indexed_size`;
+- status holds lock through refresh and size capture.
+
+Run process concurrency, indexed telemetry, and Studio telemetry tests.
+
+## Task 5: Full verification and coverage ratchet
+
+Run exact-head:
+
+- Ruff and format;
+- Mypy;
+- Import Linter and dead-code report;
+- full Pytest with branch coverage;
+- telemetry and Studio integrations;
+- Ubuntu/Windows compatibility;
+- training image;
+- PostgreSQL Catalog.
+
+Measure branch coverage for `trade_rl/telemetry/indexed_training.py`. Add or raise a
+critical-coverage threshold only to the measured safe value and never reduce an
+existing threshold.
+
+Create
+`docs/verification/2026-07-22-telemetry-process-concurrency.md` with RED/GREEN,
+workflow, artifact, digest, test-count, and coverage evidence.
+
+Create a Draft PR based on PR #80 exact head while targeting `main` for exact-head
+workflow execution. Do not merge.

--- a/docs/superpowers/specs/2026-07-22-telemetry-process-concurrency-design.md
+++ b/docs/superpowers/specs/2026-07-22-telemetry-process-concurrency-design.md
@@ -1,0 +1,172 @@
+# Telemetry Process Concurrency Hardening Design
+
+## Context
+
+`IndexedTrainingTelemetryWriter` currently inherits a writer whose lock is a
+`threading.Lock`. Two processes can therefore open the same JSONL stream, read
+the same `last_sequence`, and both append an identical or out-of-order sequence.
+The resulting stream is syntactically valid but violates the monotonic identity
+contract.
+
+Index refresh has a second race. Every reader writes the same temporary path,
+`.<name>.index.json.tmp`, before replacing the index. Concurrent readers can
+truncate, replace, or remove that shared temporary file while another reader is
+using it.
+
+The live-training UI reads telemetry while training writes it, so locking the
+stream for the entire writer lifetime is not acceptable. The lock boundary must
+be one append or one consistent read/index-refresh transaction.
+
+## Approaches considered
+
+### A. Add a third-party file-lock package
+
+A package such as `filelock` or `portalocker` would reduce implementation code,
+but it introduces a runtime dependency solely for a small OS primitive and would
+need a lock-file compatibility review.
+
+### B. Lifetime writer lock
+
+Acquire an exclusive process lock in the writer constructor and release it on
+close. This prevents competing writers, but also blocks live readers for the
+entire training run.
+
+### C. Cross-platform OS lock per operation
+
+Use a stable sidecar lock file and native advisory locking:
+
+- `fcntl.flock` on POSIX;
+- `msvcrt.locking` on Windows.
+
+Append, index refresh, indexed read, and status operations hold the same exclusive
+lock only for their short critical section. This is the selected approach.
+
+## Selected architecture
+
+### `TelemetryProcessLock`
+
+A private context manager in `indexed_training.py` owns a sidecar path:
+
+`<telemetry-name>.lock`
+
+It opens the lock file in binary read/write mode and obtains an OS-level exclusive
+lock. OS locks are automatically released when a process exits or the handle is
+closed, so crashed processes do not leave a logically held lock.
+
+The implementation must:
+
+- work on Linux and Windows compatibility jobs;
+- reject a lock path that is a symbolic link;
+- create the parent directory before opening the lock file;
+- release the lock in `finally` paths;
+- avoid nested acquisition on the same telemetry path.
+
+### Process-safe writer
+
+`IndexedTrainingTelemetryWriter` remains API-compatible with the base writer but
+owns an append-only binary file descriptor rather than a buffered text handle.
+
+For every append it:
+
+1. acquires the thread lock;
+2. serializes and validates the record before touching the file;
+3. acquires the process lock;
+4. refreshes the index from the latest visible file state;
+5. rejects an incomplete trailing record;
+6. compares the proposed sequence with the process-visible last sequence;
+7. appends one complete UTF-8 JSON line through the append-only descriptor;
+8. releases the process lock.
+
+This ensures two processes racing to append the same sequence cannot both
+succeed. One succeeds; the other observes the new sequence and raises the
+existing monotonic-sequence `ValueError`.
+
+`flush_every` becomes the durability cadence for `fsync`; every `os.write` is
+immediately visible to cooperating processes, while the configured interval
+controls durable synchronization. Explicit `flush()` and `close()` perform
+`fsync`.
+
+### Incomplete-tail fail-closed rule
+
+A process crash can interrupt a low-level write and leave bytes without a final
+newline. Appending another JSON record after those bytes would turn both records
+into one malformed line.
+
+While holding the process lock, the writer compares the refreshed
+`indexed_size` with the current file size. If the file contains an incomplete
+trailing record, append fails with a `RuntimeError`. The writer never silently
+truncates research evidence. Repair remains an explicit operator action.
+
+### Consistent indexed reads
+
+`read_indexed_training_telemetry()` holds the process lock across:
+
+- index refresh;
+- checkpoint selection;
+- JSONL scan.
+
+The scan stops at the refreshed `indexed_size`, creating a consistent snapshot.
+Records appended after the lock is released are returned by the next read rather
+than being mixed with index metadata from an earlier snapshot.
+
+`indexed_training_telemetry_status()` similarly holds the lock through refresh
+and final size capture.
+
+### Atomic index replacement
+
+Index persistence uses a process-unique temporary path containing the PID and a
+random token. It writes, flushes, and `fsync`s the temporary file before
+`os.replace`. The temporary is removed in a `finally` block. On POSIX, the parent
+directory is synchronized after replacement when supported.
+
+The process lock is still mandatory; unique temporary paths protect cleanup and
+crash recovery, not index lost-update semantics.
+
+## Compatibility constraints
+
+The change must preserve:
+
+- telemetry JSONL schema and record serialization;
+- public writer constructor, `append`, `flush`, `close`, and context-manager API;
+- strict monotonic sequence error text;
+- indexed page and status dataclasses;
+- index schema version and checkpoint stride;
+- handling of malformed complete lines and sequence gaps;
+- live Studio telemetry endpoints;
+- Linux and Windows compatibility.
+
+No database, broker, direct-exchange, or production-readiness behavior changes.
+
+## Error handling
+
+- Duplicate or regressing sequence: existing `ValueError`.
+- Append after close: existing `RuntimeError`.
+- Incomplete trailing record: explicit `RuntimeError`.
+- Lock path symbolic link: explicit `RuntimeError`.
+- Invalid or stale index: rebuild under the process lock.
+- Index temporary write failure: propagate the original exception and remove the
+  process-unique temporary where possible.
+
+## Testing strategy
+
+1. Commit process-concurrency tests before production changes.
+2. Use `multiprocessing.get_context("spawn")` so tests exercise Windows-compatible
+   process semantics on every platform.
+3. Start two writers before a shared event, then race the same sequence. Assert
+   exactly one append succeeds and the stream contains exactly one record.
+4. Run multiple processes repeatedly reading status and pages while a writer
+   appends; assert no process error, no duplicate sequence, valid index JSON, and
+   complete final status.
+5. Verify incomplete-tail fail-closed behavior.
+6. Verify explicit flush/close durability and append-after-close behavior.
+7. Run existing telemetry, Studio API, training integration, Windows/Ubuntu
+   compatibility, full suite, and critical coverage on the exact head.
+8. Add or raise a telemetry branch-coverage ratchet only from measured coverage;
+   do not reduce any existing threshold.
+
+## Pull-request structure
+
+This is a stacked Draft PR based on PR #80 exact head
+`88f7e486b6db56fdc16ab89db5a77ef599c8f48f`. It targets `main` so repository
+workflows run. After PR #79 and PR #80 merge, its effective diff will reduce to
+the telemetry hardening files.

--- a/docs/verification/2026-07-22-telemetry-process-concurrency.md
+++ b/docs/verification/2026-07-22-telemetry-process-concurrency.md
@@ -1,0 +1,222 @@
+# Telemetry Process Concurrency Verification
+
+Date: 2026-07-22
+
+Branch: `agent/harden-telemetry-process-concurrency-20260722`
+
+Pull request: #81
+
+Dependency base: PR #80 exact head
+`88f7e486b6db56fdc16ab89db5a77ef599c8f48f`
+
+## Scope
+
+This change hardens indexed training telemetry for cooperating Linux and Windows
+processes while preserving the JSONL schema, index schema, public writer API,
+indexed page/status contracts, and Studio telemetry endpoints.
+
+Implemented boundaries:
+
+- per-stream sidecar OS lock using `fcntl.flock` on POSIX and `msvcrt.locking`
+  on Windows;
+- one append or one read/index snapshot per lock acquisition rather than a
+  writer-lifetime lock;
+- process-visible sequence validation before every append;
+- append-only binary writes with a partial-write loop;
+- fail-closed rejection of incomplete trailing records;
+- fail-closed rejection when an open writer descriptor no longer identifies the
+  current telemetry path;
+- process-unique index temporary files, file `fsync`, atomic replacement, and
+  best-effort parent-directory synchronization;
+- indexed reads bounded by the refreshed `indexed_size` snapshot;
+- explicit `flush()` and `close()` durability with configurable append cadence.
+
+No evidence repair, truncation, database migration, direct exchange routing, or
+production-readiness change is included.
+
+## TDD RED evidence
+
+### Process sequence, tail, and index races
+
+RED head:
+
+`d74e639f9d0835b3a35fe00a912b725d095e73ee`
+
+Workflow run `29911288413` failed as intended on both Linux and Windows.
+
+Linux artifact:
+
+- artifact: `8525980884`
+- digest:
+  `sha256:054442d9b61ba1edb8a16b4872df696dc5951a1f6096ffc8eb53141e0e22e3f8`
+
+Windows artifact:
+
+- artifact: `8525984305`
+- digest:
+  `sha256:79f115ef017487868897507f32fdbc452626475ffe4689b431f9af0834e0ceae`
+
+The valid RED run demonstrated:
+
+1. two already-open processes both accepted sequence `1`;
+2. the writer appended after incomplete trailing JSON bytes instead of failing
+   closed;
+3. concurrent readers raced on the shared fixed `.tmp` index path, producing
+   file-not-found/replacement failures.
+
+The earlier readiness-queue test-fixture defect was corrected before this RED run;
+these failures were produced by the existing production implementation.
+
+### Open-writer stream identity drift
+
+RED head:
+
+`b63f4615075f469780e556d79ab29f6da13dafbe`
+
+Workflow run `29912033107` failed as intended because a writer whose path was
+atomically replaced continued writing to its old inode and did not raise.
+
+- artifact: `8526267296`
+- digest:
+  `sha256:63741401c5a48721f424165dd2d6d537fb9bff4d1e30ada8459881c7405effa8`
+
+The production fix compares `fstat(writer_fd)` with `stat(telemetry_path)` while
+holding the process lock and raises `RuntimeError` when the identities differ.
+
+## Focused GREEN evidence
+
+### Cross-platform process locking
+
+Workflow run `29911808844` passed on Linux and Windows.
+
+Linux artifact:
+
+- artifact: `8526200257`
+- digest:
+  `sha256:fb9c56d0e53d239dd97dbfb00f1c550642e38bfab0f775db691f0cf0b30de7e5`
+
+Windows artifact:
+
+- artifact: `8526200535`
+- digest:
+  `sha256:928b57b58e889641cee7b6c6df1658eb8b0d95caff43b91357d9a73c346f71c6`
+
+The run verified Ruff, formatting, repository-wide Mypy on Linux, native
+`msvcrt` locking on Windows, spawn-based duplicate-writer races, incomplete-tail
+rejection, concurrent page/status reads, existing telemetry contracts, training
+integration, and Studio telemetry API tests.
+
+### Stream identity fix
+
+Workflow run `29912184255`, job `88897470828`, passed source transformation,
+Ruff/format, repository-wide Mypy, process-concurrency tests, existing telemetry
+contracts, training integration, Studio API tests, commit, and push.
+
+No test tolerance or schema version was changed.
+
+## Cleanup-head full verification
+
+Cleanup head:
+
+`b203f0816b45aa26c7940961bbf929fb9c0b424c`
+
+GitHub Actions CI run `29912311501`: success.
+
+- exact-head checkout: passed;
+- Studio tests, TypeScript check, production build, and fixed viewport: passed;
+- workflow-security validation: passed;
+- Ruff and format: passed;
+- Mypy: passed;
+- Import Linter: passed;
+- dead-code report: passed;
+- recovery and structured Serving smoke: passed;
+- full Pytest: `1188 passed, 2 skipped, 11 warnings`;
+- total coverage: `83.43%`;
+- total branch coverage: `70.34%`;
+- critical branch coverage: passed;
+- CLI smoke: passed;
+- Ubuntu and Windows compatibility: passed;
+- complete training-image build and packaged non-root runtime probe: passed.
+
+Pytest diagnostics:
+
+- artifact: `8526483274`
+- digest:
+  `sha256:22463e164a4499afa62a9a39ffd18660b93d46c68b4d63be26d5a48fd720ef4f`
+
+PostgreSQL Catalog run `29912311550`: success.
+
+## Coverage ratchet
+
+Measured `trade_rl/telemetry/indexed_training.py` branch coverage:
+
+- covered branches: 64;
+- total branches: 94;
+- observed: `68.0851%`;
+- configured minimum: `68.0%`.
+
+No existing critical-coverage threshold was reduced.
+
+Ratchet head:
+
+`7ff3e98511a9a3438277bee442587f6f55f89a6f`
+
+GitHub Actions CI run `29912659864`: success.
+
+- full Pytest: `1188 passed, 2 skipped, 11 warnings`;
+- total coverage: `83.43%`;
+- total branch coverage: `70.34%`;
+- indexed telemetry branch ratchet: `68.09% >= 68.0%`;
+- all static, architecture, serving, CLI, compatibility, and training-image jobs:
+  passed.
+
+Ratchet-head Pytest diagnostics:
+
+- artifact: `8526594309`
+- digest:
+  `sha256:3450bc292a9da0a55b71168b6290a24bc574cfe92f86a672279825ea8cf0c19f`
+
+PostgreSQL Catalog run `29912659868`: success.
+
+- exact-head checkout: passed;
+- Compose validation: passed;
+- PostgreSQL startup and readiness: passed;
+- migration: passed;
+- unit and integration tests: passed;
+- cleanup: passed.
+
+## Compatibility and review
+
+Comparison from PR #80 exact head to the cleanup head was limited to four files:
+
+- the design document;
+- the implementation plan;
+- spawn-based process-concurrency tests;
+- `trade_rl/telemetry/indexed_training.py`.
+
+The coverage ratchet and this verification document are the only additional final
+files.
+
+Review conclusions:
+
+- public telemetry exports and schemas are unchanged;
+- `flush_every`, `append`, `flush`, `close`, and context-manager usage remain
+  source compatible;
+- the existing strictly-increasing sequence error text is preserved;
+- live readers are blocked only for short append/read/index transactions;
+- crashed processes release advisory locks through handle closure;
+- index temporary names no longer collide across processes;
+- incomplete evidence is never truncated or automatically repaired;
+- an open descriptor cannot silently write to a replaced telemetry inode;
+- no repository caller relies on the base writer's former private text handle;
+- no temporary verification workflow or patch script remains in the intended
+  final diff.
+
+No critical or important review issue remained at this checkpoint.
+
+## Safety boundary
+
+- production remains `NO-GO`;
+- direct exchange routing is not implemented;
+- no profitability or exchange-equivalent fill claim is introduced;
+- PR #81 remains Draft and is not merged.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ target = 90.0
 "trade_rl/risk/pretrade.py" = 90.0
 "trade_rl/rl/rewards.py" = 97.0
 "trade_rl/evaluation/gates.py" = 100.0
+"trade_rl/telemetry/indexed_training.py" = 68.0
 
 [tool.trade_rl.critical_coverage.groups.artifacts]
 minimum = 90.0

--- a/tests/telemetry/test_indexed_process_concurrency.py
+++ b/tests/telemetry/test_indexed_process_concurrency.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import json
+import multiprocessing
+import os
+import time
+from pathlib import Path
+from queue import Empty
+from typing import Any
+
+import pytest
+
+from trade_rl.telemetry import (
+    TrainingTelemetryRecord,
+    TrainingTelemetryWriter,
+    read_training_telemetry,
+    training_telemetry_status,
+)
+
+
+def _record(sequence: int) -> TrainingTelemetryRecord:
+    return TrainingTelemetryRecord(
+        sequence=sequence,
+        recorded_at="2026-07-22T09:00:00+00:00",
+        global_step=sequence * 32,
+        environment_step=sequence,
+        seed=7,
+        environment_id=0,
+        event_type="rollout",
+        market_index=100 + sequence,
+        market_time="2026-07-22T08:55:00.000000000",
+        symbol="BTCUSDT",
+        open=67_500.0,
+        high=67_900.0,
+        low=67_400.0,
+        close=67_842.3,
+        action=(0.4,),
+        executed_target=(0.4,),
+        weights_before=(0.2,),
+        weights_after=(0.4,),
+        portfolio_value=101_342.85,
+        baseline_portfolio_value=100_400.0,
+        reward=0.214,
+        drawdown=0.0086,
+        interval_cost=4.25,
+        interval_return=0.0012,
+        risk_reasons=(),
+        emergency_deleverage=False,
+        terminated=False,
+        truncated=False,
+    )
+
+
+def _duplicate_writer_worker(
+    path_value: str,
+    ready: Any,
+    start: Any,
+    results: Any,
+) -> None:
+    writer: TrainingTelemetryWriter | None = None
+    try:
+        writer = TrainingTelemetryWriter(Path(path_value), flush_every=1)
+        ready.put(("ready", os.getpid()))
+        if not start.wait(timeout=20.0):
+            results.put(("error", "TimeoutError", "start event was not released"))
+            return
+        writer.append(_record(1))
+        writer.flush()
+        results.put(("ok", os.getpid(), ""))
+    except BaseException as error:  # pragma: no cover - asserted in parent process
+        results.put(("error", type(error).__name__, str(error)))
+    finally:
+        if writer is not None:
+            writer.close()
+
+
+def _ordered_writer_worker(
+    path_value: str,
+    start: Any,
+    results: Any,
+    count: int,
+) -> None:
+    try:
+        if not start.wait(timeout=20.0):
+            raise TimeoutError("start event was not released")
+        with TrainingTelemetryWriter(Path(path_value), flush_every=1) as writer:
+            for sequence in range(1, count + 1):
+                writer.append(_record(sequence))
+                if sequence % 4 == 0:
+                    time.sleep(0.001)
+        results.put(("writer", "ok", count))
+    except BaseException as error:  # pragma: no cover - asserted in parent process
+        results.put(("writer", type(error).__name__, str(error)))
+
+
+def _reader_worker(
+    path_value: str,
+    start: Any,
+    results: Any,
+    iterations: int,
+) -> None:
+    path = Path(path_value)
+    try:
+        if not start.wait(timeout=20.0):
+            raise TimeoutError("start event was not released")
+        last_seen = 0
+        for _ in range(iterations):
+            status = training_telemetry_status(path)
+            page = read_training_telemetry(path, after_sequence=0, limit=2_000)
+            sequences = [record.sequence for record in page.items]
+            if sequences != sorted(set(sequences)):
+                raise AssertionError("reader observed duplicate or unordered sequences")
+            if status.available and status.last_sequence < last_seen:
+                raise AssertionError("status last_sequence regressed")
+            last_seen = max(last_seen, status.last_sequence)
+            time.sleep(0.001)
+        results.put(("reader", "ok", last_seen))
+    except BaseException as error:  # pragma: no cover - asserted in parent process
+        results.put(("reader", type(error).__name__, str(error)))
+
+
+def _context() -> multiprocessing.context.SpawnContext:
+    return multiprocessing.get_context("spawn")
+
+
+def _join(processes: list[multiprocessing.Process], *, timeout: float = 30.0) -> None:
+    deadline = time.monotonic() + timeout
+    for process in processes:
+        process.join(timeout=max(0.0, deadline - time.monotonic()))
+    for process in processes:
+        if process.is_alive():
+            process.terminate()
+            process.join(timeout=5.0)
+            pytest.fail(f"process {process.pid} did not terminate")
+        assert process.exitcode == 0
+
+
+def _queue_items(queue: Any, expected: int) -> list[tuple[object, ...]]:
+    items: list[tuple[object, ...]] = []
+    for _ in range(expected):
+        try:
+            items.append(tuple(queue.get(timeout=10.0)))
+        except Empty:
+            pytest.fail(f"expected {expected} process results, received {len(items)}")
+    return items
+
+
+def test_duplicate_sequence_race_allows_exactly_one_process_append(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    context = _context()
+    ready = context.Queue()
+    start = context.Event()
+    results = context.Queue()
+    processes = [
+        context.Process(
+            target=_duplicate_writer_worker,
+            args=(str(path), ready, start, results),
+        )
+        for _ in range(2)
+    ]
+
+    for process in processes:
+        process.start()
+    ready_items = _queue_items(ready, 2)
+    assert all(item[0] == "ready" for item in ready_items)
+    start.set()
+    _join(processes)
+    outcomes = _queue_items(results, 2)
+
+    successful = [item for item in outcomes if item[0] == "ok"]
+    rejected = [item for item in outcomes if item[0] == "error"]
+    assert len(successful) == 1
+    assert len(rejected) == 1
+    assert rejected[0][1] == "ValueError"
+    assert "strictly increase" in str(rejected[0][2])
+
+    page = read_training_telemetry(path, after_sequence=0, limit=10)
+    status = training_telemetry_status(path)
+    assert [item.sequence for item in page.items] == [1]
+    assert status.record_count == 1
+    assert status.last_sequence == 1
+
+
+def test_append_fails_closed_when_stream_has_incomplete_tail(tmp_path: Path) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    path.write_bytes(
+        (json.dumps(_record(1).to_json_dict(), sort_keys=True) + "\n").encode("utf-8")
+        + b'{"schema_version":"training_telemetry_v1"'
+    )
+
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        with pytest.raises(RuntimeError, match="incomplete trailing record"):
+            writer.append(_record(2))
+
+    page = read_training_telemetry(path, after_sequence=0, limit=10)
+    assert [item.sequence for item in page.items] == [1]
+
+
+def test_concurrent_readers_observe_consistent_index_snapshots(tmp_path: Path) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    context = _context()
+    start = context.Event()
+    results = context.Queue()
+    count = 96
+    readers = 4
+    processes = [
+        context.Process(
+            target=_ordered_writer_worker,
+            args=(str(path), start, results, count),
+        ),
+        *[
+            context.Process(
+                target=_reader_worker,
+                args=(str(path), start, results, 80),
+            )
+            for _ in range(readers)
+        ],
+    ]
+
+    for process in processes:
+        process.start()
+    start.set()
+    _join(processes, timeout=60.0)
+    outcomes = _queue_items(results, readers + 1)
+
+    assert all(item[1] == "ok" for item in outcomes), outcomes
+    status = training_telemetry_status(path)
+    page = read_training_telemetry(path, after_sequence=0, limit=2_000)
+    index_path = path.with_name(f"{path.name}.index.json")
+    index_payload = json.loads(index_path.read_text(encoding="utf-8"))
+
+    assert status.record_count == count
+    assert status.last_sequence == count
+    assert [item.sequence for item in page.items] == list(range(1, count + 1))
+    assert index_payload["record_count"] == count
+    assert index_payload["last_sequence"] == count
+    assert index_payload["indexed_size"] == path.stat().st_size
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows prevents replacing an open file")
+def test_append_fails_closed_when_stream_identity_is_replaced(tmp_path: Path) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    replacement = tmp_path / "replacement.jsonl"
+    writer = TrainingTelemetryWriter(path, flush_every=1)
+    try:
+        writer.append(_record(1))
+        replacement.write_text(
+            json.dumps(_record(1).to_json_dict(), sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        os.replace(replacement, path)
+
+        with pytest.raises(RuntimeError, match="stream identity changed"):
+            writer.append(_record(2))
+    finally:
+        writer.close()
+
+    page = read_training_telemetry(path, after_sequence=0, limit=10)
+    assert [item.sequence for item in page.items] == [1]

--- a/trade_rl/telemetry/indexed_training.py
+++ b/trade_rl/telemetry/indexed_training.py
@@ -2,15 +2,30 @@
 
 from __future__ import annotations
 
+import errno
 import json
+import os
+import sys
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Self, cast
+from types import TracebackType
+from typing import Any, BinaryIO, Self, cast
+from uuid import uuid4
 
 from trade_rl.telemetry import training as _training
 
+if sys.platform == "win32":
+    import msvcrt
+else:
+    import fcntl
+
 _INDEX_SCHEMA = "training_telemetry_index_v1"
 _INDEX_STRIDE = 64
+_LOCK_RETRY_SECONDS = 0.01
 _BaseRecord = _training.TrainingTelemetryRecord
 _BaseWriter = _training.TrainingTelemetryWriter
 Pair = tuple[int, int]
@@ -64,6 +79,10 @@ class _TelemetryIndex:
 
 def _index_path(path: Path) -> Path:
     return path.with_name(f"{path.name}.index.json")
+
+
+def _lock_path(path: Path) -> Path:
+    return path.with_name(f"{path.name}.lock")
 
 
 def _non_negative_int(value: object, *, field_name: str) -> int:
@@ -121,18 +140,92 @@ def _load_index(path: Path) -> _TelemetryIndex | None:
         return None
 
 
+def _sync_parent_directory(path: Path) -> None:
+    if sys.platform == "win32":
+        return
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError:
+        return
+    try:
+        os.fsync(descriptor)
+    except OSError:
+        pass
+    finally:
+        os.close(descriptor)
+
+
 def _write_index(path: Path, index: _TelemetryIndex) -> None:
     destination = _index_path(path)
-    temporary = destination.with_name(f".{destination.name}.tmp")
-    payload = json.dumps(
-        index.to_json_dict(),
-        ensure_ascii=False,
-        allow_nan=False,
-        sort_keys=True,
-        separators=(",", ":"),
+    temporary = destination.with_name(
+        f".{destination.name}.{os.getpid()}.{uuid4().hex}.tmp"
     )
-    temporary.write_text(payload + "\n", encoding="utf-8")
-    temporary.replace(destination)
+    payload = (
+        json.dumps(
+            index.to_json_dict(),
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        + b"\n"
+    )
+    try:
+        with temporary.open("xb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, destination)
+        _sync_parent_directory(destination.parent)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _prepare_windows_lock(handle: BinaryIO) -> None:
+    handle.seek(0, os.SEEK_END)
+    if handle.tell() == 0:
+        handle.write(b"\0")
+        handle.flush()
+    handle.seek(0)
+
+
+def _acquire_process_lock(handle: BinaryIO) -> None:
+    if sys.platform == "win32":
+        _prepare_windows_lock(handle)
+        while True:
+            try:
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                return
+            except OSError as error:
+                if error.errno not in (errno.EACCES, errno.EAGAIN, errno.EDEADLK):
+                    raise
+                time.sleep(_LOCK_RETRY_SECONDS)
+    else:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+
+
+def _release_process_lock(handle: BinaryIO) -> None:
+    if sys.platform == "win32":
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+    else:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+@contextmanager
+def _telemetry_process_lock(path: Path) -> Iterator[None]:
+    lock_path = _lock_path(Path(path))
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    if lock_path.is_symlink():
+        raise RuntimeError("telemetry lock path must not be a symbolic link")
+    with lock_path.open("a+b", buffering=0) as handle:
+        _acquire_process_lock(handle)
+        try:
+            yield
+        finally:
+            _release_process_lock(handle)
 
 
 def _parse_record(raw_line: bytes) -> StrictTrainingTelemetryRecord:
@@ -141,7 +234,7 @@ def _parse_record(raw_line: bytes) -> StrictTrainingTelemetryRecord:
     )
 
 
-def _refresh_index(path: Path) -> _TelemetryIndex | None:
+def _refresh_index_unlocked(path: Path) -> _TelemetryIndex | None:
     resolved = Path(path)
     if not resolved.is_file() or resolved.is_symlink():
         return None
@@ -209,64 +302,170 @@ def read_indexed_training_telemetry(
     if isinstance(limit, bool) or limit <= 0 or limit > 2_000:
         raise ValueError("limit must be between 1 and 2000")
     resolved = Path(path)
-    index = _refresh_index(resolved)
-    if index is None:
-        return _training.TrainingTelemetryPage((), after_sequence, False, 0, ())
+    with _telemetry_process_lock(resolved):
+        index = _refresh_index_unlocked(resolved)
+        if index is None:
+            return _training.TrainingTelemetryPage((), after_sequence, False, 0, ())
 
-    checkpoint_sequence, offset = _seek_offset(index, after_sequence)
-    previous_sequence = checkpoint_sequence or None
-    items: list[StrictTrainingTelemetryRecord] = []
-    truncated = False
-    with resolved.open("rb") as handle:
-        handle.seek(offset)
-        while True:
-            raw_line = handle.readline()
-            if not raw_line or not raw_line.endswith(b"\n"):
-                break
-            line = raw_line.strip()
-            if not line:
-                continue
-            try:
-                record = _parse_record(line)
-            except (UnicodeError, json.JSONDecodeError, TypeError, ValueError):
-                continue
-            if previous_sequence is not None and record.sequence <= previous_sequence:
-                continue
-            previous_sequence = record.sequence
-            if record.sequence <= after_sequence:
-                continue
-            if len(items) >= limit:
-                truncated = True
-                break
-            items.append(record)
-    next_sequence = items[-1].sequence if items else after_sequence
-    return _training.TrainingTelemetryPage(
-        items=tuple(items),
-        next_sequence=next_sequence,
-        truncated=truncated,
-        malformed_lines=index.malformed_lines,
-        sequence_gaps=tuple(index.sequence_gaps),
-    )
+        checkpoint_sequence, offset = _seek_offset(index, after_sequence)
+        previous_sequence = checkpoint_sequence or None
+        items: list[StrictTrainingTelemetryRecord] = []
+        truncated = False
+        snapshot_size = index.indexed_size
+        with resolved.open("rb") as handle:
+            handle.seek(offset)
+            while handle.tell() < snapshot_size:
+                remaining = snapshot_size - handle.tell()
+                raw_line = handle.readline(remaining)
+                if not raw_line or not raw_line.endswith(b"\n"):
+                    break
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    record = _parse_record(line)
+                except (UnicodeError, json.JSONDecodeError, TypeError, ValueError):
+                    continue
+                if (
+                    previous_sequence is not None
+                    and record.sequence <= previous_sequence
+                ):
+                    continue
+                previous_sequence = record.sequence
+                if record.sequence <= after_sequence:
+                    continue
+                if len(items) >= limit:
+                    truncated = True
+                    break
+                items.append(record)
+        next_sequence = items[-1].sequence if items else after_sequence
+        return _training.TrainingTelemetryPage(
+            items=tuple(items),
+            next_sequence=next_sequence,
+            truncated=truncated,
+            malformed_lines=index.malformed_lines,
+            sequence_gaps=tuple(index.sequence_gaps),
+        )
 
 
 def indexed_training_telemetry_status(
     path: Path,
 ) -> _training.TrainingTelemetryStatus:
     resolved = Path(path)
-    index = _refresh_index(resolved)
-    if index is None:
-        return _training.TrainingTelemetryStatus(False, 0, 0, 0, 0)
-    return _training.TrainingTelemetryStatus(
-        available=True,
-        record_count=index.record_count,
-        last_sequence=index.last_sequence,
-        malformed_lines=index.malformed_lines,
-        size_bytes=resolved.stat().st_size,
-    )
+    with _telemetry_process_lock(resolved):
+        index = _refresh_index_unlocked(resolved)
+        if index is None:
+            return _training.TrainingTelemetryStatus(False, 0, 0, 0, 0)
+        return _training.TrainingTelemetryStatus(
+            available=True,
+            record_count=index.record_count,
+            last_sequence=index.last_sequence,
+            malformed_lines=index.malformed_lines,
+            size_bytes=resolved.stat().st_size,
+        )
+
+
+def _write_all(descriptor: int, payload: bytes) -> None:
+    view = memoryview(payload)
+    while view:
+        written = os.write(descriptor, view)
+        if written <= 0:
+            raise OSError("telemetry append made no progress")
+        view = view[written:]
 
 
 class IndexedTrainingTelemetryWriter(_BaseWriter):
-    """Existing append writer paired with the indexed status implementation."""
+    """Append telemetry with thread and cross-process sequence serialization."""
+
+    def __init__(self, path: Path, *, flush_every: int = 32) -> None:
+        if isinstance(flush_every, bool) or flush_every <= 0:
+            raise ValueError("flush_every must be positive")
+        self.path = Path(path)
+        self.flush_every = int(flush_every)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if self.path.is_symlink():
+            raise RuntimeError("telemetry path must not be a symbolic link")
+        self._lock = threading.Lock()
+        self._pending = 0
+        flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND | getattr(os, "O_BINARY", 0)
+        descriptor = os.open(self.path, flags, 0o600)
+        self._fd: int | None = descriptor
+        try:
+            with _telemetry_process_lock(self.path):
+                index = _refresh_index_unlocked(self.path)
+                self._last_sequence = 0 if index is None else index.last_sequence
+        except BaseException:
+            os.close(descriptor)
+            self._fd = None
+            raise
+
+    def append(self, record: _BaseRecord) -> None:
+        payload = (
+            json.dumps(
+                record.to_json_dict(),
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+                allow_nan=False,
+            ).encode("utf-8")
+            + b"\n"
+        )
+        with self._lock:
+            descriptor = self._fd
+            if descriptor is None:
+                raise RuntimeError("telemetry writer is closed")
+            with _telemetry_process_lock(self.path):
+                index = _refresh_index_unlocked(self.path)
+                if index is None:
+                    raise RuntimeError("telemetry stream is unavailable")
+                path_stat = self.path.stat()
+                descriptor_stat = os.fstat(descriptor)
+                if (
+                    int(descriptor_stat.st_dev),
+                    int(descriptor_stat.st_ino),
+                ) != (int(path_stat.st_dev), int(path_stat.st_ino)):
+                    raise RuntimeError("telemetry stream identity changed")
+                if path_stat.st_size != index.indexed_size:
+                    raise RuntimeError(
+                        "telemetry file has an incomplete trailing record"
+                    )
+                if record.sequence <= index.last_sequence:
+                    raise ValueError("telemetry sequence must strictly increase")
+                _write_all(descriptor, payload)
+                self._last_sequence = record.sequence
+                self._pending += 1
+                if self._pending >= self.flush_every:
+                    os.fsync(descriptor)
+                    self._pending = 0
+
+    def flush(self) -> None:
+        with self._lock:
+            if self._fd is not None:
+                os.fsync(self._fd)
+                self._pending = 0
+
+    def close(self) -> None:
+        with self._lock:
+            descriptor = self._fd
+            if descriptor is None:
+                return
+            try:
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+                self._fd = None
+                self._pending = 0
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc_value: BaseException | None,
+        _traceback: TracebackType | None,
+    ) -> None:
+        self.close()
 
 
 __all__ = [


### PR DESCRIPTION
## Summary

Recreates the already-verified PR #81 telemetry concurrency hardening directly from current `main`, after the dependent architecture and environment-runtime changes were merged independently.

- adds cross-platform per-stream OS file locking (`fcntl.flock` / `msvcrt.locking`)
- validates the latest process-visible sequence before every append
- guarantees exactly one writer wins duplicate-sequence races
- fails closed on incomplete trailing JSON records
- reads index refresh and JSONL scan as one locked snapshot
- writes durable process-unique index temporary files and atomically replaces the index
- detects when an open writer path was replaced and refuses obsolete-inode writes
- adds spawn-based multiprocessing regressions and a measured critical branch-coverage ratchet

## Clean scope

Base: `6cf23b98698f5d53ec40629dd723efc4bd4cfbb6`

Final head: `0e22094485c0b530b64da3a0c70f96b5410b2c66`

The effective diff is exactly six files:

- `trade_rl/telemetry/indexed_training.py`
- `tests/telemetry/test_indexed_process_concurrency.py`
- one telemetry coverage-threshold entry in `pyproject.toml`
- design, implementation plan, and verification documentation

## Original TDD evidence

The original PR #81 branch recorded RED failures for duplicate writers, incomplete tails, fixed temporary-index races, and obsolete-inode writes, followed by Linux and Windows GREEN multiprocessing runs.

Original exact-head verification:

- CI run `29912979207`
- PostgreSQL Catalog run `29912979195`
- `1188 passed, 2 skipped`
- total coverage `83.44%`
- telemetry branch coverage `64/94 = 68.09% >= 68.0%`

## Clean exact-head verification

GitHub Actions CI run `29956385683`: **success**

- Studio Vitest, TypeScript, production build, and fixed viewport: passed
- workflow security: passed
- Ruff and format: passed
- Mypy: passed
- Import Linter: passed
- dead-code report: passed
- recovery and structured Serving smoke: passed
- full Pytest: `1197 passed, 2 skipped, 11 warnings`
- total coverage: `83.43%`
- total branch coverage: `70.34%`
- `trade_rl/telemetry/indexed_training.py`: `64/94 = 68.09% >= 68.0%`
- critical branch-coverage ratchets: passed
- CLI smoke: passed
- Ubuntu compatibility and spawn multiprocessing regressions: passed
- Windows compatibility and spawn multiprocessing regressions: passed
- complete training-image build and packaged non-root runtime probe: passed

PostgreSQL Catalog run `29956385705`: **success**

- exact-head checkout: passed
- Compose validation: passed
- PostgreSQL startup/readiness: passed
- installation and migration: passed
- unit and integration tests: passed
- shutdown and cleanup: passed

Exact-head artifacts:

- pytest diagnostics `8544270458`, digest `sha256:eb3af56b36c057495d96bdba85f9be894cac3dd96e18bdaf1ddcc4407b3bdf84`
- architecture diagnostics `8544227996`, digest `sha256:141c5b3f3bf4b4443a73754899d79effb96c21dc0bd8989125f37606722fd81b`
- static diagnostics `8544227415`, digest `sha256:095c032b677c6af423add78e5093813bd7ae7d7f71bbe9bb38ef708f5f1858ea`
- training-image evidence `8544221968`, digest `sha256:b06b24a42458cf6be0a00ad2dec46671761c02eeb314cb28c1e7f8e8b3e304ef`
- Studio layout diagnostics `8544216788`, digest `sha256:03f7e919f7b5169aeaf7ac2c84ba122015ee764e04c3d7a7e093db5c1e530932`
- Windows compatibility `8544216083`, digest `sha256:92e00bdd1ea56592e4bafa87c6662b4603097cc5d0393b8aae8a012803d9ee01`
- Ubuntu compatibility `8544208737`, digest `sha256:d3d7cd79eb2bae8bab4e6219ebccf9ae9555ea9f766b21443f6d48b1480d5bed`

## Review result

The clean diff retains the public telemetry and Studio APIs and does not alter the JSON or sparse-index schema. Writes and index refreshes are serialized per stream, and corruption or identity drift fails closed rather than truncating or repairing evidence. No critical or important review issue remains.

## Safety boundary

- production remains `NO-GO`
- no direct exchange routing
- no telemetry evidence truncation or automatic repair
- JSON and index schemas remain unchanged
