### PR TITLE
fix: bind telemetry cursors to stream generation

### DIFF
--- a/docs/superpowers/plans/2026-07-22-telemetry-cursor-generation.md
+++ b/docs/superpowers/plans/2026-07-22-telemetry-cursor-generation.md
@@ -1,0 +1,909 @@
+# Generation-Bound Telemetry Polling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bind Studio telemetry cursors to an explicit stream generation, prevent mixed-generation replay, and shorten polling lock duration without weakening process safety.
+
+**Architecture:** Persist a UUID generation in sidecar index v2. Refresh index metadata under the existing cross-process lock, capture an identity-verified file snapshot, then parse the bounded page after releasing the lock. Propagate generation/reset state through Python telemetry contracts, Studio API models, TypeScript guards, API client, and the polling hook.
+
+**Tech Stack:** Python 3.12, dataclasses, pathlib, UUID, pytest, FastAPI/Pydantic, React 19, TypeScript, Vitest, Testing Library, Ruff, Mypy, Import Linter, GitHub Actions.
+
+## Global Constraints
+
+- Preserve telemetry JSONL schema `training_telemetry_v1`.
+- Replace only the internal sidecar schema with `training_telemetry_index_v2`.
+- Keep sequence pagination and the maximum page limit of 2,000 records.
+- New Python dataclass fields must be final fields with defaults so existing positional constructors remain valid.
+- A generation mismatch must return zero records and `reset_required=True`.
+- A no-growth poll must perform zero sidecar writes and zero `fsync` calls through `_write_index()`.
+- Page-body parsing must occur outside the append serialization lock.
+- Existing critical coverage thresholds may not be reduced.
+- Production remains `NO-GO`; direct exchange routing is out of scope.
+
+---
+
+## File map
+
+- Modify `trade_rl/telemetry/training.py`: additive page/status generation fields.
+- Modify `trade_rl/telemetry/indexed_training.py`: index v2, generation validation, change-aware refresh, snapshot capture, generation-aware reads.
+- Modify `tests/telemetry/test_training.py`: deterministic generation, no-op poll, lock duration, and near-tail scaling contracts.
+- Modify `tests/telemetry/test_indexed_process_concurrency.py`: preserve generation and process-safety regression coverage where needed.
+- Modify `trade_rl/studio/telemetry.py`: expose generation/reset in Studio response models and reader methods.
+- Modify `trade_rl/studio/api.py`: accept the expected generation query parameter.
+- Modify `tests/studio/test_telemetry_api.py`: API generation/reset and invalid-query contracts.
+- Modify `studio/src/data/types.ts`: TypeScript response fields.
+- Modify `studio/src/live/telemetryGuards.ts`: strict UUID and reset validation.
+- Modify `studio/src/api/studioApi.ts`: send `stream_generation`.
+- Modify `studio/src/live/useTrainingTelemetry.ts`: generation-bound polling and one retry.
+- Create `studio/src/live/useTrainingTelemetry.test.tsx`: hook-level reset and race tests.
+- Modify frontend mocks that implement `StudioApi`, including `studio/src/pages/LiveTrainingPage.test.tsx` and `studio/src/pages/RuntimePages.test.tsx`.
+- Modify `pyproject.toml`: add a non-regressing telemetry polling coverage group after measuring final coverage.
+- Create `docs/verification/2026-07-22-telemetry-cursor-generation.md`: exact RED/GREEN and CI evidence.
+
+---
+
+### Task 1: Commit Python generation RED contracts
+
+**Files:**
+- Modify: `tests/telemetry/test_training.py`
+
+**Interfaces:**
+- Consumes: existing `TrainingTelemetryWriter`, `read_training_telemetry()`, and `training_telemetry_status()` package exports.
+- Produces: failing contracts for `stream_generation`, `expected_generation`, and `reset_required`.
+
+- [ ] **Step 1: Add generation helpers and failing tests**
+
+Add `import os` and the following tests after `test_index_rebuilds_after_stream_replacement`:
+
+```python
+def _required_generation(value: str | None) -> str:
+    assert value is not None
+    return value
+
+
+def test_generation_remains_stable_across_normal_append(tmp_path: Path) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        writer.append(record(1))
+    first = training_telemetry_status(path)
+
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        writer.append(record(2))
+    second = training_telemetry_status(path)
+
+    assert _required_generation(first.stream_generation) == second.stream_generation
+
+
+def test_old_generation_requests_reset_after_stream_replacement(tmp_path: Path) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        writer.append(record(1))
+        writer.append(record(2))
+    old_generation = _required_generation(
+        training_telemetry_status(path).stream_generation
+    )
+
+    replacement = tmp_path / "replacement.jsonl"
+    replacement.write_text(
+        json.dumps(record(1).to_json_dict(), sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(replacement, path)
+
+    page = read_training_telemetry(
+        path,
+        after_sequence=2,
+        limit=10,
+        expected_generation=old_generation,
+    )
+
+    assert page.items == ()
+    assert page.next_sequence == 0
+    assert page.reset_required is True
+    assert page.stream_generation not in (None, old_generation)
+
+
+def test_index_loss_rotates_generation_and_invalidates_cursor(tmp_path: Path) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        writer.append(record(1))
+    first = training_telemetry_status(path)
+    old_generation = _required_generation(first.stream_generation)
+    path.with_name(f"{path.name}.index.json").unlink()
+
+    page = read_training_telemetry(
+        path,
+        after_sequence=1,
+        limit=10,
+        expected_generation=old_generation,
+    )
+
+    assert page.items == ()
+    assert page.reset_required is True
+    assert page.stream_generation not in (None, old_generation)
+
+
+def test_expected_generation_requires_canonical_uuid(tmp_path: Path) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        writer.append(record(1))
+
+    with pytest.raises(ValueError, match="expected_generation"):
+        read_training_telemetry(
+            path,
+            after_sequence=0,
+            limit=10,
+            expected_generation="not-a-generation",
+        )
+```
+
+- [ ] **Step 2: Run the RED tests**
+
+Run:
+
+```bash
+uv run pytest -q \
+  tests/telemetry/test_training.py::test_generation_remains_stable_across_normal_append \
+  tests/telemetry/test_training.py::test_old_generation_requests_reset_after_stream_replacement \
+  tests/telemetry/test_training.py::test_index_loss_rotates_generation_and_invalidates_cursor \
+  tests/telemetry/test_training.py::test_expected_generation_requires_canonical_uuid
+```
+
+Expected: FAIL because status/page generation fields and `expected_generation` do not exist.
+
+- [ ] **Step 3: Record RED evidence**
+
+Save the pytest output as an Actions artifact or a committed verification note containing the exact failing head, run ID, artifact ID, and SHA-256 digest.
+
+- [ ] **Step 4: Commit the tests**
+
+```bash
+git add tests/telemetry/test_training.py
+git commit -m "test: bind telemetry cursor to stream generation"
+```
+
+---
+
+### Task 2: Commit low-contention polling RED contracts
+
+**Files:**
+- Modify: `tests/telemetry/test_training.py`
+
+**Interfaces:**
+- Consumes: private module hooks `_write_index` and `_parse_record` only inside tests.
+- Produces: deterministic tests proving unchanged polls do not write, page parsing releases the process lock, and near-tail reads are bounded.
+
+- [ ] **Step 1: Add imports**
+
+Add:
+
+```python
+import threading
+
+from trade_rl.telemetry import indexed_training as indexed
+```
+
+- [ ] **Step 2: Add no-growth write test**
+
+```python
+def test_no_growth_polls_do_not_rewrite_index(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        for sequence in range(1, 70):
+            writer.append(record(sequence))
+    assert training_telemetry_status(path).last_sequence == 69
+
+    writes: list[int] = []
+
+    def fail_on_write(_path: Path, _index: object) -> None:
+        writes.append(1)
+
+    monkeypatch.setattr(indexed, "_write_index", fail_on_write)
+
+    status = training_telemetry_status(path)
+    page = read_training_telemetry(path, after_sequence=64, limit=10)
+
+    assert status.last_sequence == 69
+    assert [item.sequence for item in page.items] == [65, 66, 67, 68, 69]
+    assert writes == []
+```
+
+- [ ] **Step 3: Add lock-release test**
+
+```python
+def test_page_parsing_does_not_hold_append_process_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        for sequence in range(1, 131):
+            writer.append(record(sequence))
+    assert training_telemetry_status(path).last_sequence == 130
+
+    original_parse = indexed._parse_record
+    parse_started = threading.Event()
+    release_parse = threading.Event()
+    reader_done = threading.Event()
+    writer_done = threading.Event()
+    errors: list[BaseException] = []
+
+    def blocking_parse(raw_line: bytes):
+        if not parse_started.is_set():
+            parse_started.set()
+            if not release_parse.wait(timeout=10.0):
+                raise TimeoutError("page parse was not released")
+        return original_parse(raw_line)
+
+    monkeypatch.setattr(indexed, "_parse_record", blocking_parse)
+
+    def read_page() -> None:
+        try:
+            read_training_telemetry(path, after_sequence=64, limit=20)
+        except BaseException as error:  # pragma: no cover - asserted below
+            errors.append(error)
+        finally:
+            reader_done.set()
+
+    def append_record() -> None:
+        try:
+            with TrainingTelemetryWriter(path, flush_every=1) as writer:
+                writer.append(record(131))
+        except BaseException as error:  # pragma: no cover - asserted below
+            errors.append(error)
+        finally:
+            writer_done.set()
+
+    reader = threading.Thread(target=read_page)
+    reader.start()
+    assert parse_started.wait(timeout=10.0)
+
+    writer = threading.Thread(target=append_record)
+    writer.start()
+    assert writer_done.wait(timeout=2.0), "writer remained blocked by page parsing"
+
+    release_parse.set()
+    reader.join(timeout=10.0)
+    writer.join(timeout=10.0)
+
+    assert reader_done.is_set()
+    assert errors == []
+    assert training_telemetry_status(path).last_sequence == 131
+```
+
+- [ ] **Step 4: Add deterministic near-tail scaling test**
+
+```python
+def test_near_tail_page_parses_at_most_one_checkpoint_stride(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    with TrainingTelemetryWriter(path, flush_every=256) as writer:
+        for sequence in range(1, 4_097):
+            writer.append(record(sequence))
+    assert training_telemetry_status(path).last_sequence == 4_096
+
+    original_parse = indexed._parse_record
+    parsed = 0
+
+    def counted_parse(raw_line: bytes):
+        nonlocal parsed
+        parsed += 1
+        return original_parse(raw_line)
+
+    monkeypatch.setattr(indexed, "_parse_record", counted_parse)
+    page = read_training_telemetry(path, after_sequence=4_080, limit=20)
+
+    assert [item.sequence for item in page.items] == list(range(4_081, 4_097))
+    assert parsed <= 80
+```
+
+- [ ] **Step 5: Run the RED tests**
+
+Run:
+
+```bash
+uv run pytest -q \
+  tests/telemetry/test_training.py::test_no_growth_polls_do_not_rewrite_index \
+  tests/telemetry/test_training.py::test_page_parsing_does_not_hold_append_process_lock \
+  tests/telemetry/test_training.py::test_near_tail_page_parses_at_most_one_checkpoint_stride
+```
+
+Expected: the no-growth write test and lock-release test FAIL against the current implementation. The near-tail bound may already pass and is retained as a non-regression contract.
+
+- [ ] **Step 6: Commit the tests**
+
+```bash
+git add tests/telemetry/test_training.py
+git commit -m "test: constrain telemetry polling critical section"
+```
+
+---
+
+### Task 3: Implement sidecar generation and snapshot reads
+
+**Files:**
+- Modify: `trade_rl/telemetry/training.py`
+- Modify: `trade_rl/telemetry/indexed_training.py`
+- Test: `tests/telemetry/test_training.py`
+- Test: `tests/telemetry/test_indexed_process_concurrency.py`
+
+**Interfaces:**
+- Produces: `TrainingTelemetryPage.stream_generation`, `TrainingTelemetryPage.reset_required`, `TrainingTelemetryStatus.stream_generation`, and `read_indexed_training_telemetry(..., expected_generation=None)`.
+- Preserves: `TrainingTelemetryWriter`, page size limits, strict record parsing, sequence gap behavior, and process lock path.
+
+- [ ] **Step 1: Add backward-compatible dataclass fields**
+
+In `trade_rl/telemetry/training.py`, change the dataclasses to:
+
+```python
+@dataclass(frozen=True, slots=True)
+class TrainingTelemetryPage:
+    items: tuple[TrainingTelemetryRecord, ...]
+    next_sequence: int
+    truncated: bool
+    malformed_lines: int
+    sequence_gaps: tuple[tuple[int, int], ...]
+    stream_generation: str | None = None
+    reset_required: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class TrainingTelemetryStatus:
+    available: bool
+    record_count: int
+    last_sequence: int
+    malformed_lines: int
+    size_bytes: int
+    stream_generation: str | None = None
+```
+
+- [ ] **Step 2: Add index v2 generation parsing**
+
+In `trade_rl/telemetry/indexed_training.py`:
+
+```python
+from uuid import UUID, uuid4
+
+_INDEX_SCHEMA = "training_telemetry_index_v2"
+
+
+def _canonical_generation(value: object, *, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"telemetry index {field_name} is invalid")
+    try:
+        resolved = str(UUID(value))
+    except (ValueError, AttributeError) as error:
+        raise ValueError(f"telemetry index {field_name} is invalid") from error
+    if resolved != value:
+        raise ValueError(f"telemetry index {field_name} is invalid")
+    return resolved
+```
+
+Add `generation: str` to `_TelemetryIndex`, include it in `to_json_dict()`, and require it in `_load_index()`.
+
+Create new indexes with:
+
+```python
+_TelemetryIndex(
+    device=int(stat.st_dev),
+    inode=int(stat.st_ino),
+    generation=str(uuid4()),
+)
+```
+
+- [ ] **Step 3: Make index refresh change-aware**
+
+Add:
+
+```python
+@dataclass(frozen=True, slots=True)
+class _IndexRefresh:
+    index: _TelemetryIndex | None
+    changed: bool
+```
+
+Refactor `_refresh_index_unlocked()` to return `_IndexRefresh`. Set `changed=True` when:
+
+- no valid index existed;
+- stream device/inode changed;
+- stream size shrank below `indexed_size`;
+- at least one complete line advanced `indexed_size`;
+- malformed/blank complete appended lines changed index counters or size.
+
+Call `_write_index()` only when `changed` is true. Do not mutate `last_scan_start` or write the index on a no-growth poll.
+
+- [ ] **Step 4: Add verified snapshot capture**
+
+Add:
+
+```python
+@dataclass(slots=True)
+class _TelemetrySnapshot:
+    handle: BinaryIO
+    size: int
+    index: _TelemetryIndex
+
+    def close(self) -> None:
+        self.handle.close()
+
+
+def _open_snapshot_unlocked(path: Path, index: _TelemetryIndex) -> _TelemetrySnapshot:
+    handle = path.open("rb")
+    try:
+        stat = os.fstat(handle.fileno())
+        if (int(stat.st_dev), int(stat.st_ino)) != (index.device, index.inode):
+            raise RuntimeError("telemetry stream identity changed")
+        if stat.st_size < index.indexed_size:
+            raise RuntimeError("telemetry stream size regressed")
+        return _TelemetrySnapshot(handle=handle, size=index.indexed_size, index=index)
+    except BaseException:
+        handle.close()
+        raise
+```
+
+- [ ] **Step 5: Implement generation-aware page reads**
+
+Change the signature to:
+
+```python
+def read_indexed_training_telemetry(
+    path: Path,
+    *,
+    after_sequence: int = 0,
+    limit: int = 512,
+    expected_generation: str | None = None,
+) -> _training.TrainingTelemetryPage:
+```
+
+Validate a non-null expected generation with `UUID` canonicalization and a `ValueError` message containing `expected_generation`.
+
+Under `_telemetry_process_lock`:
+
+1. refresh the index;
+2. return the missing-stream page when no index exists;
+3. return an empty reset page when the expected generation differs;
+4. capture `_TelemetrySnapshot` and compute the checkpoint offset.
+
+Release the lock before parsing. Parse only until `snapshot.size`, close the snapshot in `finally`, and return the index generation with `reset_required=False`.
+
+Mismatch return:
+
+```python
+return _training.TrainingTelemetryPage(
+    items=(),
+    next_sequence=0,
+    truncated=False,
+    malformed_lines=index.malformed_lines,
+    sequence_gaps=tuple(index.sequence_gaps),
+    stream_generation=index.generation,
+    reset_required=True,
+)
+```
+
+- [ ] **Step 6: Add generation to status and writer refresh usage**
+
+Update `indexed_training_telemetry_status()` to use `_IndexRefresh.index` and return `stream_generation=index.generation`.
+
+Update writer initialization and append to read `.index` from the refresh result. Preserve descriptor/path identity checks and incomplete-tail rejection.
+
+- [ ] **Step 7: Run focused Python verification**
+
+```bash
+uv run ruff check trade_rl/telemetry tests/telemetry
+uv run ruff format --check trade_rl/telemetry tests/telemetry
+uv run mypy .
+uv run pytest -q \
+  tests/telemetry/test_training.py \
+  tests/telemetry/test_indexed_process_concurrency.py \
+  tests/integrations/test_training_telemetry.py
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add \
+  trade_rl/telemetry/training.py \
+  trade_rl/telemetry/indexed_training.py \
+  tests/telemetry/test_training.py \
+  tests/telemetry/test_indexed_process_concurrency.py
+git commit -m "fix: bind telemetry pages to stream generation"
+```
+
+---
+
+### Task 4: Add Studio backend generation contract
+
+**Files:**
+- Modify: `trade_rl/studio/telemetry.py`
+- Modify: `trade_rl/studio/api.py`
+- Modify: `tests/studio/test_telemetry_api.py`
+
+**Interfaces:**
+- Consumes: Python telemetry page/status generation fields.
+- Produces: camel-case `streamGeneration`, `resetRequired`, and optional `stream_generation` query input.
+
+- [ ] **Step 1: Write failing Studio API tests**
+
+Add tests that assert:
+
+```python
+status_payload = client.get(
+    f"/api/studio/jobs/{job_id}/telemetry/status?seed=7"
+).json()
+assert UUID(status_payload["streamGeneration"])
+
+old_generation = status_payload["streamGeneration"]
+# Replace the JSONL stream with a new sequence-1 stream and remove/rebuild its index.
+reset_payload = client.get(
+    f"/api/studio/jobs/{job_id}/telemetry/events",
+    params={
+        "seed": 7,
+        "after_sequence": 10,
+        "limit": 10,
+        "stream_generation": old_generation,
+    },
+).json()
+assert reset_payload["items"] == []
+assert reset_payload["nextSequence"] == 0
+assert reset_payload["resetRequired"] is True
+assert reset_payload["streamGeneration"] != old_generation
+```
+
+Add an invalid query test:
+
+```python
+response = client.get(
+    f"/api/studio/jobs/{job_id}/telemetry/events",
+    params={"stream_generation": "not-a-uuid"},
+)
+assert response.status_code == 422
+```
+
+- [ ] **Step 2: Run RED Studio tests**
+
+```bash
+uv run pytest -q tests/studio/test_telemetry_api.py
+```
+
+Expected: FAIL because response fields and query input do not exist.
+
+- [ ] **Step 3: Implement response fields**
+
+In `trade_rl/studio/telemetry.py`:
+
+```python
+class TelemetryStatusResponse(StudioModel):
+    ...
+    stream_generation: str | None = None
+
+
+class TelemetryEventsResponse(StudioModel):
+    ...
+    stream_generation: str | None = None
+    reset_required: bool = False
+```
+
+Add `stream_generation: str | None = None` to `StudioTelemetryReader.events()` and pass it as `expected_generation`.
+
+Map page/status generation fields into the response models for both available and unavailable paths.
+
+- [ ] **Step 4: Implement API query validation**
+
+In `trade_rl/studio/api.py`, add:
+
+```python
+stream_generation: str | None = Query(
+    default=None,
+    pattern=r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+),
+```
+
+Pass it to `telemetry_reader.events()`.
+
+- [ ] **Step 5: Verify and commit**
+
+```bash
+uv run ruff check trade_rl/studio tests/studio/test_telemetry_api.py
+uv run ruff format --check trade_rl/studio tests/studio/test_telemetry_api.py
+uv run mypy .
+uv run pytest -q tests/studio/test_telemetry_api.py tests/telemetry tests/integrations/test_training_telemetry.py
+git add trade_rl/studio/telemetry.py trade_rl/studio/api.py tests/studio/test_telemetry_api.py
+git commit -m "feat: expose telemetry stream generation in Studio"
+```
+
+---
+
+### Task 5: Make frontend polling generation-safe
+
+**Files:**
+- Modify: `studio/src/data/types.ts`
+- Modify: `studio/src/live/telemetryGuards.ts`
+- Modify: `studio/src/api/studioApi.ts`
+- Modify: `studio/src/live/useTrainingTelemetry.ts`
+- Create: `studio/src/live/useTrainingTelemetry.test.tsx`
+- Modify: `studio/src/pages/LiveTrainingPage.test.tsx`
+- Modify: `studio/src/pages/RuntimePages.test.tsx`
+
+**Interfaces:**
+- Consumes: `streamGeneration` and `resetRequired` API fields.
+- Produces: generation-bound `loadTelemetryEvents()` calls and a hook that performs at most one reset/race retry.
+
+- [ ] **Step 1: Add failing guard and hook tests**
+
+Create `studio/src/live/useTrainingTelemetry.test.tsx` using `renderHook`, `act`, and `waitFor`.
+
+Test reset behavior with an API mock whose first event response is:
+
+```typescript
+{
+  seed: 7,
+  items: [],
+  nextSequence: 0,
+  truncated: false,
+  malformedLines: 0,
+  sequenceGaps: [],
+  streamGeneration: '22222222-2222-4222-8222-222222222222',
+  resetRequired: true,
+}
+```
+
+and whose retry returns one sequence-1 record for the new generation. Assert:
+
+```typescript
+await waitFor(() => expect(result.current.records.map((item) => item.sequence)).toEqual([1]))
+expect(api.loadTelemetryEvents).toHaveBeenNthCalledWith(
+  1,
+  'job-live',
+  0,
+  512,
+  7,
+  null,
+)
+expect(api.loadTelemetryEvents).toHaveBeenNthCalledWith(
+  2,
+  'job-live',
+  0,
+  512,
+  7,
+  '22222222-2222-4222-8222-222222222222',
+)
+```
+
+Add a generation-race test where status returns generation A and events returns generation B. The retry returns matching generation B. Assert no generation-A records are ever published and exactly two event calls occur.
+
+Add guard tests in the same file or a focused guard test block proving malformed generation strings and `resetRequired` non-booleans are rejected.
+
+- [ ] **Step 2: Run frontend RED**
+
+```bash
+cd studio
+npm test -- --run src/live/useTrainingTelemetry.test.tsx
+```
+
+Expected: FAIL because fields/signatures/retry behavior do not exist.
+
+- [ ] **Step 3: Extend TypeScript contracts and guards**
+
+In `studio/src/data/types.ts`:
+
+```typescript
+export interface TelemetryStatusResponse {
+  ...
+  streamGeneration: string | null
+}
+
+export interface TelemetryEventsResponse {
+  ...
+  streamGeneration: string | null
+  resetRequired: boolean
+}
+```
+
+In `telemetryGuards.ts`, add:
+
+```typescript
+const generationPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+const isNullableGeneration = (value: unknown): value is string | null =>
+  value === null || (typeof value === 'string' && generationPattern.test(value))
+```
+
+Require the generation field in status/events and require `resetRequired` to be boolean.
+
+- [ ] **Step 4: Extend the API client signature**
+
+Change `loadTelemetryEvents()` and `StudioApi.loadTelemetryEvents` to accept:
+
+```typescript
+(
+  jobId: string,
+  afterSequence?: number,
+  limit?: number,
+  seed?: number | null,
+  streamGeneration?: string | null,
+) => Promise<TelemetryEventsResponse>
+```
+
+The exported function may retain `fetcher` as its final sixth parameter. Add `stream_generation` to `URLSearchParams` only when non-null.
+
+Update all StudioApi test mocks to the new signature and add generation/reset fields to response fixtures.
+
+- [ ] **Step 5: Implement one-retry hook behavior**
+
+Add:
+
+```typescript
+const generation = useRef<string | null>(null)
+```
+
+Refactor refresh into an inner function `loadSnapshot(allowRetry: boolean)`.
+
+Rules:
+
+- call events with `generation.current`;
+- if `page.resetRequired`, clear records/status, set sequence to zero, adopt `page.streamGeneration`, and retry once;
+- if status/page generations are both non-null and differ, clear state, set generation to null, and retry once;
+- if either condition repeats when `allowRetry` is false, throw an explicit generation-change error;
+- before accepting records, require the page generation to equal the stored generation;
+- reset generation to null in the job/seed effect cleanup path.
+
+- [ ] **Step 6: Run frontend verification**
+
+```bash
+cd studio
+npm test -- --run
+npm run typecheck
+npm run build
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add \
+  studio/src/data/types.ts \
+  studio/src/live/telemetryGuards.ts \
+  studio/src/api/studioApi.ts \
+  studio/src/live/useTrainingTelemetry.ts \
+  studio/src/live/useTrainingTelemetry.test.tsx \
+  studio/src/pages/LiveTrainingPage.test.tsx \
+  studio/src/pages/RuntimePages.test.tsx
+git commit -m "fix: reset live telemetry on stream generation change"
+```
+
+---
+
+### Task 6: Verify process safety, coverage, and evidence
+
+**Files:**
+- Modify: `pyproject.toml`
+- Create: `docs/verification/2026-07-22-telemetry-cursor-generation.md`
+
+**Interfaces:**
+- Consumes: completed backend/frontend implementation.
+- Produces: a non-regressing branch coverage floor and exact-head verification evidence.
+
+- [ ] **Step 1: Run focused cross-platform process tests**
+
+Run locally or in an exact-head matrix:
+
+```bash
+uv run pytest -q \
+  tests/telemetry/test_training.py \
+  tests/telemetry/test_indexed_process_concurrency.py \
+  tests/integrations/test_training_telemetry.py \
+  tests/studio/test_telemetry_api.py
+```
+
+Run the same focused set on Ubuntu and Windows. Expected: all pass, including native `fcntl` and `msvcrt` paths.
+
+- [ ] **Step 2: Run the full repository verification**
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy .
+uv run lint-imports
+uv run pytest -q --cov=trade_rl --cov-branch --cov-report=term-missing --cov-report=json
+cd studio && npm test -- --run && npm run typecheck && npm run build
+```
+
+Expected: every command exits 0 and overall coverage remains at least 80%.
+
+- [ ] **Step 3: Compute the telemetry polling coverage floor**
+
+Run:
+
+```bash
+python - <<'PY'
+import json
+from math import floor
+
+coverage = json.load(open("coverage.json", encoding="utf-8"))
+summary = coverage["files"]["trade_rl/telemetry/indexed_training.py"]["summary"]
+covered = summary["covered_branches"]
+total = summary["num_branches"]
+percent = 100.0 if total == 0 else covered / total * 100.0
+minimum = floor(percent * 10.0) / 10.0
+print(f"covered={covered} total={total} percent={percent:.4f} minimum={minimum:.1f}")
+PY
+```
+
+Update `pyproject.toml` automatically from the measured result:
+
+```bash
+python - <<'PY'
+import json
+from math import floor
+from pathlib import Path
+
+coverage = json.loads(Path("coverage.json").read_text(encoding="utf-8"))
+summary = coverage["files"]["trade_rl/telemetry/indexed_training.py"]["summary"]
+covered = summary["covered_branches"]
+total = summary["num_branches"]
+percent = 100.0 if total == 0 else covered / total * 100.0
+minimum = floor(percent * 10.0) / 10.0
+
+path = Path("pyproject.toml")
+source = path.read_text(encoding="utf-8")
+header = "[tool.trade_rl.critical_coverage.groups.telemetry_polling]"
+block = (
+    f"\n{header}\n"
+    f"minimum = {minimum:.1f}\n"
+    "paths = [\n"
+    '    "trade_rl/telemetry/indexed_training.py",\n'
+    "]\n"
+)
+if header in source:
+    before, remainder = source.split(header, 1)
+    next_group = remainder.find("\n[tool.")
+    source = before.rstrip() + block + (
+        "" if next_group < 0 else remainder[next_group:]
+    )
+else:
+    source = source.rstrip() + "\n" + block
+path.write_text(source, encoding="utf-8")
+print(
+    f"telemetry_polling: covered={covered} total={total} "
+    f"percent={percent:.4f} minimum={minimum:.1f}"
+)
+PY
+```
+
+Do not modify or lower any existing group.
+
+- [ ] **Step 4: Re-run the full CI command after adding the ratchet**
+
+Expected: critical branch coverage passes with the measured floor.
+
+- [ ] **Step 5: Write verification evidence**
+
+Create `docs/verification/2026-07-22-telemetry-cursor-generation.md` containing:
+
+- design and plan paths;
+- RED commit SHAs and failure summaries;
+- GREEN commit SHA;
+- Ubuntu and Windows run IDs;
+- final exact-head SHA;
+- full test counts, skipped tests, warnings, total coverage, total branch coverage, and telemetry branch coverage;
+- pytest artifact ID and SHA-256 digest;
+- PostgreSQL run ID and each successful step;
+- confirmation that telemetry JSON schema remains v1, index schema is v2, and production remains `NO-GO`.
+
+- [ ] **Step 6: Commit final evidence**
+
+```bash
+git add pyproject.toml docs/verification/2026-07-22-telemetry-cursor-generation.md
+git commit -m "docs: verify generation-bound telemetry polling"
+```
+
+- [ ] **Step 7: Verify the exact final head once more**
+
+Fetch workflow runs for the final documentation commit. Do not claim completion until normal CI and PostgreSQL Catalog both report `completed/success` for that exact SHA.

--- a/docs/superpowers/specs/2026-07-22-telemetry-cursor-generation-design.md
+++ b/docs/superpowers/specs/2026-07-22-telemetry-cursor-generation-design.md
@@ -1,0 +1,161 @@
+# Generation-Bound Telemetry Polling Design
+
+## Context
+
+Indexed training telemetry is now process-safe, but the polling cursor is still only a sequence number. The sidecar index detects file replacement or truncation and rebuilds itself, while Studio clients continue sending the old `after_sequence` value. If a new stream at the same path restarts sequence numbering, the client can receive empty pages indefinitely or mix records from different stream generations.
+
+Polling also performs unnecessary durable index writes when the stream has not changed, and `read_indexed_training_telemetry()` keeps the exclusive process lock while parsing the returned page. Long page parsing can therefore delay training appends.
+
+## Goals
+
+1. Bind every status and event page to one stable opaque stream generation.
+2. Detect replacement, truncation, or index rebuild without relying on sequence rollback heuristics.
+3. Never return records from a new generation against an old generation cursor.
+4. Reset Studio buffers explicitly before records from a replacement stream are accepted.
+5. Avoid rewriting and `fsync`-ing an unchanged sidecar index.
+6. Hold the process lock only while refreshing index metadata and capturing a consistent file snapshot.
+7. Preserve training telemetry record schema v1, existing sequence semantics within one generation, and the current 2,000-record limit.
+
+## Non-goals
+
+- Replacing sequence pagination with byte cursors.
+- Persisting browser cursor state across page reloads.
+- Repairing malformed, truncated, or manually edited telemetry files.
+- Changing telemetry sampling frequency, training callbacks, job ownership, or artifact publication.
+- Supporting direct exchange execution or changing production `NO-GO` status.
+
+## Chosen approach
+
+Use a persisted opaque generation identifier in the telemetry sidecar index.
+
+The generation is created whenever the index must be rebuilt from stream identity rather than incrementally extended. It remains stable while complete records are appended to the same stream. Index deletion, stream replacement, inode change, or truncation creates a new generation. A conservative generation change after index loss is acceptable because it fails closed and forces a clean client replay.
+
+A sequence-only heuristic was rejected because a replacement stream may have the same or a larger last sequence. A complete byte-cursor API replacement was rejected because it would create unnecessary migration scope for the current Studio API.
+
+## Sidecar index contract
+
+The internal index schema moves from `training_telemetry_index_v1` to `training_telemetry_index_v2` and adds:
+
+- `generation`: canonical lower-case UUID string.
+
+Loading an old or malformed index returns `None`, causing a full rebuild and a new generation. The telemetry JSONL schema remains unchanged.
+
+`_refresh_index_unlocked()` returns an explicit refresh result containing:
+
+- the refreshed index or `None`;
+- whether durable index state changed;
+- snapshot file size;
+- an open binary snapshot handle whose identity was verified against the index when a page read requires one.
+
+The index is written only when it was created, rebuilt, or advanced through at least one complete appended line. A no-growth poll does not create a temporary file, call `fsync`, replace the index, or sync the directory.
+
+## Snapshot and lock boundary
+
+For event reads:
+
+1. Acquire the per-stream process lock.
+2. Load or rebuild the index and scan only bytes after `indexed_size`.
+3. Open the telemetry file, verify its device and inode against the index, and capture `snapshot_size = indexed_size`.
+4. Validate the caller's expected generation.
+5. Release the process lock while keeping the verified snapshot handle open.
+6. Parse only bytes up to `snapshot_size`.
+7. Close the snapshot handle.
+
+Appending after step 5 is allowed. The page never reads beyond its captured size, so new records appear on the next poll. Replacement after step 5 cannot change the already-open snapshot identity. Windows replacement is naturally blocked while the handle is open; POSIX retains the opened inode.
+
+Status polling completes entirely under the short metadata lock and returns index metadata without parsing the page body.
+
+## Public telemetry contracts
+
+`TrainingTelemetryStatus` adds the following final field with a default of `None` so existing positional construction remains compatible:
+
+- `stream_generation: str | None = None`.
+
+`TrainingTelemetryPage` adds the following final fields with defaults so existing five-argument positional construction remains compatible:
+
+- `stream_generation: str | None = None`;
+- `reset_required: bool = False`.
+
+`read_training_telemetry()` adds an optional keyword-only `expected_generation: str | None = None`.
+
+Behavior:
+
+- Missing stream: generation is `None`, page is empty, and `reset_required` is false.
+- Initial request without an expected generation: return the current generation and normal records.
+- Matching expected generation: return normal records.
+- Mismatched expected generation: return no records, `next_sequence=0`, the current generation, and `reset_required=true`.
+- A non-UUID expected generation is rejected as invalid input rather than treated as a legitimate old cursor.
+
+No records are returned on a generation mismatch. The caller must reset before replaying the new stream.
+
+## Studio API contract
+
+`TelemetryStatusResponse` adds `streamGeneration`.
+
+`TelemetryEventsResponse` adds:
+
+- `streamGeneration`;
+- `resetRequired`.
+
+The events endpoint accepts optional `stream_generation` and passes it as `expected_generation` to the telemetry reader. The query value is validated as a canonical UUID string.
+
+Studio preserves the existing camel-case response convention.
+
+## Frontend behavior
+
+`useTrainingTelemetry()` stores both sequence and generation refs.
+
+Polling behavior:
+
+1. Send the current generation with the event request when known.
+2. If `resetRequired` is true, clear buffered records, set sequence to zero, adopt the returned generation, and immediately issue one replacement-generation poll.
+3. If no generation is stored yet, adopt the page generation before accepting records.
+4. Reject a page whose generation unexpectedly differs without `resetRequired`.
+5. Compare the status and event page generations returned by the parallel requests. If both are non-null and differ, discard the responses and retry once rather than publishing a mixed snapshot.
+6. On job or seed change, clear generation, sequence, records, and status together.
+
+A single refresh performs at most one automatic reset or generation-race retry to prevent loops if the stream changes continuously.
+
+## Error handling
+
+- Invalid sidecar generation values invalidate the index and trigger a safe rebuild.
+- File identity drift during snapshot capture raises a runtime telemetry identity error; Studio converts it to `artifact_invalid`.
+- A stream that changes again during the automatic retry leaves the UI delayed/offline with an explicit error rather than combining generations.
+- Incomplete trailing records remain excluded from `indexed_size`; append continues to fail closed until the tail is resolved externally.
+
+## Testing
+
+### RED contracts
+
+1. Replace a stream after the client has cursor sequence 100; an old-generation request must currently return an empty normal page rather than an explicit reset.
+2. Delete the index while preserving the JSONL file; the generation must change and invalidate the old cursor.
+3. Instrument `_write_index`; repeated no-growth status/events polls must currently rewrite the index.
+4. Block record parsing in a reader thread; a writer append must currently remain blocked because parsing holds the process lock.
+5. Frontend receives `resetRequired`; current hook must fail to clear records and replay from zero.
+6. Status and Events return different generations during one parallel refresh; the current hook must fail to discard the mixed snapshot.
+
+### GREEN contracts
+
+- Generation remains stable across normal appends.
+- Replacement, truncation, or index loss changes generation.
+- Old generation returns no records and requests reset.
+- Reset replay returns only the new generation.
+- No-growth polls perform zero durable index writes.
+- Writer append completes while an already-snapshotted page is being parsed.
+- Status and Events generation races are retried once without publishing either response.
+- Linux and Windows compatibility tests pass.
+- Existing strict parsing, duplicate seed, process-concurrency, Studio, and integration tests remain green.
+- Add a deterministic large-stream test proving a near-tail page parses at most one checkpoint stride plus the requested page, rather than the whole file.
+
+## Compatibility and migration
+
+The sidecar index is a cache and may be rebuilt, so the v1-to-v2 transition requires no migration command. Existing telemetry JSONL files remain readable. Python and Studio response models gain additive fields with backward-compatible defaults where direct construction exists. Existing internal call sites that do not pass an expected generation retain initial-request behavior.
+
+## Acceptance criteria
+
+- Old cursor plus changed generation cannot return telemetry records.
+- Studio never combines two generations in one in-memory record buffer.
+- A status/events race cannot publish a mixed generation snapshot.
+- Repeated unchanged polls do not rewrite the index.
+- Page parsing does not hold the append serialization lock.
+- All exact-head CI, PostgreSQL, Ubuntu/Windows compatibility, frontend tests/build, and critical coverage checks pass without lowering existing thresholds.

--- a/docs/verification/2026-07-22-telemetry-cursor-generation.md
+++ b/docs/verification/2026-07-22-telemetry-cursor-generation.md
@@ -1,0 +1,273 @@
+# Generation-Bound Telemetry Polling Verification
+
+Date: 2026-07-22
+
+## Scope
+
+This verification covers the generation-bound telemetry polling change implemented in Draft PR #83.
+
+Design:
+
+- `docs/superpowers/specs/2026-07-22-telemetry-cursor-generation-design.md`
+
+Implementation plan:
+
+- `docs/superpowers/plans/2026-07-22-telemetry-cursor-generation.md`
+
+The branch starts from PR #81 exact head:
+
+- `2e56fd7b42f2677dc0440ff9ec3cc03a55e5c786`
+
+## Implemented contract
+
+- The internal sidecar index schema is `training_telemetry_index_v2`.
+- The telemetry JSONL record schema remains `training_telemetry_v1`.
+- Every valid index has a canonical lower-case UUID stream generation.
+- A normal append preserves the generation.
+- Stream replacement, truncation, invalid index state, or index loss creates a new generation.
+- A request with a stale expected generation receives no records, `next_sequence=0`, and `reset_required=True`.
+- No-growth status and event polls do not rewrite or `fsync` the sidecar index.
+- The process lock is released after an identity-verified bounded snapshot is captured; page-body parsing occurs outside the append serialization lock.
+- Studio API responses expose `streamGeneration` and `resetRequired`.
+- The frontend clears its in-memory buffer and sequence cursor before replaying a replacement generation.
+- Status and Events responses from different generations are discarded and retried once rather than published as a mixed snapshot.
+- The existing frontend `connection` contract, 2,048-record buffer cap, and stale-request cancellation behavior remain intact.
+
+## TDD evidence
+
+### Python telemetry RED
+
+Exact head:
+
+- `6407c5496e402dce36c71375a7f64de05e379771`
+
+Workflow:
+
+- Run `29915043603`
+- Conclusion: expected failure
+
+Artifact:
+
+- ID `8527504146`
+- Digest `sha256:c6c97b601316a984bfad1092a0f2f2a38a2628e550515d8622ecd60c35871dc6`
+
+Observed failures before implementation:
+
+- telemetry status and pages had no generation fields;
+- the reader accepted no expected-generation cursor;
+- stream replacement and index loss could not request an explicit reset;
+- unchanged polls rewrote the index;
+- page parsing held the process lock and blocked an append.
+
+The deterministic near-tail bounded-parse test already passed and was retained as a regression contract.
+
+### Python telemetry GREEN
+
+Implementation head:
+
+- `c04f4084375e6e56b91ffe415ed69026fa4d6389`
+
+Workflow:
+
+- Run `29915319097`
+- Conclusion: success
+
+Verification included:
+
+- Ruff formatting and linting;
+- Mypy across the Python project;
+- telemetry unit tests;
+- spawn-based process-concurrency tests;
+- training telemetry integration tests.
+
+### Studio backend RED
+
+Workflow:
+
+- Run `29915513524`
+- Conclusion: expected failure
+
+Artifact:
+
+- ID `8527690750`
+- Digest `sha256:1e08ab17ac5482b763f1dc24777d20058f7a5c9c9f5a2670e13b7cc1a8372896`
+
+Observed failures before implementation:
+
+- status and event responses did not expose a stream generation;
+- stale generation queries were ignored;
+- invalid generation queries were not rejected by the endpoint contract.
+
+### Studio backend GREEN
+
+Implementation head:
+
+- `ec6f7cdc76bdb355dadcaf6d717ab7d113887ce7`
+
+Workflow:
+
+- Run `29915833168`
+- Conclusion: success
+
+Verification included Studio API tests, telemetry tests, process tests, integration tests, Ruff, formatting, and Mypy.
+
+### Frontend RED
+
+Workflow:
+
+- Run `29916129060`
+- Conclusion: expected failure
+
+Artifact:
+
+- ID `8527945463`
+- Digest `sha256:78b78936309483c08bea9bc37c6b48210860f5456d83a1dd6085495072dd6987`
+
+Observed failures before implementation:
+
+- stale generation responses did not trigger a replay from sequence zero;
+- mixed Status and Events generations were published instead of retried;
+- malformed generation values were accepted by guards;
+- non-boolean reset flags were accepted by guards.
+
+### Frontend GREEN
+
+Implementation head:
+
+- `69ff12afa4672b810bc4a74b775b49596e753967`
+
+Workflow:
+
+- Run `29917535977`
+- Conclusion: success
+
+Verification included:
+
+- focused generation-reset hook tests;
+- the complete Vitest suite;
+- TypeScript type checking;
+- production frontend build.
+
+## Cross-platform verification
+
+Focused cross-platform workflow:
+
+- Run `29917703239`
+- Conclusion: success
+
+Linux artifact:
+
+- ID `8528622708`
+- Digest `sha256:95065be9c178d7942bff925ea464033e33e645729f21505f1fdbad727b695575`
+
+Windows artifact:
+
+- ID `8528621179`
+- Digest `sha256:9d36bfb92bc44ae85a20bedc164450e266566702a9d20375af05ce1dbca844bc`
+
+Both platforms passed the telemetry generation, process-concurrency, integration, and Studio API focused suites. Linux additionally passed Ruff, format checking, and Mypy. The Windows run exercised the native `msvcrt.locking` path.
+
+## Full-suite verification and flaky-test disposition
+
+Cleanup head:
+
+- `dc66ac1558a4b317ef3f02b26d7fbc352966ec3b`
+
+The first Core attempt reached the full test suite and produced:
+
+- `1196 passed, 1 failed, 2 skipped, 11 warnings`;
+- total coverage `83.45%`.
+
+The single failure was the existing Torch gradient comparison:
+
+- `tests/rl/test_sequence_policy_core.py::test_projection_after_selection_matches_legacy_outputs_and_gradients`
+- observed maximum absolute difference `4.112720489501953e-06` against tolerance `1e-06`.
+
+That same test had previously shown the same non-deterministic behavior outside this telemetry change. The failed Core job was rerun without changing source or tests.
+
+Same-head rerun:
+
+- CI run `29917834673`
+- Rerun Core job `88916816325`
+- Conclusion: success
+
+The rerun produced:
+
+- `1197 passed, 2 skipped, 11 warnings`;
+- total coverage `83.45%`;
+- total branch coverage `70.35%`;
+- `trade_rl/telemetry/indexed_training.py`: `76/110 = 69.09%` branch coverage.
+
+Successful rerun artifact:
+
+- ID `8528843820`
+- Digest `sha256:270768dc6ea6e5f4a0d609d34af38d3b56fe9ca2088f187d21c9e31ce95e0496`
+
+Because the failure did not reproduce on the identical head and the telemetry-focused Linux/Windows suites were already green, no unrelated Torch test tolerance change was included in this PR.
+
+## Coverage ratchet verification
+
+Ratchet head:
+
+- `664e8cd956a3d9ef62139a46cbdc5f62376807ec`
+
+The per-file critical branch threshold for `trade_rl/telemetry/indexed_training.py` was raised from `68.0%` to `69.0%`. No existing threshold was reduced.
+
+GitHub Actions:
+
+- CI run `29918540093`: success
+- PostgreSQL Catalog run `29918540139`: success
+
+Core checks:
+
+- Studio frontend tests: success
+- fixed viewport verification: success
+- workflow security: success
+- Ruff: success
+- Ruff format check: success
+- Mypy: success
+- import architecture: success
+- dead-code report: success
+- recovery and structured serving smoke: success
+- full tests and coverage: success
+- critical branch coverage: success
+- CLI smoke: success
+- Ubuntu compatibility: success
+- Windows compatibility: success
+- training image build and non-root packaged runtime probe: success
+
+Full-suite result:
+
+- `1197 passed, 2 skipped, 11 warnings`
+- total coverage `83.45%`
+- total branch coverage `70.35%`
+- indexed telemetry branch coverage `69.09%`
+- critical telemetry threshold `69.09% >= 69.0%`
+
+Pytest artifact:
+
+- ID `8528980253`
+- Digest `sha256:48d40000ee917171166d47297567af2ded2db20cddc49ba831403b1f2f26949c`
+
+PostgreSQL steps passed:
+
+- Compose validation;
+- PostgreSQL startup and readiness;
+- dependency installation;
+- migrations;
+- unit and integration tests;
+- clean shutdown.
+
+## Safety boundary
+
+- Production remains `NO-GO`.
+- Direct exchange routing is not implemented.
+- The telemetry JSONL evidence schema remains v1.
+- The index is still a rebuildable cache and is not treated as primary evidence.
+- No malformed or truncated telemetry evidence is automatically repaired.
+- No record from a replacement generation is returned against an old generation cursor.
+- PR #83 remains Draft and is not merged.
+
+## Final-head requirement
+
+This document commit creates a new exact head. Normal CI and PostgreSQL Catalog must both report `completed/success` for that documentation head before the PR is described as fully verified.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,7 @@ target = 90.0
 "trade_rl/risk/pretrade.py" = 90.0
 "trade_rl/rl/rewards.py" = 97.0
 "trade_rl/evaluation/gates.py" = 100.0
-"trade_rl/telemetry/indexed_training.py" = 68.0
+"trade_rl/telemetry/indexed_training.py" = 69.0
 
 [tool.trade_rl.critical_coverage.groups.artifacts]
 minimum = 90.0

--- a/studio/src/api/studioApi.ts
+++ b/studio/src/api/studioApi.ts
@@ -149,6 +149,7 @@ export function loadTelemetryEvents(
   afterSequence = 0,
   limit = 512,
   seed: number | null = null,
+  streamGeneration: string | null = null,
   fetcher: typeof fetch = fetch,
 ): Promise<TelemetryEventsResponse> {
   const parameters = new URLSearchParams({
@@ -156,6 +157,9 @@ export function loadTelemetryEvents(
     limit: String(limit),
   })
   if (seed !== null) parameters.set('seed', String(seed))
+  if (streamGeneration !== null) {
+    parameters.set('stream_generation', streamGeneration)
+  }
   return requestJson(
     `/api/studio/jobs/${encodeURIComponent(jobId)}/telemetry/events?${parameters.toString()}`,
     fetcher,
@@ -200,7 +204,7 @@ export interface StudioApi {
   cancelJob: (jobId: string) => Promise<JobSummary>
   loadJobLog: (jobId: string) => Promise<JobLogResponse>
   loadTelemetryStatus: (jobId: string, seed?: number | null) => Promise<TelemetryStatusResponse>
-  loadTelemetryEvents: (jobId: string, afterSequence?: number, limit?: number, seed?: number | null) => Promise<TelemetryEventsResponse>
+  loadTelemetryEvents: (jobId: string, afterSequence?: number, limit?: number, seed?: number | null, streamGeneration?: string | null) => Promise<TelemetryEventsResponse>
   loadCheckpointEvaluations?: (jobId: string) => Promise<CheckpointEvaluationsResponse>
   loadRunComparison: (leftResourceId: string, rightResourceId: string) => Promise<RunComparison>
   loadEvidenceReport: (runResourceId: string) => Promise<EvidenceReport>

--- a/studio/src/data/types.ts
+++ b/studio/src/data/types.ts
@@ -156,6 +156,7 @@ export interface TelemetryStatusResponse {
   malformedLines: number
   sizeBytes: number
   source: string | null
+  streamGeneration: string | null
 }
 
 export interface TelemetryEventsResponse {
@@ -165,6 +166,8 @@ export interface TelemetryEventsResponse {
   truncated: boolean
   malformedLines: number
   sequenceGaps: [number, number][]
+  streamGeneration: string | null
+  resetRequired: boolean
 }
 
 export interface CheckpointEvaluationItem {

--- a/studio/src/live/telemetryGuards.ts
+++ b/studio/src/live/telemetryGuards.ts
@@ -17,6 +17,9 @@ const isNumberArray = (value: unknown): value is number[] =>
   Array.isArray(value) && value.every(isFiniteNumber)
 const isStringArray = (value: unknown): value is string[] =>
   Array.isArray(value) && value.every((item) => typeof item === 'string')
+const generationPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+const isNullableGeneration = (value: unknown): value is string | null =>
+  value === null || (typeof value === 'string' && generationPattern.test(value))
 const eventTypes = new Set([
   'rollout',
   'position',
@@ -71,6 +74,7 @@ export function isTelemetryStatus(value: unknown): value is TelemetryStatusRespo
     && isNonNegativeInteger(value.malformedLines)
     && isNonNegativeInteger(value.sizeBytes)
     && (value.source === null || typeof value.source === 'string')
+    && isNullableGeneration(value.streamGeneration)
 }
 
 export function isTelemetryEvents(value: unknown): value is TelemetryEventsResponse {
@@ -88,6 +92,9 @@ export function isTelemetryEvents(value: unknown): value is TelemetryEventsRespo
     && typeof value.truncated === 'boolean'
     && isNonNegativeInteger(value.malformedLines)
     && Array.isArray(value.sequenceGaps)
+    && isNullableGeneration(value.streamGeneration)
+    && typeof value.resetRequired === 'boolean'
+    && (!value.resetRequired || (value.items.length === 0 && value.nextSequence === 0))
     && value.sequenceGaps.every((gap) =>
       Array.isArray(gap)
       && gap.length === 2

--- a/studio/src/live/useTrainingTelemetry.test.tsx
+++ b/studio/src/live/useTrainingTelemetry.test.tsx
@@ -1,0 +1,175 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { StudioApi } from '../api/studioApi'
+import type {
+  TelemetryEventsResponse,
+  TelemetryStatusResponse,
+  TrainingTelemetryRecord,
+} from '../data/types'
+import { isTelemetryEvents, isTelemetryStatus } from './telemetryGuards'
+import { useTrainingTelemetry } from './useTrainingTelemetry'
+
+const GENERATION_A = '11111111-1111-4111-8111-111111111111'
+const GENERATION_B = '22222222-2222-4222-8222-222222222222'
+
+function telemetry(sequence: number): TrainingTelemetryRecord {
+  return {
+    schemaVersion: 'training_telemetry_v1',
+    sequence,
+    recordedAt: '2026-07-22T11:00:00+00:00',
+    globalStep: sequence * 32,
+    environmentStep: sequence,
+    seed: 7,
+    environmentId: 0,
+    eventType: 'rollout',
+    marketIndex: 100 + sequence,
+    marketTime: '2026-07-22T10:55:00.000000000',
+    symbol: 'BTCUSDT',
+    open: 67_500,
+    high: 67_900,
+    low: 67_400,
+    close: 67_842.3,
+    action: [0.4],
+    executedTarget: [0.4],
+    weightsBefore: [0.2],
+    weightsAfter: [0.4],
+    portfolioValue: 101_342.85,
+    baselinePortfolioValue: 100_400,
+    reward: 0.214,
+    drawdown: 0.0086,
+    intervalCost: 4.25,
+    intervalReturn: 0.0012,
+    riskReasons: [],
+    emergencyDeleverage: false,
+    terminated: false,
+    truncated: false,
+  }
+}
+
+function status(generation: string): TelemetryStatusResponse {
+  return {
+    available: true,
+    selectedSeed: 7,
+    availableSeeds: [7],
+    recordCount: 1,
+    lastSequence: 1,
+    malformedLines: 0,
+    sizeBytes: 1024,
+    source: 'research/.staging/live/seed-7/telemetry/training-telemetry.jsonl',
+    streamGeneration: generation,
+  } as unknown as TelemetryStatusResponse
+}
+
+function page(
+  generation: string,
+  items: TrainingTelemetryRecord[],
+  resetRequired = false,
+): TelemetryEventsResponse {
+  return {
+    seed: 7,
+    items,
+    nextSequence: items.at(-1)?.sequence ?? 0,
+    truncated: false,
+    malformedLines: 0,
+    sequenceGaps: [],
+    streamGeneration: generation,
+    resetRequired,
+  } as unknown as TelemetryEventsResponse
+}
+
+function api(
+  loadTelemetryStatus: ReturnType<typeof vi.fn>,
+  loadTelemetryEvents: ReturnType<typeof vi.fn>,
+): StudioApi {
+  const unused = vi.fn().mockRejectedValue(new Error('not used'))
+  return {
+    loadDatasets: unused,
+    loadRuns: unused,
+    loadConfigs: unused,
+    loadJobs: unused,
+    submitTrainingJob: unused,
+    cancelJob: unused,
+    loadJobLog: unused,
+    loadTelemetryStatus,
+    loadTelemetryEvents,
+    loadCheckpointEvaluations: unused,
+    loadRunComparison: unused,
+    loadEvidenceReport: unused,
+    loadServingMonitor: unused,
+  } as unknown as StudioApi
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('useTrainingTelemetry generation handling', () => {
+  it('clears a stale cursor and immediately replays the replacement generation', async () => {
+    const loadStatus = vi.fn().mockResolvedValue(status(GENERATION_B))
+    const loadEvents = vi.fn()
+      .mockResolvedValueOnce(page(GENERATION_B, [], true))
+      .mockResolvedValueOnce(page(GENERATION_B, [telemetry(1)]))
+    const runtimeApi = api(loadStatus, loadEvents)
+
+    const { result, unmount } = renderHook(() =>
+      useTrainingTelemetry('job-live', runtimeApi, 7))
+
+    await waitFor(() => expect(loadEvents).toHaveBeenCalledTimes(2), { timeout: 300 })
+    await waitFor(() =>
+      expect(result.current.records.map((item) => item.sequence)).toEqual([1]))
+
+    expect(loadEvents).toHaveBeenNthCalledWith(
+      1,
+      'job-live',
+      0,
+      512,
+      7,
+      null,
+    )
+    expect(loadEvents).toHaveBeenNthCalledWith(
+      2,
+      'job-live',
+      0,
+      512,
+      7,
+      GENERATION_B,
+    )
+    unmount()
+  })
+
+  it('discards a mixed status and events generation before publishing records', async () => {
+    const loadStatus = vi.fn()
+      .mockResolvedValueOnce(status(GENERATION_A))
+      .mockResolvedValueOnce(status(GENERATION_B))
+    const loadEvents = vi.fn()
+      .mockResolvedValueOnce(page(GENERATION_B, [telemetry(99)]))
+      .mockResolvedValueOnce(page(GENERATION_B, [telemetry(1)]))
+    const runtimeApi = api(loadStatus, loadEvents)
+
+    const { result, unmount } = renderHook(() =>
+      useTrainingTelemetry('job-live', runtimeApi, 7))
+
+    await waitFor(() => expect(loadEvents).toHaveBeenCalledTimes(2), { timeout: 300 })
+    await waitFor(() =>
+      expect(result.current.records.map((item) => item.sequence)).toEqual([1]))
+    expect(result.current.records.some((item) => item.sequence === 99)).toBe(false)
+    unmount()
+  })
+})
+
+describe('telemetry generation guards', () => {
+  it('rejects an invalid status generation', () => {
+    expect(isTelemetryStatus({
+      ...status(GENERATION_A),
+      streamGeneration: 'not-a-generation',
+    })).toBe(false)
+  })
+
+  it('rejects a non-boolean reset flag', () => {
+    expect(isTelemetryEvents({
+      ...page(GENERATION_A, []),
+      resetRequired: 'yes',
+    })).toBe(false)
+  })
+})

--- a/studio/src/live/useTrainingTelemetry.ts
+++ b/studio/src/live/useTrainingTelemetry.ts
@@ -17,6 +17,18 @@ export interface TrainingTelemetryState {
   refresh: () => Promise<void>
 }
 
+function mergeRecords(
+  current: TrainingTelemetryRecord[],
+  incoming: TrainingTelemetryRecord[],
+): TrainingTelemetryRecord[] {
+  if (incoming.length === 0) return current
+  const bySequence = new Map(current.map((item) => [item.sequence, item]))
+  for (const item of incoming) bySequence.set(item.sequence, item)
+  return [...bySequence.values()]
+    .sort((left, right) => left.sequence - right.sequence)
+    .slice(-MAX_BUFFERED_RECORDS)
+}
+
 export function useTrainingTelemetry(
   jobId: string | null,
   api: StudioApi = studioApi,
@@ -28,6 +40,7 @@ export function useTrainingTelemetry(
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const sequence = useRef(0)
+  const generation = useRef<string | null>(null)
   const request = useRef(0)
 
   const refresh = useCallback(async () => {
@@ -36,32 +49,102 @@ export function useTrainingTelemetry(
       setConnection('offline')
       return
     }
+    const resolvedJobId = jobId
     const currentRequest = ++request.current
-    try {
+    setLoading(true)
+
+    async function loadSnapshot(allowRetry: boolean): Promise<void> {
+      const expectedGeneration = generation.current
       const [nextStatus, page] = await Promise.all([
-        api.loadTelemetryStatus(jobId, seed),
-        api.loadTelemetryEvents(jobId, sequence.current, 512, seed),
+        api.loadTelemetryStatus(resolvedJobId, seed),
+        api.loadTelemetryEvents(
+          resolvedJobId,
+          sequence.current,
+          512,
+          seed,
+          expectedGeneration,
+        ),
       ])
       if (currentRequest !== request.current) return
+
+      const retry = async (
+        nextGeneration: string | null,
+        reason: string,
+      ): Promise<void> => {
+        setRecords([])
+        setStatus(null)
+        setConnection('connecting')
+        sequence.current = 0
+        generation.current = nextGeneration
+        if (!allowRetry) {
+          throw new Error(`Telemetry stream changed repeatedly: ${reason}`)
+        }
+        await loadSnapshot(false)
+      }
+
+      if (page.resetRequired) {
+        if (page.streamGeneration === null) {
+          throw new Error('Telemetry reset response has no stream generation')
+        }
+        await retry(page.streamGeneration, 'cursor generation is stale')
+        return
+      }
+
+      if (
+        nextStatus.streamGeneration !== null
+        && page.streamGeneration !== null
+        && nextStatus.streamGeneration !== page.streamGeneration
+      ) {
+        await retry(null, 'status and events generations differ')
+        return
+      }
+
+      if (
+        nextStatus.available
+        && (
+          nextStatus.streamGeneration === null
+          || page.streamGeneration === null
+        )
+      ) {
+        throw new Error('Available telemetry response has no stream generation')
+      }
+
+      const resolvedGeneration = page.streamGeneration
+        ?? nextStatus.streamGeneration
+      if (generation.current === null) {
+        generation.current = resolvedGeneration
+      } else if (
+        resolvedGeneration !== null
+        && generation.current !== resolvedGeneration
+      ) {
+        throw new Error('Telemetry generation changed without a reset response')
+      }
+
       setStatus(nextStatus)
       if (page.items.length > 0) {
-        const accepted = page.items.filter((item) => item.sequence > sequence.current)
+        const accepted = page.items.filter(
+          (item) => item.sequence > sequence.current,
+        )
         if (accepted.length > 0) {
-          sequence.current = Math.max(sequence.current, page.nextSequence)
-          setRecords((current) => {
-            const bySequence = new Map(current.map((item) => [item.sequence, item]))
-            for (const item of accepted) bySequence.set(item.sequence, item)
-            return [...bySequence.values()]
-              .sort((left, right) => left.sequence - right.sequence)
-              .slice(-MAX_BUFFERED_RECORDS)
-          })
+          setRecords((current) => mergeRecords(current, accepted))
         }
       }
+      sequence.current = Math.max(sequence.current, page.nextSequence)
       setError(null)
-      setConnection(nextStatus.available ? (page.truncated ? 'delayed' : 'live') : 'delayed')
+      setConnection(
+        nextStatus.available ? (page.truncated ? 'delayed' : 'live') : 'delayed',
+      )
+    }
+
+    try {
+      await loadSnapshot(true)
     } catch (reason) {
       if (currentRequest !== request.current) return
-      setError(reason instanceof Error ? reason.message : 'テレメトリを取得できませんでした。')
+      setError(
+        reason instanceof Error
+          ? reason.message
+          : 'テレメトリを取得できませんでした。',
+      )
       setConnection('offline')
     } finally {
       if (currentRequest === request.current) setLoading(false)
@@ -71,6 +154,7 @@ export function useTrainingTelemetry(
   useEffect(() => {
     request.current += 1
     sequence.current = 0
+    generation.current = null
     setRecords([])
     setStatus(null)
     setConnection(jobId ? 'connecting' : 'offline')

--- a/studio/src/pages/LiveTrainingPage.test.tsx
+++ b/studio/src/pages/LiveTrainingPage.test.tsx
@@ -110,6 +110,7 @@ function api(): StudioApi {
         malformedLines: 0,
         sizeBytes: 2048,
         source: items.length > 0 ? `research/.staging/btc-live-001/seed-${selected}/telemetry/training-telemetry.jsonl` : null,
+        streamGeneration: items.length > 0 ? '33333333-3333-4333-8333-333333333333' : null,
       })
     }),
     loadTelemetryEvents: vi.fn().mockImplementation((
@@ -127,6 +128,8 @@ function api(): StudioApi {
         truncated: false,
         malformedLines: 0,
         sequenceGaps: [],
+        streamGeneration: '33333333-3333-4333-8333-333333333333',
+        resetRequired: false,
       })
     }),
     loadCheckpointEvaluations: vi.fn().mockResolvedValue({
@@ -243,6 +246,7 @@ describe('LiveTrainingPage', () => {
       malformedLines: 0,
       sizeBytes: 4096,
       source: 'research/.staging/btc-live-001/seed-7/telemetry/training-telemetry.jsonl',
+      streamGeneration: '33333333-3333-4333-8333-333333333333',
     })
     runtimeApi.loadTelemetryEvents = vi.fn().mockImplementation((
       _jobId: string,
@@ -254,6 +258,8 @@ describe('LiveTrainingPage', () => {
       truncated: false,
       malformedLines: 0,
       sequenceGaps: [],
+      streamGeneration: '33333333-3333-4333-8333-333333333333',
+      resetRequired: false,
     }))
 
     render(<LiveTrainingPage api={runtimeApi} />)

--- a/tests/studio/test_telemetry_api.py
+++ b/tests/studio/test_telemetry_api.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import json
+import os
 from pathlib import Path
+from uuid import UUID
 
 from trade_rl.telemetry.training import TrainingTelemetryRecord, TrainingTelemetryWriter
 
@@ -79,7 +82,10 @@ def test_telemetry_status_and_cursor_page_are_scoped_to_known_job(
     )
 
     assert status.status_code == 200
-    assert status.json() == {
+    status_payload = status.json()
+    generation = status_payload.pop("streamGeneration")
+    assert str(UUID(generation)) == generation
+    assert status_payload == {
         "available": True,
         "selectedSeed": 7,
         "availableSeeds": [7],
@@ -94,6 +100,8 @@ def test_telemetry_status_and_cursor_page_are_scoped_to_known_job(
     assert [item["sequence"] for item in page.json()["items"]] == [2]
     assert page.json()["nextSequence"] == 2
     assert page.json()["truncated"] is False
+    assert page.json()["streamGeneration"] == generation
+    assert page.json()["resetRequired"] is False
 
 
 def test_telemetry_can_select_independent_seed_streams(tmp_path: Path) -> None:
@@ -146,6 +154,7 @@ def test_telemetry_reports_unavailable_and_rejects_unknown_job(tmp_path: Path) -
     assert unavailable.json()["selectedSeed"] is None
     assert unavailable.json()["availableSeeds"] == []
     assert unavailable.json()["source"] is None
+    assert unavailable.json()["streamGeneration"] is None
     assert missing.status_code == 404
     assert missing.json()["detail"]["code"] == "resource_not_found"
 
@@ -167,3 +176,62 @@ def test_telemetry_rejects_multiple_streams_for_one_seed(tmp_path: Path) -> None
 
     assert response.status_code != 200
     assert response.json()["detail"]["code"] == "artifact_invalid"
+
+
+def test_old_stream_generation_requests_reset_without_returning_records(
+    tmp_path: Path,
+) -> None:
+    api, _, catalog, _ = client(tmp_path)
+    created = api.post(
+        "/api/studio/jobs/training",
+        json=request(catalog, run_id="live-reset").model_dump(by_alias=True),
+    ).json()
+    stream = stream_path(tmp_path, "live-reset", 7)
+    with TrainingTelemetryWriter(stream, flush_every=1) as writer:
+        writer.append(record(1))
+        writer.append(record(2))
+    old_generation = api.get(
+        f"/api/studio/jobs/{created['id']}/telemetry/status"
+    ).json()["streamGeneration"]
+
+    replacement = tmp_path / "replacement.jsonl"
+    replacement.write_text(
+        json.dumps(record(1).to_json_dict(), sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(replacement, stream)
+
+    response = api.get(
+        f"/api/studio/jobs/{created['id']}/telemetry/events",
+        params={
+            "seed": 7,
+            "after_sequence": 2,
+            "limit": 10,
+            "stream_generation": old_generation,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["items"] == []
+    assert payload["nextSequence"] == 0
+    assert payload["resetRequired"] is True
+    assert payload["streamGeneration"] != old_generation
+    assert str(UUID(payload["streamGeneration"])) == payload["streamGeneration"]
+
+
+def test_telemetry_events_reject_invalid_stream_generation(tmp_path: Path) -> None:
+    api, _, catalog, _ = client(tmp_path)
+    created = api.post(
+        "/api/studio/jobs/training",
+        json=request(catalog, run_id="live-invalid-generation").model_dump(
+            by_alias=True
+        ),
+    ).json()
+
+    response = api.get(
+        f"/api/studio/jobs/{created['id']}/telemetry/events",
+        params={"stream_generation": "not-a-uuid"},
+    )
+
+    assert response.status_code == 422

--- a/tests/telemetry/test_training.py
+++ b/tests/telemetry/test_training.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import os
+import threading
 from pathlib import Path
 
 import pytest
@@ -11,6 +13,7 @@ from trade_rl.telemetry import (
     read_training_telemetry,
     training_telemetry_status,
 )
+from trade_rl.telemetry import indexed_training as indexed
 
 
 def record(sequence: int, *, event_type: str = "rollout") -> TrainingTelemetryRecord:
@@ -173,4 +176,195 @@ def test_index_rebuilds_after_stream_replacement(tmp_path: Path) -> None:
     assert status.last_sequence == 1
     assert rebuilt_payload["last_scan_start"] == 0
     assert [item.sequence for item in page.items] == [1]
-    assert next_payload["last_scan_start"] == path.stat().st_size
+    assert next_payload == rebuilt_payload
+
+
+def _required_generation(value: str | None) -> str:
+    assert value is not None
+    return value
+
+
+def test_generation_remains_stable_across_normal_append(tmp_path: Path) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        writer.append(record(1))
+    first = training_telemetry_status(path)
+
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        writer.append(record(2))
+    second = training_telemetry_status(path)
+
+    assert _required_generation(first.stream_generation) == second.stream_generation
+
+
+def test_old_generation_requests_reset_after_stream_replacement(tmp_path: Path) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        writer.append(record(1))
+        writer.append(record(2))
+    old_generation = _required_generation(
+        training_telemetry_status(path).stream_generation
+    )
+
+    replacement = tmp_path / "replacement.jsonl"
+    replacement.write_text(
+        json.dumps(record(1).to_json_dict(), sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(replacement, path)
+
+    page = read_training_telemetry(
+        path,
+        after_sequence=2,
+        limit=10,
+        expected_generation=old_generation,
+    )
+
+    assert page.items == ()
+    assert page.next_sequence == 0
+    assert page.reset_required is True
+    assert page.stream_generation not in (None, old_generation)
+
+
+def test_index_loss_rotates_generation_and_invalidates_cursor(tmp_path: Path) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        writer.append(record(1))
+    first = training_telemetry_status(path)
+    old_generation = _required_generation(first.stream_generation)
+    path.with_name(f"{path.name}.index.json").unlink()
+
+    page = read_training_telemetry(
+        path,
+        after_sequence=1,
+        limit=10,
+        expected_generation=old_generation,
+    )
+
+    assert page.items == ()
+    assert page.reset_required is True
+    assert page.stream_generation not in (None, old_generation)
+
+
+def test_expected_generation_requires_canonical_uuid(tmp_path: Path) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        writer.append(record(1))
+
+    with pytest.raises(ValueError, match="expected_generation"):
+        read_training_telemetry(
+            path,
+            after_sequence=0,
+            limit=10,
+            expected_generation="not-a-generation",
+        )
+
+
+def test_no_growth_polls_do_not_rewrite_index(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        for sequence in range(1, 70):
+            writer.append(record(sequence))
+    assert training_telemetry_status(path).last_sequence == 69
+
+    writes: list[int] = []
+
+    def fail_on_write(_path: Path, _index: object) -> None:
+        writes.append(1)
+
+    monkeypatch.setattr(indexed, "_write_index", fail_on_write)
+
+    status = training_telemetry_status(path)
+    page = read_training_telemetry(path, after_sequence=64, limit=10)
+
+    assert status.last_sequence == 69
+    assert [item.sequence for item in page.items] == [65, 66, 67, 68, 69]
+    assert writes == []
+
+
+def test_page_parsing_does_not_hold_append_process_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        for sequence in range(1, 131):
+            writer.append(record(sequence))
+    assert training_telemetry_status(path).last_sequence == 130
+
+    original_parse = indexed._parse_record
+    parse_started = threading.Event()
+    release_parse = threading.Event()
+    reader_done = threading.Event()
+    writer_done = threading.Event()
+    errors: list[BaseException] = []
+
+    def blocking_parse(raw_line: bytes) -> TrainingTelemetryRecord:
+        if not parse_started.is_set():
+            parse_started.set()
+            if not release_parse.wait(timeout=10.0):
+                raise TimeoutError("page parse was not released")
+        return original_parse(raw_line)
+
+    monkeypatch.setattr(indexed, "_parse_record", blocking_parse)
+
+    def read_page() -> None:
+        try:
+            read_training_telemetry(path, after_sequence=64, limit=20)
+        except BaseException as error:  # pragma: no cover - asserted below
+            errors.append(error)
+        finally:
+            reader_done.set()
+
+    def append_record() -> None:
+        try:
+            with TrainingTelemetryWriter(path, flush_every=1) as writer:
+                writer.append(record(131))
+        except BaseException as error:  # pragma: no cover - asserted below
+            errors.append(error)
+        finally:
+            writer_done.set()
+
+    reader = threading.Thread(target=read_page)
+    reader.start()
+    assert parse_started.wait(timeout=10.0)
+
+    writer = threading.Thread(target=append_record)
+    writer.start()
+    assert writer_done.wait(timeout=2.0), "writer remained blocked by page parsing"
+
+    release_parse.set()
+    reader.join(timeout=10.0)
+    writer.join(timeout=10.0)
+
+    assert reader_done.is_set()
+    assert errors == []
+    assert training_telemetry_status(path).last_sequence == 131
+
+
+def test_near_tail_page_parses_at_most_one_checkpoint_stride(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    with TrainingTelemetryWriter(path, flush_every=256) as writer:
+        for sequence in range(1, 4_097):
+            writer.append(record(sequence))
+    assert training_telemetry_status(path).last_sequence == 4_096
+
+    original_parse = indexed._parse_record
+    parsed = 0
+
+    def counted_parse(raw_line: bytes) -> TrainingTelemetryRecord:
+        nonlocal parsed
+        parsed += 1
+        return original_parse(raw_line)
+
+    monkeypatch.setattr(indexed, "_parse_record", counted_parse)
+    page = read_training_telemetry(path, after_sequence=4_080, limit=20)
+
+    assert [item.sequence for item in page.items] == list(range(4_081, 4_097))
+    assert parsed <= 80

--- a/trade_rl/studio/api.py
+++ b/trade_rl/studio/api.py
@@ -185,12 +185,20 @@ def create_app(
         seed: int | None = Query(default=None, ge=0),
         after_sequence: int = Query(default=0, ge=0),
         limit: int = Query(default=512, ge=1, le=2_000),
+        stream_generation: str | None = Query(
+            default=None,
+            pattern=(
+                r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-"
+                r"[0-9a-f]{4}-[0-9a-f]{12}$"
+            ),
+        ),
     ) -> TelemetryEventsResponse:
         return telemetry_reader.events(
             resolved_supervisor.get_job(job_id),
             seed=seed,
             after_sequence=after_sequence,
             limit=limit,
+            stream_generation=stream_generation,
         )
 
     @app.get(

--- a/trade_rl/studio/telemetry.py
+++ b/trade_rl/studio/telemetry.py
@@ -73,6 +73,7 @@ class TelemetryStatusResponse(StudioModel):
     malformed_lines: int = Field(ge=0)
     size_bytes: int = Field(ge=0)
     source: str | None = None
+    stream_generation: str | None = None
 
 
 class TelemetryEventsResponse(StudioModel):
@@ -82,6 +83,8 @@ class TelemetryEventsResponse(StudioModel):
     truncated: bool
     malformed_lines: int = Field(ge=0)
     sequence_gaps: tuple[tuple[int, int], ...]
+    stream_generation: str | None = None
+    reset_required: bool = False
 
 
 def _response(record: TelemetryRecordInput) -> TelemetryRecordResponse:
@@ -194,6 +197,7 @@ class StudioTelemetryReader:
             malformed_lines=status.malformed_lines,
             size_bytes=status.size_bytes,
             source=self._source(path),
+            stream_generation=status.stream_generation,
         )
 
     def events(
@@ -203,6 +207,7 @@ class StudioTelemetryReader:
         seed: int | None = None,
         after_sequence: int,
         limit: int,
+        stream_generation: str | None = None,
     ) -> TelemetryEventsResponse:
         _, selected_seed, path = self._selection(job, seed)
         if path is None:
@@ -218,6 +223,7 @@ class StudioTelemetryReader:
             path,
             after_sequence=after_sequence,
             limit=limit,
+            expected_generation=stream_generation,
         )
         if selected_seed is None or any(
             item.seed != selected_seed for item in page.items
@@ -232,6 +238,8 @@ class StudioTelemetryReader:
             truncated=page.truncated,
             malformed_lines=page.malformed_lines,
             sequence_gaps=page.sequence_gaps,
+            stream_generation=page.stream_generation,
+            reset_required=page.reset_required,
         )
 
 

--- a/trade_rl/telemetry/indexed_training.py
+++ b/trade_rl/telemetry/indexed_training.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from types import TracebackType
 from typing import Any, BinaryIO, Self, cast
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from trade_rl.telemetry import training as _training
 
@@ -23,7 +23,7 @@ if sys.platform == "win32":
 else:
     import fcntl
 
-_INDEX_SCHEMA = "training_telemetry_index_v1"
+_INDEX_SCHEMA = "training_telemetry_index_v2"
 _INDEX_STRIDE = 64
 _LOCK_RETRY_SECONDS = 0.01
 _BaseRecord = _training.TrainingTelemetryRecord
@@ -54,6 +54,7 @@ class StrictTrainingTelemetryRecord(_BaseRecord):
 class _TelemetryIndex:
     device: int
     inode: int
+    generation: str
     indexed_size: int = 0
     last_scan_start: int = 0
     record_count: int = 0
@@ -67,6 +68,7 @@ class _TelemetryIndex:
             "schema_version": _INDEX_SCHEMA,
             "device": self.device,
             "inode": self.inode,
+            "generation": self.generation,
             "indexed_size": self.indexed_size,
             "last_scan_start": self.last_scan_start,
             "record_count": self.record_count,
@@ -75,6 +77,22 @@ class _TelemetryIndex:
             "sequence_gaps": self.sequence_gaps,
             "checkpoints": self.checkpoints,
         }
+
+
+@dataclass(frozen=True, slots=True)
+class _IndexRefresh:
+    index: _TelemetryIndex | None
+    changed: bool
+
+
+@dataclass(slots=True)
+class _TelemetrySnapshot:
+    handle: BinaryIO
+    size: int
+    index: _TelemetryIndex
+
+    def close(self) -> None:
+        self.handle.close()
 
 
 def _index_path(path: Path) -> Path:
@@ -89,6 +107,27 @@ def _non_negative_int(value: object, *, field_name: str) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value < 0:
         raise ValueError(f"telemetry index {field_name} is invalid")
     return value
+
+
+def _canonical_generation(value: object, *, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"telemetry index {field_name} is invalid")
+    try:
+        resolved = str(UUID(value))
+    except (AttributeError, ValueError) as error:
+        raise ValueError(f"telemetry index {field_name} is invalid") from error
+    if resolved != value:
+        raise ValueError(f"telemetry index {field_name} is invalid")
+    return resolved
+
+
+def _expected_generation(value: str | None) -> str | None:
+    if value is None:
+        return None
+    try:
+        return _canonical_generation(value, field_name="expected_generation")
+    except ValueError as error:
+        raise ValueError("expected_generation must be a canonical UUID") from error
 
 
 def _pairs(value: object, *, field_name: str) -> list[Pair]:
@@ -118,6 +157,9 @@ def _load_index(path: Path) -> _TelemetryIndex | None:
         return _TelemetryIndex(
             device=_non_negative_int(raw.get("device"), field_name="device"),
             inode=_non_negative_int(raw.get("inode"), field_name="inode"),
+            generation=_canonical_generation(
+                raw.get("generation"), field_name="generation"
+            ),
             indexed_size=_non_negative_int(
                 raw.get("indexed_size"), field_name="indexed_size"
             ),
@@ -199,7 +241,11 @@ def _acquire_process_lock(handle: BinaryIO) -> None:
                 msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
                 return
             except OSError as error:
-                if error.errno not in (errno.EACCES, errno.EAGAIN, errno.EDEADLK):
+                if error.errno not in (
+                    errno.EACCES,
+                    errno.EAGAIN,
+                    errno.EDEADLK,
+                ):
                     raise
                 time.sleep(_LOCK_RETRY_SECONDS)
     else:
@@ -234,29 +280,43 @@ def _parse_record(raw_line: bytes) -> StrictTrainingTelemetryRecord:
     )
 
 
-def _refresh_index_unlocked(path: Path) -> _TelemetryIndex | None:
+def _new_index(stat: os.stat_result) -> _TelemetryIndex:
+    return _TelemetryIndex(
+        device=int(stat.st_dev),
+        inode=int(stat.st_ino),
+        generation=str(uuid4()),
+    )
+
+
+def _refresh_index_unlocked(path: Path) -> _IndexRefresh:
     resolved = Path(path)
     if not resolved.is_file() or resolved.is_symlink():
-        return None
+        return _IndexRefresh(None, False)
     stat = resolved.stat()
     existing = _load_index(resolved)
-    if (
+    rebuilt = (
         existing is None
         or existing.device != int(stat.st_dev)
         or existing.inode != int(stat.st_ino)
         or stat.st_size < existing.indexed_size
-    ):
-        index = _TelemetryIndex(device=int(stat.st_dev), inode=int(stat.st_ino))
-    else:
-        index = existing
-    index.last_scan_start = index.indexed_size
+    )
+    index = _new_index(stat) if rebuilt else existing
+    if index is None:
+        raise RuntimeError("telemetry index refresh failed")
+    changed = rebuilt
+    scan_start = index.indexed_size
+    advanced = False
 
     with resolved.open("rb") as handle:
-        handle.seek(index.indexed_size)
+        handle.seek(scan_start)
         while True:
             raw_line = handle.readline()
             if not raw_line or not raw_line.endswith(b"\n"):
                 break
+            if not advanced:
+                index.last_scan_start = scan_start
+                advanced = True
+            changed = True
             end_offset = handle.tell()
             index.indexed_size = end_offset
             line = raw_line.strip()
@@ -264,7 +324,12 @@ def _refresh_index_unlocked(path: Path) -> _TelemetryIndex | None:
                 continue
             try:
                 record = _parse_record(line)
-            except (UnicodeError, json.JSONDecodeError, TypeError, ValueError):
+            except (
+                UnicodeError,
+                json.JSONDecodeError,
+                TypeError,
+                ValueError,
+            ):
                 index.malformed_lines += 1
                 continue
             if record.sequence <= index.last_sequence:
@@ -278,8 +343,33 @@ def _refresh_index_unlocked(path: Path) -> _TelemetryIndex | None:
             index.last_sequence = record.sequence
             if index.record_count == 1 or index.record_count % _INDEX_STRIDE == 0:
                 index.checkpoints.append((record.sequence, end_offset))
-    _write_index(resolved, index)
-    return index
+    if changed:
+        _write_index(resolved, index)
+    return _IndexRefresh(index, changed)
+
+
+def _open_snapshot_unlocked(
+    path: Path,
+    index: _TelemetryIndex,
+) -> _TelemetrySnapshot:
+    handle = path.open("rb")
+    try:
+        stat = os.fstat(handle.fileno())
+        if (int(stat.st_dev), int(stat.st_ino)) != (
+            index.device,
+            index.inode,
+        ):
+            raise RuntimeError("telemetry stream identity changed")
+        if stat.st_size < index.indexed_size:
+            raise RuntimeError("telemetry stream size regressed")
+        return _TelemetrySnapshot(
+            handle=handle,
+            size=index.indexed_size,
+            index=index,
+        )
+    except BaseException:
+        handle.close()
+        raise
 
 
 def _seek_offset(index: _TelemetryIndex, after_sequence: int) -> Pair:
@@ -296,56 +386,75 @@ def read_indexed_training_telemetry(
     *,
     after_sequence: int = 0,
     limit: int = 512,
+    expected_generation: str | None = None,
 ) -> _training.TrainingTelemetryPage:
     if isinstance(after_sequence, bool) or after_sequence < 0:
         raise ValueError("after_sequence must be non-negative")
     if isinstance(limit, bool) or limit <= 0 or limit > 2_000:
         raise ValueError("limit must be between 1 and 2000")
+    expected = _expected_generation(expected_generation)
     resolved = Path(path)
     with _telemetry_process_lock(resolved):
-        index = _refresh_index_unlocked(resolved)
+        refresh = _refresh_index_unlocked(resolved)
+        index = refresh.index
         if index is None:
             return _training.TrainingTelemetryPage((), after_sequence, False, 0, ())
-
+        if expected is not None and expected != index.generation:
+            return _training.TrainingTelemetryPage(
+                items=(),
+                next_sequence=0,
+                truncated=False,
+                malformed_lines=index.malformed_lines,
+                sequence_gaps=tuple(index.sequence_gaps),
+                stream_generation=index.generation,
+                reset_required=True,
+            )
         checkpoint_sequence, offset = _seek_offset(index, after_sequence)
-        previous_sequence = checkpoint_sequence or None
-        items: list[StrictTrainingTelemetryRecord] = []
-        truncated = False
-        snapshot_size = index.indexed_size
-        with resolved.open("rb") as handle:
-            handle.seek(offset)
-            while handle.tell() < snapshot_size:
-                remaining = snapshot_size - handle.tell()
-                raw_line = handle.readline(remaining)
-                if not raw_line or not raw_line.endswith(b"\n"):
-                    break
-                line = raw_line.strip()
-                if not line:
-                    continue
-                try:
-                    record = _parse_record(line)
-                except (UnicodeError, json.JSONDecodeError, TypeError, ValueError):
-                    continue
-                if (
-                    previous_sequence is not None
-                    and record.sequence <= previous_sequence
-                ):
-                    continue
-                previous_sequence = record.sequence
-                if record.sequence <= after_sequence:
-                    continue
-                if len(items) >= limit:
-                    truncated = True
-                    break
-                items.append(record)
-        next_sequence = items[-1].sequence if items else after_sequence
-        return _training.TrainingTelemetryPage(
-            items=tuple(items),
-            next_sequence=next_sequence,
-            truncated=truncated,
-            malformed_lines=index.malformed_lines,
-            sequence_gaps=tuple(index.sequence_gaps),
-        )
+        snapshot = _open_snapshot_unlocked(resolved, index)
+
+    previous_sequence = checkpoint_sequence or None
+    items: list[StrictTrainingTelemetryRecord] = []
+    truncated = False
+    try:
+        snapshot.handle.seek(offset)
+        while snapshot.handle.tell() < snapshot.size:
+            remaining = snapshot.size - snapshot.handle.tell()
+            raw_line = snapshot.handle.readline(remaining)
+            if not raw_line or not raw_line.endswith(b"\n"):
+                break
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                record = _parse_record(line)
+            except (
+                UnicodeError,
+                json.JSONDecodeError,
+                TypeError,
+                ValueError,
+            ):
+                continue
+            if previous_sequence is not None and record.sequence <= previous_sequence:
+                continue
+            previous_sequence = record.sequence
+            if record.sequence <= after_sequence:
+                continue
+            if len(items) >= limit:
+                truncated = True
+                break
+            items.append(record)
+    finally:
+        snapshot.close()
+    next_sequence = items[-1].sequence if items else after_sequence
+    return _training.TrainingTelemetryPage(
+        items=tuple(items),
+        next_sequence=next_sequence,
+        truncated=truncated,
+        malformed_lines=snapshot.index.malformed_lines,
+        sequence_gaps=tuple(snapshot.index.sequence_gaps),
+        stream_generation=snapshot.index.generation,
+        reset_required=False,
+    )
 
 
 def indexed_training_telemetry_status(
@@ -353,15 +462,22 @@ def indexed_training_telemetry_status(
 ) -> _training.TrainingTelemetryStatus:
     resolved = Path(path)
     with _telemetry_process_lock(resolved):
-        index = _refresh_index_unlocked(resolved)
+        refresh = _refresh_index_unlocked(resolved)
+        index = refresh.index
         if index is None:
             return _training.TrainingTelemetryStatus(False, 0, 0, 0, 0)
+        snapshot = _open_snapshot_unlocked(resolved, index)
+        try:
+            size_bytes = int(os.fstat(snapshot.handle.fileno()).st_size)
+        finally:
+            snapshot.close()
         return _training.TrainingTelemetryStatus(
             available=True,
             record_count=index.record_count,
             last_sequence=index.last_sequence,
             malformed_lines=index.malformed_lines,
-            size_bytes=resolved.stat().st_size,
+            size_bytes=size_bytes,
+            stream_generation=index.generation,
         )
 
 
@@ -392,7 +508,7 @@ class IndexedTrainingTelemetryWriter(_BaseWriter):
         self._fd: int | None = descriptor
         try:
             with _telemetry_process_lock(self.path):
-                index = _refresh_index_unlocked(self.path)
+                index = _refresh_index_unlocked(self.path).index
                 self._last_sequence = 0 if index is None else index.last_sequence
         except BaseException:
             os.close(descriptor)
@@ -415,7 +531,7 @@ class IndexedTrainingTelemetryWriter(_BaseWriter):
             if descriptor is None:
                 raise RuntimeError("telemetry writer is closed")
             with _telemetry_process_lock(self.path):
-                index = _refresh_index_unlocked(self.path)
+                index = _refresh_index_unlocked(self.path).index
                 if index is None:
                     raise RuntimeError("telemetry stream is unavailable")
                 path_stat = self.path.stat()

--- a/trade_rl/telemetry/training.py
+++ b/trade_rl/telemetry/training.py
@@ -278,6 +278,8 @@ class TrainingTelemetryPage:
     truncated: bool
     malformed_lines: int
     sequence_gaps: tuple[tuple[int, int], ...]
+    stream_generation: str | None = None
+    reset_required: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -287,6 +289,7 @@ class TrainingTelemetryStatus:
     last_sequence: int
     malformed_lines: int
     size_bytes: int
+    stream_generation: str | None = None
 
 
 class TrainingTelemetryWriter:


### PR DESCRIPTION
## Summary

Recreates the verified PR #83 generation-bound telemetry polling on the current `main` history, after telemetry process locking was merged independently through PR #95.

- persists a canonical UUID stream generation in rebuildable index schema `training_telemetry_index_v2`
- keeps generation stable across normal appends and rotates it after replacement, truncation, invalid index state, or index loss
- returns no replacement-generation records for a stale cursor and reports `next_sequence=0` with `reset_required=true`
- avoids sidecar rewrites and `fsync` during no-growth polling
- captures an identity-verified bounded file snapshot under the stream lock, then parses the page outside the append lock
- exposes `streamGeneration` and `resetRequired` through Python and Studio APIs
- validates canonical UUID query values
- resets the frontend buffer and replays once from sequence zero after generation changes
- retries once when Status and Events generations disagree, without publishing mixed records
- preserves stale-request cancellation, connection state, and the 2,048-record cap

Telemetry JSONL evidence remains `training_telemetry_v1`; only the rebuildable sidecar index moves to v2.

## Clean scope

Verified base: `c449f424d556bf7e7d4fe1f43625c786c0243dc0`

Final head: `1c96d0c4e85f7bc84027e586db2bbae8bbff2849`

The effective diff is exactly 16 files and contains no dependency history. The existing environment/episode-isolation test in `LiveTrainingPage.test.tsx` is preserved; this PR adds only six generation fields to its two mock response paths.

During verification, `main` advanced by documentation-only PR #98 (`b51cd9e840da28d987c1056bbe2f7d7532ca932a`). The new main commit changes only the previous telemetry-concurrency verification document and does not overlap this PR's 16-file diff.

## Original TDD evidence

The original PR #83 recorded independent RED/GREEN phases for Python telemetry, Studio backend, and the React polling hook, plus Linux and Windows process verification.

Original final verification:

- CI run `29918835669`
- PostgreSQL Catalog run `29918835603`
- final pytest artifact `8529103393`
- indexed telemetry branch coverage `76/110 = 69.09% >= 69.0%`

## Clean exact-head verification

GitHub Actions CI run `29957142356`: **success**

- Studio Vitest, TypeScript, production build, and fixed viewport: passed
- workflow security: passed
- Ruff and format: passed
- Mypy: passed
- Import Linter: passed
- dead-code report: passed
- recovery and structured Serving smoke: passed
- full Pytest: `1206 passed, 2 skipped, 11 warnings`
- total coverage: `83.45%`
- total branch coverage: `70.35%`
- `trade_rl/telemetry/indexed_training.py`: `76/110 = 69.09% >= 69.0%`
- critical branch-coverage ratchets: passed
- CLI smoke: passed
- Ubuntu compatibility and generation/process-concurrency regressions: passed
- Windows compatibility, native locking, and generation regressions: passed
- complete training-image build and packaged non-root runtime probe: passed

PostgreSQL Catalog run `29957142448`: **success**

- exact-head checkout: passed
- Compose validation: passed
- PostgreSQL startup/readiness: passed
- installation and migration: passed
- unit and integration tests: passed
- shutdown and cleanup: passed

Exact-head artifacts:

- pytest diagnostics `8544561261`, digest `sha256:85df4d375e4c409e709df914e497385c14ffd9428ea20d2d63b8a3be8971fe83`
- architecture diagnostics `8544516089`, digest `sha256:fa87b745a44a7615edca253764b3054b017650127cf444c5e05dfb23d2b6d975`
- static diagnostics `8544515628`, digest `sha256:a98315d2d8c74b6c3c3180e59b3a7d40df4e97f2e42c6bb04015b4a56f344d1e`
- training-image evidence `8544510019`, digest `sha256:62cefb4020eecad1b2d1311dc24c34f4486eb124828696a077c3cc3ddc016596`
- Studio layout diagnostics `8544504573`, digest `sha256:dcbfc3f54835bb4ea98124a5022f9815589d1007b9d138cc6131edd7e5e6826d`
- Windows compatibility `8544500680`, digest `sha256:a05554f464e201a4ae35a3e6706b09ff49ec005da86b5307f847d4f580a94b9d`
- Ubuntu compatibility `8544494654`, digest `sha256:839bec87feacf897364d63f7b69257ec456a5fa7ec2256a431f7aa111374ccc8`

## Review result

The clean diff keeps JSONL evidence at v1, treats index v2 as rebuildable cache state, and never returns replacement-generation records against an old generation cursor. Frontend reset/replay is bounded to one automatic retry and preserves the existing environment/episode isolation tests. No critical or important review issue remains.

## Safety boundary

- production remains `NO-GO`
- direct exchange routing is not implemented
- telemetry JSONL evidence schema remains v1
- sidecar index v2 is a rebuildable cache, not primary evidence
- malformed or truncated evidence is not automatically repaired
