### PR TITLE
fix: add producer telemetry episode identity

### DIFF
--- a/docs/superpowers/plans/2026-07-23-telemetry-episode-identity.md
+++ b/docs/superpowers/plans/2026-07-23-telemetry-episode-identity.md
@@ -1,0 +1,86 @@
+# Telemetry Episode Identity Implementation Plan
+
+Date: 2026-07-23
+
+## Scope
+
+Implement the design in `docs/superpowers/specs/2026-07-23-telemetry-episode-identity-design.md` as one independent PR from current `main`.
+
+## Task 1 — Reproduce the missing boundary
+
+Add a frontend regression in `studio/src/live/telemetryStreams.test.ts` where:
+
+- one environment emits records for two explicit episode IDs;
+- terminal flags are absent;
+- `environmentStep` and `marketIndex` remain monotonic;
+- the expected current episode contains only the newest explicit ID.
+
+Verify the focused test fails because the current implementation joins both episodes.
+
+## Task 2 — Add the record contract
+
+Update `trade_rl/telemetry/training.py`:
+
+- add nullable `episode_id`;
+- validate non-negative integer semantics;
+- serialize it in JSON;
+- accept missing or null values as legacy records;
+- reject boolean, negative, and non-integer explicit values.
+
+Add focused record-contract tests.
+
+## Task 3 — Allocate identity in the producer
+
+Update `trade_rl/rl/training_telemetry.py`:
+
+- maintain an active episode ID per vector environment;
+- allocate a new ID for a new environment episode;
+- emit the ID on every retained record;
+- rotate only after writing a terminal or truncated record;
+- clear previous-close and previous-weight fallback state at rotation.
+
+Add integration tests for interleaved environments, stable identity, terminal rotation, and fallback-state reset.
+
+## Task 4 — Expose Studio and browser contracts
+
+Update:
+
+- `trade_rl/studio/telemetry.py`;
+- `studio/src/data/types.ts`;
+- `studio/src/live/telemetryGuards.ts`;
+- affected fixtures.
+
+Require strict explicit values while normalizing legacy omission to `null`.
+
+## Task 5 — Prefer explicit identity in current UI boundary
+
+Update the existing `currentEnvironmentEpisode()` implementation rather than importing the older alternate page/track implementation:
+
+- latest explicit ID selects exact matching records;
+- latest legacy record uses the existing heuristic;
+- existing environment and current-episode UI remains unchanged.
+
+Keep PR #85 behavior and tests intact.
+
+## Task 6 — Add measured coverage and documentation
+
+Measure `trade_rl/rl/training_telemetry.py` branch coverage and add only the supported threshold to the current `pyproject.toml`; do not overwrite later telemetry-generation or environment-runtime ratchets.
+
+Record RED/GREEN evidence, exact commit SHA, workflow runs, test totals, coverage, and artifact digests.
+
+## Verification
+
+Run exact-head CI covering:
+
+- Studio Vitest, TypeScript, production build, and fixed viewport;
+- Ruff and format;
+- Mypy;
+- Import Linter and architecture tests;
+- Serving smoke;
+- complete Pytest and critical branch coverage;
+- CLI smoke;
+- Ubuntu and Windows compatibility;
+- complete training image and non-root probe;
+- PostgreSQL Compose, migration, and integration tests.
+
+Production remains `NO-GO`.

--- a/docs/superpowers/specs/2026-07-23-telemetry-episode-identity-design.md
+++ b/docs/superpowers/specs/2026-07-23-telemetry-episode-identity-design.md
@@ -1,0 +1,76 @@
+# Telemetry Episode Identity Design
+
+Date: 2026-07-23
+
+## Problem
+
+Live Training already isolates vector environments and conservatively detects the current episode from terminal records or counter rollback. That browser-side boundary prevents the confirmed visualization defect, but it is still inferential. An auto-reset environment can begin a new episode while `environment_step` and `market_index` remain monotonic and no retained terminal record is available. In that case, the current fallback can join two episodes.
+
+## Goal
+
+Add a producer-issued, nullable episode identity to training telemetry without changing the existing JSONL schema identifier or replacing the current Live Training UI.
+
+## Invariants
+
+- `schema_version` remains `training_telemetry_v1`.
+- `episode_id` is additive and nullable so historical records remain readable.
+- A sampler assigns one non-negative episode ID per vector environment.
+- Records from the same active environment episode retain the same ID.
+- A terminal or truncated transition is written with its current ID; the next record for that environment receives a new ID.
+- Episode allocation is stream-local and collision-free for records emitted after sampler startup.
+- Producer state for previous close and previous weights is cleared when the episode ends.
+- Studio normalizes the field to `episodeId` and validates explicit values strictly.
+- Live Training prefers an explicit ID when the latest selected-environment record has one.
+- Legacy records with no ID continue to use the existing terminal/rollback boundary.
+- Explicit and legacy records are never silently combined into one authoritative episode when the latest record is explicit.
+
+## Data contract
+
+`TrainingTelemetryRecord` gains:
+
+```text
+episode_id: int | None = None
+```
+
+JSON gains:
+
+```json
+{"episode_id": 12}
+```
+
+or, for legacy/unknown identity:
+
+```json
+{"episode_id": null}
+```
+
+The field does not alter sequence, stream generation, sparse-index, process-lock, cursor reset, or evidence-file identity contracts.
+
+## Producer allocation
+
+`TrainingTelemetrySampler` owns:
+
+- a mapping from `environment_id` to active `episode_id`;
+- a monotonically increasing next-ID counter initialized above the existing stream sequence.
+
+The sequence-derived start avoids reusing an ID after appending to a pre-existing stream without scanning all historical optional IDs. The ID is not claimed to be globally unique outside one telemetry stream.
+
+## Browser selection
+
+For one selected environment:
+
+1. Sort records by global telemetry sequence.
+2. Inspect the latest record.
+3. When its `episodeId` is non-null, return only records with that exact ID.
+4. When it is null, retain the current conservative terminal, environment-step rollback, and market-index rollback logic.
+
+This keeps legacy compatibility while ensuring explicit producer identity takes precedence.
+
+## Non-goals
+
+- No alternate Live Training page or selector design.
+- No rewrite of historical JSONL evidence.
+- No change to training, checkpoint selection, sealed evaluation, Serving, release, or execution.
+- No production-readiness claim.
+
+Production remains `NO-GO`.

--- a/docs/verification/2026-07-23-telemetry-episode-identity.md
+++ b/docs/verification/2026-07-23-telemetry-episode-identity.md
@@ -24,6 +24,7 @@ The implementation intentionally does not import the alternate Live Training pag
 - The same environment episode retains one ID across retained records.
 - A terminal or truncated record is emitted with the current ID.
 - The next retained record for that environment receives a new ID.
+- Reopening an existing telemetry stream starts allocation above the existing sequence/episode range and does not reuse an earlier producer-issued ID.
 - Producer fallback state for previous close and previous weights is cleared when the episode ends.
 - Studio normalizes the field to `episodeId`.
 - Python, Studio, and browser guards reject boolean, negative, and non-integer explicit values.
@@ -52,6 +53,7 @@ The implementation adds:
 
 - nullable record serialization and strict parsing;
 - per-environment producer allocation and post-terminal rotation;
+- restart-safe stream-local allocation which remains above existing IDs;
 - Studio API normalization;
 - TypeScript type and runtime guard support;
 - explicit-ID-first current-episode selection;
@@ -63,11 +65,11 @@ No production training, checkpoint selection, sealed evaluation, promotion, rele
 
 ## Exact-head verification
 
-Final verified head before this documentation-only commit:
+Final verified implementation-and-test head before this documentation-only commit:
 
-- `91423b49724bf740fb9c9e60d354d82b7def06a3`
+- `9e806f5fd5ceac751fa77e25a1b72b140de1e6a7`
 
-GitHub Actions CI run `29958406026`: success.
+GitHub Actions CI run `29958798560`: success.
 
 - exact-head checkout: passed;
 - complete Studio Vitest suite: passed;
@@ -80,7 +82,7 @@ GitHub Actions CI run `29958406026`: success.
 - Import Linter architecture contracts: passed;
 - dead-code report: passed;
 - recovery and structured Serving smoke: passed;
-- full Pytest: `1213 passed, 2 skipped, 11 warnings`;
+- full Pytest: `1214 passed, 2 skipped, 11 warnings`;
 - total coverage: `83.47%`;
 - total branch coverage: `4868 / 6916 = 70.39%`;
 - sampler branch coverage: `55 / 70 = 78.57% >= 78.5%`;
@@ -91,7 +93,7 @@ GitHub Actions CI run `29958406026`: success.
 - Windows compatibility: passed;
 - complete training-image build and packaged non-root runtime probe: passed.
 
-PostgreSQL Catalog run `29958406465`: success.
+PostgreSQL Catalog run `29958798616`: success.
 
 - exact-head checkout: passed;
 - Compose validation: passed;
@@ -102,19 +104,21 @@ PostgreSQL Catalog run `29958406465`: success.
 
 ## Exact-head artifacts
 
-- Pytest diagnostics: ID `8545059144`, digest `sha256:8813e4d595ae24db8251b779c94230d6056ebd1b33c732af4d00c7204cf4033d`;
-- architecture diagnostics: ID `8545012315`, digest `sha256:1435db92243ebbd517506ac0c2cc7c6ebcba52019f7881888ffc9e0da4416c5e`;
-- static diagnostics: ID `8545011652`, digest `sha256:ec2e4f1c6471803bcebe0784c0054017dfd38ad371a24c1445c388b57f7908f1`;
-- training-image evidence: ID `8545004825`, digest `sha256:fbf8fb80597d8ece373f4dce4039f3f0b58cc98c385fd039dcda236f61666606`;
-- Studio layout diagnostics: ID `8545000826`, digest `sha256:2ccaae7ec835fb3e714f96a3406969a3a68e488759c3bed38909419fc44ef292`;
-- Windows compatibility: ID `8544993849`, digest `sha256:dad4657b1d505fa579aceda304775f8c230ffd43a1730d198760b6a40bcd0432`;
-- Ubuntu compatibility: ID `8544991093`, digest `sha256:9185352e617f3721bdb9f7a37aaf6cf02dc6dd173a3cc8d178db5f2a1c3f20fb`.
+- Pytest diagnostics: ID `8545202616`, digest `sha256:208ccbe2158aed8d08f60c36f92af1e3bcc0e96a5da3728c859211bdb2157db2`;
+- architecture diagnostics: ID `8545161810`, digest `sha256:ea475021bd459ac56700141adfe4f5ddec2436309ce8fa3da939fa0ddf5391bc`;
+- static diagnostics: ID `8545161251`, digest `sha256:67442ae066d7a71180a7ac3a04c7797c612a0b471b4890ecefc7b9d7d9bf5eeb`;
+- training-image evidence: ID `8545154614`, digest `sha256:cb13c90ecaba02860ceffaea829b2fb762afc69f39a875a19649c67c905ba474`;
+- Studio layout diagnostics: ID `8545151953`, digest `sha256:6b580c8a33aee11623e1938d85899e172a0ad5b2963e411bb515014134ed6291`;
+- Windows compatibility: ID `8545146264`, digest `sha256:4ec32c60a6b5fdbd188cf2d65336b9f2816907d748ad3b4735c5199ffbf2d6da`;
+- Ubuntu compatibility: ID `8545143616`, digest `sha256:1756aefbb47f6b54f74fa033aec117708964a597cd3c303154128716f954d520`.
 
 This verification file is documentation-only. The final PR head must pass exact-head CI again before merge.
 
 ## Review result
 
 The effective comparison from current `main` contains exactly 16 implementation/test/design files before this verification note. It does not include the alternate page and track implementation from old PR #84. The current Live Training environment and episode-isolation tests remain intact.
+
+The restart regression closes the remaining stream-local allocation ambiguity: a newly constructed sampler reading an existing JSONL continues both sequence and episode identity monotonically instead of reusing the first episode ID.
 
 No critical or important review issue remains.
 

--- a/docs/verification/2026-07-23-telemetry-episode-identity.md
+++ b/docs/verification/2026-07-23-telemetry-episode-identity.md
@@ -1,0 +1,126 @@
+# Telemetry Episode Identity Verification
+
+Date: 2026-07-23
+
+## Scope
+
+This verification covers Draft PR #103, which adds producer-issued episode identity to the existing Live Training environment/current-episode isolation boundary.
+
+Design:
+
+- `docs/superpowers/specs/2026-07-23-telemetry-episode-identity-design.md`
+
+Implementation plan:
+
+- `docs/superpowers/plans/2026-07-23-telemetry-episode-identity.md`
+
+The implementation intentionally does not import the alternate Live Training page or track architecture from stacked Draft PR #84. The existing environment selector and current-episode presentation merged through PR #85 remain in place.
+
+## Implemented contract
+
+- Primary JSONL evidence remains `training_telemetry_v1`.
+- `episode_id` is additive and nullable, so historical records remain readable.
+- The telemetry sampler owns one active non-negative episode ID per vector environment.
+- The same environment episode retains one ID across retained records.
+- A terminal or truncated record is emitted with the current ID.
+- The next retained record for that environment receives a new ID.
+- Producer fallback state for previous close and previous weights is cleared when the episode ends.
+- Studio normalizes the field to `episodeId`.
+- Python, Studio, and browser guards reject boolean, negative, and non-integer explicit values.
+- Live Training prefers the latest explicit episode ID for the selected environment.
+- Historical records with `null` identity continue to use the existing terminal and counter-rollback boundary.
+- Stream generation, sequence, sparse-index, process-lock, cursor-reset, and JSONL file-identity contracts are unchanged.
+
+## TDD RED evidence
+
+RED head:
+
+- `75204910275e7034eca0f66325645a6f9699db21`
+
+GitHub Actions CI run:
+
+- `29957910685`
+- expected failure in `Verify Studio frontend`
+
+The regression used one environment with explicit episode IDs `41` and `42` while `environmentStep` and `marketIndex` remained monotonic and no terminal marker was retained. The pre-change heuristic returned all four records instead of only the two records from episode `42`.
+
+Ubuntu and Windows compatibility jobs passed at the RED head, confirming that the failure was isolated to the newly introduced frontend contract.
+
+## GREEN implementation
+
+The implementation adds:
+
+- nullable record serialization and strict parsing;
+- per-environment producer allocation and post-terminal rotation;
+- Studio API normalization;
+- TypeScript type and runtime guard support;
+- explicit-ID-first current-episode selection;
+- legacy-null fallback behavior;
+- focused Python, Studio, integration, and frontend tests;
+- a measured critical branch-coverage threshold for `trade_rl/rl/training_telemetry.py`.
+
+No production training, checkpoint selection, sealed evaluation, promotion, release, Serving, or execution logic changes.
+
+## Exact-head verification
+
+Final verified head before this documentation-only commit:
+
+- `91423b49724bf740fb9c9e60d354d82b7def06a3`
+
+GitHub Actions CI run `29958406026`: success.
+
+- exact-head checkout: passed;
+- complete Studio Vitest suite: passed;
+- TypeScript type checking: passed;
+- Studio production build: passed;
+- fixed viewport verification: passed;
+- workflow security: passed;
+- Ruff and format: passed;
+- Mypy: passed;
+- Import Linter architecture contracts: passed;
+- dead-code report: passed;
+- recovery and structured Serving smoke: passed;
+- full Pytest: `1213 passed, 2 skipped, 11 warnings`;
+- total coverage: `83.47%`;
+- total branch coverage: `4868 / 6916 = 70.39%`;
+- sampler branch coverage: `55 / 70 = 78.57% >= 78.5%`;
+- indexed telemetry branch coverage remains `76 / 110 = 69.09% >= 69.0%`;
+- all critical branch-coverage ratchets: passed;
+- CLI smoke: passed;
+- Ubuntu compatibility: passed;
+- Windows compatibility: passed;
+- complete training-image build and packaged non-root runtime probe: passed.
+
+PostgreSQL Catalog run `29958406465`: success.
+
+- exact-head checkout: passed;
+- Compose validation: passed;
+- PostgreSQL startup and readiness: passed;
+- installation and migration: passed;
+- unit and integration tests: passed;
+- shutdown and cleanup: passed.
+
+## Exact-head artifacts
+
+- Pytest diagnostics: ID `8545059144`, digest `sha256:8813e4d595ae24db8251b779c94230d6056ebd1b33c732af4d00c7204cf4033d`;
+- architecture diagnostics: ID `8545012315`, digest `sha256:1435db92243ebbd517506ac0c2cc7c6ebcba52019f7881888ffc9e0da4416c5e`;
+- static diagnostics: ID `8545011652`, digest `sha256:ec2e4f1c6471803bcebe0784c0054017dfd38ad371a24c1445c388b57f7908f1`;
+- training-image evidence: ID `8545004825`, digest `sha256:fbf8fb80597d8ece373f4dce4039f3f0b58cc98c385fd039dcda236f61666606`;
+- Studio layout diagnostics: ID `8545000826`, digest `sha256:2ccaae7ec835fb3e714f96a3406969a3a68e488759c3bed38909419fc44ef292`;
+- Windows compatibility: ID `8544993849`, digest `sha256:dad4657b1d505fa579aceda304775f8c230ffd43a1730d198760b6a40bcd0432`;
+- Ubuntu compatibility: ID `8544991093`, digest `sha256:9185352e617f3721bdb9f7a37aaf6cf02dc6dd173a3cc8d178db5f2a1c3f20fb`.
+
+This verification file is documentation-only. The final PR head must pass exact-head CI again before merge.
+
+## Review result
+
+The effective comparison from current `main` contains exactly 16 implementation/test/design files before this verification note. It does not include the alternate page and track implementation from old PR #84. The current Live Training environment and episode-isolation tests remain intact.
+
+No critical or important review issue remains.
+
+## Safety boundary
+
+- Production remains `NO-GO`.
+- Direct exchange routing is not implemented.
+- No profitability or exchange-equivalent fill claim is introduced.
+- Historical telemetry is not rewritten or repaired.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ target = 90.0
 "trade_rl/rl/rewards.py" = 97.0
 "trade_rl/evaluation/gates.py" = 100.0
 "trade_rl/telemetry/indexed_training.py" = 69.0
+"trade_rl/rl/training_telemetry.py" = 78.5
 
 [tool.trade_rl.critical_coverage.groups.artifacts]
 minimum = 90.0

--- a/studio/src/data/types.ts
+++ b/studio/src/data/types.ts
@@ -123,6 +123,7 @@ export interface TrainingTelemetryRecord {
   environmentStep: number
   seed: number
   environmentId: number
+  episodeId: number | null
   eventType: TelemetryEventType
   marketIndex: number | null
   marketTime: string | null

--- a/studio/src/live/telemetryGuards.test.ts
+++ b/studio/src/live/telemetryGuards.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import type { TrainingTelemetryRecord } from '../data/types'
+import { isTrainingTelemetryRecord } from './telemetryGuards'
+
+function record(episodeId: number | null): TrainingTelemetryRecord {
+  return {
+    schemaVersion: 'training_telemetry_v1',
+    sequence: 1,
+    recordedAt: '2026-07-22T13:00:00+00:00',
+    globalStep: 32,
+    environmentStep: 1,
+    seed: 7,
+    environmentId: 0,
+    episodeId,
+    eventType: 'rollout',
+    marketIndex: 101,
+    marketTime: '2026-07-22T12:55:00.000000000',
+    symbol: 'BTCUSDT',
+    open: 100,
+    high: 101,
+    low: 99,
+    close: 100.5,
+    action: [0.2],
+    executedTarget: [0.2],
+    weightsBefore: [0.1],
+    weightsAfter: [0.2],
+    portfolioValue: 1_000,
+    baselinePortfolioValue: 990,
+    reward: 0.1,
+    drawdown: 0,
+    intervalCost: 0,
+    intervalReturn: 0.001,
+    riskReasons: [],
+    emergencyDeleverage: false,
+    terminated: false,
+    truncated: false,
+  }
+}
+
+describe('isTrainingTelemetryRecord episode identity', () => {
+  it('accepts explicit and normalized legacy identities', () => {
+    expect(isTrainingTelemetryRecord(record(4))).toBe(true)
+    expect(isTrainingTelemetryRecord(record(null))).toBe(true)
+  })
+
+  it('rejects missing, negative, and boolean episode identities', () => {
+    const missing = { ...record(null) } as Record<string, unknown>
+    delete missing.episodeId
+
+    expect(isTrainingTelemetryRecord(missing)).toBe(false)
+    expect(isTrainingTelemetryRecord({ ...record(null), episodeId: -1 })).toBe(false)
+    expect(isTrainingTelemetryRecord({ ...record(null), episodeId: true })).toBe(false)
+  })
+})

--- a/studio/src/live/telemetryGuards.ts
+++ b/studio/src/live/telemetryGuards.ts
@@ -38,6 +38,7 @@ export function isTrainingTelemetryRecord(value: unknown): value is TrainingTele
     && isNonNegativeInteger(value.environmentStep)
     && isNonNegativeInteger(value.seed)
     && isNonNegativeInteger(value.environmentId)
+    && (value.episodeId === null || isNonNegativeInteger(value.episodeId))
     && typeof value.eventType === 'string' && eventTypes.has(value.eventType)
     && (value.marketIndex === null || isNonNegativeInteger(value.marketIndex))
     && (value.marketTime === null || typeof value.marketTime === 'string')

--- a/studio/src/live/telemetryStreams.test.ts
+++ b/studio/src/live/telemetryStreams.test.ts
@@ -3,9 +3,7 @@ import { describe, expect, it } from 'vitest'
 import type { TrainingTelemetryRecord } from '../data/types'
 import { currentEnvironmentEpisode, telemetryEnvironmentIds } from './telemetryStreams'
 
-type RecordOverrides = Partial<TrainingTelemetryRecord> & {
-  episodeId?: number | null
-}
+type RecordOverrides = Partial<TrainingTelemetryRecord>
 
 function record(
   sequence: number,
@@ -20,6 +18,7 @@ function record(
     environmentStep: sequence,
     seed: 7,
     environmentId,
+    episodeId: null,
     eventType: 'rollout',
     marketIndex: 100 + sequence,
     marketTime: `2026-07-23T00:00:${String(sequence).padStart(2, '0')}.000000000`,

--- a/studio/src/live/telemetryStreams.test.ts
+++ b/studio/src/live/telemetryStreams.test.ts
@@ -3,10 +3,14 @@ import { describe, expect, it } from 'vitest'
 import type { TrainingTelemetryRecord } from '../data/types'
 import { currentEnvironmentEpisode, telemetryEnvironmentIds } from './telemetryStreams'
 
+type RecordOverrides = Partial<TrainingTelemetryRecord> & {
+  episodeId?: number | null
+}
+
 function record(
   sequence: number,
   environmentId: number,
-  overrides: Partial<TrainingTelemetryRecord> = {},
+  overrides: RecordOverrides = {},
 ): TrainingTelemetryRecord {
   return {
     schemaVersion: 'training_telemetry_v1',
@@ -64,6 +68,17 @@ describe('telemetry stream selection', () => {
 
     expect(currentEnvironmentEpisode(records, 0).map((item) => item.sequence)).toEqual([5, 6])
     expect(currentEnvironmentEpisode(records, 1).map((item) => item.sequence)).toEqual([2, 4])
+  })
+
+  it('prefers producer episode identity when counters remain monotonic', () => {
+    const records = [
+      record(1, 0, { episodeId: 41, environmentStep: 10, marketIndex: 110 }),
+      record(2, 0, { episodeId: 41, environmentStep: 11, marketIndex: 111 }),
+      record(3, 0, { episodeId: 42, environmentStep: 12, marketIndex: 112 }),
+      record(4, 0, { episodeId: 42, environmentStep: 13, marketIndex: 113 }),
+    ]
+
+    expect(currentEnvironmentEpisode(records, 0).map((item) => item.sequence)).toEqual([3, 4])
   })
 
   it('starts a new episode when environment counters roll back', () => {

--- a/studio/src/live/telemetryStreams.ts
+++ b/studio/src/live/telemetryStreams.ts
@@ -29,6 +29,11 @@ export function currentEnvironmentEpisode(
     .sort((left, right) => left.sequence - right.sequence)
   if (environmentRecords.length === 0) return []
 
+  const latestEpisodeId = environmentRecords.at(-1)?.episodeId ?? null
+  if (latestEpisodeId !== null) {
+    return environmentRecords.filter((record) => record.episodeId === latestEpisodeId)
+  }
+
   let episodeStart = 0
   for (let index = 1; index < environmentRecords.length; index += 1) {
     if (crossesEpisodeBoundary(environmentRecords[index - 1], environmentRecords[index])) {

--- a/studio/src/live/useTrainingTelemetry.test.tsx
+++ b/studio/src/live/useTrainingTelemetry.test.tsx
@@ -22,6 +22,7 @@ function telemetry(sequence: number): TrainingTelemetryRecord {
     environmentStep: sequence,
     seed: 7,
     environmentId: 0,
+    episodeId: 1,
     eventType: 'rollout',
     marketIndex: 100 + sequence,
     marketTime: '2026-07-22T10:55:00.000000000',

--- a/studio/src/pages/LiveTrainingPage.test.tsx
+++ b/studio/src/pages/LiveTrainingPage.test.tsx
@@ -44,6 +44,7 @@ function telemetry(
     environmentStep: sequence,
     seed,
     environmentId: 0,
+    episodeId: null,
     eventType: sequence === 2 ? 'position' : 'rollout',
     marketIndex: 100 + sequence,
     marketTime: `2026-07-21T08:0${sequence}:00.000000000`,

--- a/tests/integrations/test_training_telemetry_episode_identity.py
+++ b/tests/integrations/test_training_telemetry_episode_identity.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+
+from trade_rl.integrations.training_telemetry import TrainingTelemetrySampler
+from trade_rl.telemetry import read_training_telemetry
+
+
+def _info(
+    step: int,
+    *,
+    price: float = 100.0,
+    before: tuple[float, ...] | None = (0.2,),
+    after: tuple[float, ...] = (0.2,),
+    exact_market: bool = True,
+    terminated: bool = False,
+    truncated: bool = False,
+) -> dict[str, object]:
+    book = SimpleNamespace(
+        weights=np.asarray(after, dtype=np.float64),
+        portfolio_value=1_000.0 + step,
+        mark_prices=np.asarray([price], dtype=np.float64),
+    )
+    result: dict[str, object] = {
+        "decision_step_index": step,
+        "telemetry_symbol": "BTCUSDT",
+        "telemetry_weights_after": np.asarray(after, dtype=np.float64),
+        "hybrid_execution": SimpleNamespace(book=book),
+        "portfolio_value_after": 1_000.0 + step,
+        "baseline_portfolio_value_after": 1_000.0,
+        "reward_total_scaled": 0.0,
+        "drawdown_after": 0.0,
+        "interval_cost": 0.0,
+        "interval_net_return": 0.0,
+        "telemetry_risk_reasons": (),
+        "emergency_deleverage": False,
+        "hybrid_terminated": terminated,
+        "TimeLimit.truncated": truncated,
+    }
+    if before is not None:
+        result["telemetry_weights_before"] = np.asarray(before, dtype=np.float64)
+    if exact_market:
+        result.update(
+            {
+                "telemetry_market_index": 100 + step,
+                "telemetry_market_time": "2026-07-22T12:00:00.000000000",
+                "telemetry_ohlc": (price, price, price, price),
+            }
+        )
+    return result
+
+
+def test_vector_environments_receive_distinct_episode_ids_and_rotate_after_done(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    sampler = TrainingTelemetrySampler(path, seed=3, sample_every=1)
+
+    assert (
+        sampler.consume(
+            global_step=2,
+            actions=np.asarray([[0.1], [0.2]], dtype=np.float32),
+            rewards=np.asarray([0.0, 0.0], dtype=np.float32),
+            dones=np.asarray([False, False]),
+            infos=(_info(1), _info(1, price=600.0)),
+        )
+        == 2
+    )
+    assert (
+        sampler.consume(
+            global_step=4,
+            actions=np.asarray([[0.0], [0.2]], dtype=np.float32),
+            rewards=np.asarray([0.0, 0.0], dtype=np.float32),
+            dones=np.asarray([True, False]),
+            infos=(
+                _info(2, terminated=True),
+                _info(2, price=601.0),
+            ),
+        )
+        == 2
+    )
+    assert (
+        sampler.consume(
+            global_step=6,
+            actions=np.asarray([[0.3], [0.2]], dtype=np.float32),
+            rewards=np.asarray([0.0, 0.0], dtype=np.float32),
+            dones=np.asarray([False, False]),
+            infos=(
+                _info(0, price=200.0),
+                _info(3, price=602.0),
+            ),
+        )
+        == 2
+    )
+    sampler.close()
+
+    items = read_training_telemetry(path, limit=20).items
+    environment_zero = [item for item in items if item.environment_id == 0]
+    environment_one = [item for item in items if item.environment_id == 1]
+
+    assert environment_zero[0].episode_id == environment_zero[1].episode_id
+    assert environment_zero[2].episode_id not in (
+        None,
+        environment_zero[1].episode_id,
+    )
+    assert len({item.episode_id for item in environment_one}) == 1
+    assert environment_zero[0].episode_id != environment_one[0].episode_id
+
+
+def test_terminal_transition_clears_visual_fallback_state_for_next_episode(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    sampler = TrainingTelemetrySampler(path, seed=5, sample_every=1)
+
+    assert (
+        sampler.consume(
+            global_step=1,
+            actions=np.asarray([[0.8]], dtype=np.float32),
+            rewards=np.asarray([0.0], dtype=np.float32),
+            dones=np.asarray([True]),
+            infos=(
+                _info(
+                    8,
+                    price=100.0,
+                    before=(0.2,),
+                    after=(0.8,),
+                    terminated=True,
+                ),
+            ),
+        )
+        == 1
+    )
+    assert (
+        sampler.consume(
+            global_step=2,
+            actions=np.asarray([[0.1]], dtype=np.float32),
+            rewards=np.asarray([0.0], dtype=np.float32),
+            dones=np.asarray([False]),
+            infos=(
+                _info(
+                    0,
+                    price=600.0,
+                    before=None,
+                    after=(0.1,),
+                    exact_market=False,
+                ),
+            ),
+        )
+        == 1
+    )
+    sampler.close()
+
+    first, second = read_training_telemetry(path, limit=10).items
+
+    assert second.episode_id not in (None, first.episode_id)
+    assert second.open == 600.0
+    assert second.close == 600.0
+    assert second.weights_before == (0.0,)

--- a/tests/integrations/test_training_telemetry_episode_identity.py
+++ b/tests/integrations/test_training_telemetry_episode_identity.py
@@ -160,3 +160,42 @@ def test_terminal_transition_clears_visual_fallback_state_for_next_episode(
     assert second.open == 600.0
     assert second.close == 600.0
     assert second.weights_before == (0.0,)
+
+
+def test_sampler_restart_does_not_reuse_existing_stream_episode_id(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    first_sampler = TrainingTelemetrySampler(path, seed=9, sample_every=1)
+
+    assert (
+        first_sampler.consume(
+            global_step=1,
+            actions=np.asarray([[0.1]], dtype=np.float32),
+            rewards=np.asarray([0.0], dtype=np.float32),
+            dones=np.asarray([False]),
+            infos=(_info(1),),
+        )
+        == 1
+    )
+    first_sampler.close()
+
+    resumed_sampler = TrainingTelemetrySampler(path, seed=9, sample_every=1)
+    assert (
+        resumed_sampler.consume(
+            global_step=2,
+            actions=np.asarray([[0.2]], dtype=np.float32),
+            rewards=np.asarray([0.0], dtype=np.float32),
+            dones=np.asarray([False]),
+            infos=(_info(2, price=101.0),),
+        )
+        == 1
+    )
+    resumed_sampler.close()
+
+    first, resumed = read_training_telemetry(path, limit=10).items
+
+    assert first.episode_id is not None
+    assert resumed.episode_id is not None
+    assert resumed.episode_id > first.episode_id
+    assert resumed.sequence == first.sequence + 1

--- a/tests/studio/test_telemetry_episode_api.py
+++ b/tests/studio/test_telemetry_episode_api.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+
+from .test_api import client
+from .test_jobs import request
+from .test_telemetry_api import record, stream_path
+
+
+def test_telemetry_api_exposes_explicit_and_legacy_episode_identity(
+    tmp_path: Path,
+) -> None:
+    api, _, catalog, _ = client(tmp_path)
+    created = api.post(
+        "/api/studio/jobs/training",
+        json=request(catalog, run_id="live-episode-api").model_dump(by_alias=True),
+    ).json()
+    stream = stream_path(tmp_path, "live-episode-api", 7)
+    stream.parent.mkdir(parents=True, exist_ok=True)
+
+    explicit = replace(record(1), episode_id=5).to_json_dict()
+    legacy = record(2).to_json_dict()
+    legacy.pop("episode_id")
+    stream.write_text(
+        "\n".join(
+            (
+                json.dumps(explicit, sort_keys=True, separators=(",", ":")),
+                json.dumps(legacy, sort_keys=True, separators=(",", ":")),
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    response = api.get(
+        f"/api/studio/jobs/{created['id']}/telemetry/events",
+        params={"seed": 7, "limit": 10},
+    )
+
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert [item["sequence"] for item in items] == [1, 2]
+    assert [item["episodeId"] for item in items] == [5, None]

--- a/tests/telemetry/test_episode_identity_contract.py
+++ b/tests/telemetry/test_episode_identity_contract.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pytest
+
+from trade_rl.telemetry import TrainingTelemetryRecord
+
+
+def _record(sequence: int, *, episode_id: int | None = None) -> TrainingTelemetryRecord:
+    values: dict[str, object] = {
+        "sequence": sequence,
+        "recorded_at": "2026-07-22T12:00:00+00:00",
+        "global_step": sequence * 32,
+        "environment_step": sequence,
+        "seed": 7,
+        "environment_id": 0,
+        "event_type": "rollout",
+        "market_index": 100 + sequence,
+        "market_time": "2026-07-22T11:55:00.000000000",
+        "symbol": "BTCUSDT",
+        "open": 67_500.0,
+        "high": 67_900.0,
+        "low": 67_400.0,
+        "close": 67_842.3,
+        "action": (0.4,),
+        "executed_target": (0.4,),
+        "weights_before": (0.2,),
+        "weights_after": (0.4,),
+        "portfolio_value": 101_342.85,
+        "baseline_portfolio_value": 100_400.0,
+        "reward": 0.214,
+        "drawdown": 0.0086,
+        "interval_cost": 4.25,
+        "interval_return": 0.0012,
+        "risk_reasons": (),
+        "emergency_deleverage": False,
+        "terminated": False,
+        "truncated": False,
+    }
+    if episode_id is not None:
+        values["episode_id"] = episode_id
+    return TrainingTelemetryRecord(**values)  # type: ignore[arg-type]
+
+
+def test_episode_id_round_trip_is_explicit() -> None:
+    original = _record(1, episode_id=9)
+
+    restored = TrainingTelemetryRecord.from_json_dict(original.to_json_dict())
+
+    assert restored.episode_id == 9
+    assert original.to_json_dict()["episode_id"] == 9
+
+
+def test_legacy_record_without_episode_id_remains_readable() -> None:
+    payload = _record(1).to_json_dict()
+    payload.pop("episode_id", None)
+
+    restored = TrainingTelemetryRecord.from_json_dict(payload)
+
+    assert restored.episode_id is None
+
+
+@pytest.mark.parametrize("episode_id", (-1, True))
+def test_invalid_episode_id_fails_closed(episode_id: object) -> None:
+    payload = _record(1).to_json_dict()
+    payload["episode_id"] = episode_id
+
+    with pytest.raises(ValueError, match="episode_id"):
+        TrainingTelemetryRecord.from_json_dict(payload)

--- a/trade_rl/rl/training_telemetry.py
+++ b/trade_rl/rl/training_telemetry.py
@@ -204,6 +204,22 @@ class TrainingTelemetrySampler:
         self.disabled = False
         self._previous_weights: dict[int, tuple[float, ...]] = {}
         self._previous_close: dict[int, float] = {}
+        self._episode_ids: dict[int, int] = {}
+        self._next_episode_id = self.sequence + 1
+
+    def _episode_id(self, environment_id: int) -> int:
+        current = self._episode_ids.get(environment_id)
+        if current is not None:
+            return current
+        assigned = self._next_episode_id
+        self._next_episode_id += 1
+        self._episode_ids[environment_id] = assigned
+        return assigned
+
+    def _finish_episode(self, environment_id: int) -> None:
+        self._episode_ids.pop(environment_id, None)
+        self._previous_weights.pop(environment_id, None)
+        self._previous_close.pop(environment_id, None)
 
     def _weights(
         self,
@@ -363,6 +379,7 @@ class TrainingTelemetrySampler:
                     if environment_id < reward_rows.size
                     else None
                 )
+                episode_id = self._episode_id(environment_id)
                 self.writer.append(
                     TrainingTelemetryRecord(
                         sequence=self.sequence,
@@ -399,9 +416,16 @@ class TrainingTelemetrySampler:
                         emergency_deleverage=bool(info.get("emergency_deleverage")),
                         terminated=bool(info.get("hybrid_terminated")) or done,
                         truncated=bool(info.get("TimeLimit.truncated")),
+                        episode_id=episode_id,
                     )
                 )
                 emitted += 1
+                if (
+                    done
+                    or bool(info.get("hybrid_terminated"))
+                    or bool(info.get("TimeLimit.truncated"))
+                ):
+                    self._finish_episode(environment_id)
             return emitted
         except Exception:
             self.close()

--- a/trade_rl/studio/telemetry.py
+++ b/trade_rl/studio/telemetry.py
@@ -33,6 +33,7 @@ class TelemetryRecordResponse(StudioModel):
     environment_step: int = Field(ge=0)
     seed: int = Field(ge=0)
     environment_id: int = Field(ge=0)
+    episode_id: int | None = Field(default=None, ge=0)
     event_type: Literal[
         "rollout",
         "position",

--- a/trade_rl/telemetry/training.py
+++ b/trade_rl/telemetry/training.py
@@ -137,6 +137,7 @@ class TrainingTelemetryRecord:
     emergency_deleverage: bool
     terminated: bool
     truncated: bool
+    episode_id: int | None = None
     schema_version: str = TELEMETRY_SCHEMA_VERSION
 
     def __post_init__(self) -> None:
@@ -161,6 +162,12 @@ class TrainingTelemetryRecord:
             or self.market_index < 0
         ):
             raise ValueError("market_index is invalid")
+        if self.episode_id is not None and (
+            isinstance(self.episode_id, bool)
+            or not isinstance(self.episode_id, int)
+            or self.episode_id < 0
+        ):
+            raise ValueError("episode_id is invalid")
         try:
             recorded = datetime.fromisoformat(self.recorded_at.replace("Z", "+00:00"))
         except ValueError as error:
@@ -205,6 +212,7 @@ class TrainingTelemetryRecord:
             "environment_step": self.environment_step,
             "seed": self.seed,
             "environment_id": self.environment_id,
+            "episode_id": self.episode_id,
             "event_type": self.event_type,
             "market_index": self.market_index,
             "market_time": self.market_time,
@@ -246,6 +254,7 @@ class TrainingTelemetryRecord:
             environment_step=_required_int(raw, "environment_step"),
             seed=_required_int(raw, "seed"),
             environment_id=_required_int(raw, "environment_id"),
+            episode_id=_optional_int(raw, "episode_id"),
             event_type=cast(TelemetryEventType, event_type),
             market_index=_optional_int(raw, "market_index"),
             market_time=_optional_string(raw, "market_time"),


### PR DESCRIPTION
## Summary

Adds producer-issued episode identity to the existing Live Training environment/current-episode isolation boundary without replacing the UI merged through PR #85.

- keeps primary JSONL evidence at `training_telemetry_v1`
- adds nullable `episode_id` for backward-compatible historical reads
- allocates one active episode ID per vector environment
- emits terminal/truncated records with the current ID, then rotates the next record to a new ID
- reopens existing telemetry streams above the existing sequence/episode range without reusing an earlier producer-issued ID
- clears producer fallback state at episode completion
- normalizes the field through Studio as `episodeId`
- rejects invalid explicit values in Python and browser guards
- makes the current `telemetryStreams` boundary prefer producer identity
- preserves the legacy terminal/counter-rollback fallback for records with `episodeId=null`
- preserves stream generation, cursor reset, sparse index, process locking, and the existing environment selector/current-episode UI

## Clean scope

Current `main` base: `d533dcd65a10870b6fe90fdbadbf64ba938c2b1f`

Final head: `5eebadac20cc798bd751abf1124b06d436e7e096`

The branch is behind `main` by zero commits. The effective diff is 17 files: 16 implementation/test/design files plus one verification note.

The old alternate page and track implementation from stacked Draft PR #84 is not included. Existing PR #85 environment/episode-isolation tests remain intact.

## TDD RED evidence

RED head: `75204910275e7034eca0f66325645a6f9699db21`

CI run `29957910685`: expected failure in `Verify Studio frontend`.

The regression changed explicit episode IDs from `41` to `42` while `environmentStep` and `marketIndex` remained monotonic and no terminal marker was retained. The previous heuristic returned `[1, 2, 3, 4]` instead of the expected current episode `[3, 4]`.

Ubuntu and Windows compatibility jobs passed at the RED head, isolating the failure to the new frontend contract.

## Final exact-head verification

Documentation-complete head `5eebadac20cc798bd751abf1124b06d436e7e096`:

GitHub Actions CI run `29959104546`: **success**

- exact-head checkout: passed
- Studio Vitest, TypeScript, production build, and fixed viewport: passed
- workflow security: passed
- Ruff and format: passed
- Mypy: passed
- Import Linter: passed
- dead-code report: passed
- recovery and structured Serving smoke: passed
- full Pytest: `1214 passed, 2 skipped, 11 warnings`
- total coverage: `83.47%`
- total branch coverage: `4868 / 6916 = 70.39%`
- sampler branch coverage: `55 / 70 = 78.57% >= 78.5%`
- indexed telemetry branch coverage remains `76 / 110 = 69.09% >= 69.0%`
- all critical branch-coverage ratchets: passed
- CLI smoke: passed
- Ubuntu compatibility: passed
- Windows compatibility: passed
- complete training-image build and packaged non-root runtime probe: passed

PostgreSQL Catalog run `29959104573`: **success**

- exact-head checkout: passed
- Compose validation: passed
- PostgreSQL startup/readiness: passed
- installation and migration: passed
- unit and integration tests: passed
- shutdown and cleanup: passed

Final exact-head artifacts:

- Pytest diagnostics `8545374713`, digest `sha256:36fef3c73010d31990e6d6e5c8dfc309b6b060d5c918ad009d8fdb3f5cabec59`
- architecture diagnostics `8545334985`, digest `sha256:fc7d2715cfe5501f4a009d0d22300eae81279e9bcbdb58bee6af3c38f547ef48`
- static diagnostics `8545334432`, digest `sha256:61b66ece0c689b7afc5bec5bbcadca5e82f9a5da1af5dfd24ec7c0961a68492a`
- training-image evidence `8545330396`, digest `sha256:6451936d930601e29940b077f85f65fcc518a5cc1a61aceecefb6a7640b7e2d7`
- Studio layout diagnostics `8545326401`, digest `sha256:6f5ee7382b12e8f21113c2dfbd78bb7e37e56a9320f087bd453d952cc66289ad`
- Windows compatibility `8545324180`, digest `sha256:4aa5820747d51e396cc44b896ecaf42593a0dd4d097289a9b9b06904bffeb0e7`
- Ubuntu compatibility `8545317342`, digest `sha256:f15ab190d5a492a7fbbb74fa47e8bd2b2bb13a26d2d1a98f8751cd7d6ae0a21f`

## Review result

The producer owns episode allocation, while the browser only selects records by explicit identity or falls back for legacy records. Restarted samplers continue stream-local identity monotonically. No episode identity is used by training selection, sealed evaluation, promotion, release, Serving, or execution. No critical or important review issue remains.

## Safety boundary

- production remains `NO-GO`
- direct exchange routing is not implemented
- no historical telemetry rewrite or repair
- no profitability or exchange-equivalent fill claim
