### PR TITLE
chore: sync current main into sequence projection guard

### DIFF
--- a/docs/superpowers/plans/2026-07-22-environment-runtime-decomposition.md
+++ b/docs/superpowers/plans/2026-07-22-environment-runtime-decomposition.md
@@ -1,0 +1,401 @@
+# Environment Runtime Decomposition Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract action planning, risk projection, reward transition, and information construction from `ResidualMarketEnv.step()` into independently tested services without changing runtime behavior or public contracts.
+
+**Architecture:** Four stateless or narrowly stateful services consume immutable request dataclasses and return immutable results. `ResidualMarketEnv` remains the sole owner of Gymnasium state and applies service results in the existing order.
+
+**Tech Stack:** Python 3.12, NumPy, Gymnasium, dataclasses, Pytest, Ruff, Mypy, coverage.py, GitHub Actions.
+
+## Global Constraints
+
+- Preserve the `ResidualMarketEnv` constructor, public properties, Gymnasium tuple contract, schema versions, and environment digest payload.
+- Preserve target identity, signal-delay, risk reason ordering, reward ordering, terminal accounting, and every existing `info` key and optional-key condition.
+- Keep books, order books, pending targets, indices, action history, position ages, and diagnostics mutable only in `ResidualMarketEnv`.
+- Do not add direct exchange routing or change production `NO-GO` status.
+- Use TDD: architecture and service tests must fail before production modules are added.
+- Do not lower the existing `environment_runtime` critical branch-coverage threshold of `64.0`.
+
+---
+
+## File map
+
+- Create `trade_rl/rl/environment_decision.py`: action parsing, composition, signal delay, and decision-bar planning.
+- Create `trade_rl/rl/environment_risk.py`: emergency, pre-trade, and portfolio risk projection.
+- Create `trade_rl/rl/environment_reward.py`: reward transition input mapping.
+- Create `trade_rl/rl/environment_info.py`: stable step and terminal information dictionaries.
+- Modify `trade_rl/rl/environment.py`: instantiate and orchestrate the four services; retain thin private delegates where compatibility requires them.
+- Create `tests/architecture/test_environment_step_decomposition.py`: source and ownership contracts.
+- Create `tests/rl/test_environment_decision_service.py`: action migration, delay, and bar-count tests.
+- Create `tests/rl/test_environment_risk_service.py`: shape, emergency, and advanced-risk tests.
+- Create `tests/rl/test_environment_reward_service.py`: reward input-mapping tests.
+- Create `tests/rl/test_environment_info_service.py`: stable optional and terminal key tests.
+- Modify `pyproject.toml`: add a separate measured branch-coverage group for the new step services.
+- Create `docs/verification/2026-07-22-environment-runtime-decomposition.md`: RED/GREEN and exact-head evidence.
+
+---
+
+### Task 1: Add RED architecture contracts
+
+**Files:**
+- Create: `tests/architecture/test_environment_step_decomposition.py`
+
+**Interfaces:**
+- Consumes: current `trade_rl/rl/environment.py` source.
+- Produces: failing contracts requiring `EnvironmentDecisionPlanner`, `EnvironmentRiskProjector`, `EnvironmentRewardCoordinator`, and `EnvironmentInfoBuilder`.
+
+- [ ] **Step 1: Write failing source contracts**
+
+Require the four module paths, assert `ResidualMarketEnv` imports and constructs all four services, and assert the facade no longer directly calls `composer.compose`, `emergency_risk_monitor.assess`, `reward_tracker.step`, or constructs the large step `info` literal.
+
+- [ ] **Step 2: Run RED test**
+
+Run:
+
+```bash
+uv run pytest -q tests/architecture/test_environment_step_decomposition.py
+```
+
+Expected: FAIL because the four service modules and delegates do not yet exist.
+
+- [ ] **Step 3: Commit RED evidence**
+
+```bash
+git add tests/architecture/test_environment_step_decomposition.py
+git commit -m "test: require environment step services"
+```
+
+### Task 2: Implement decision planning service
+
+**Files:**
+- Create: `trade_rl/rl/environment_decision.py`
+- Create: `tests/rl/test_environment_decision_service.py`
+
+**Interfaces:**
+- Produces:
+
+```python
+@dataclass(frozen=True, slots=True)
+class EnvironmentDecisionRequest:
+    action: np.ndarray
+    trends: TrendTargets
+    alpha: np.ndarray
+    factor_basis: np.ndarray
+    hybrid_weights: np.ndarray
+    shadow_weights: np.ndarray
+    pending_hybrid_target: np.ndarray | None
+    pending_shadow_target: np.ndarray | None
+    current_index: int
+    end_index: int
+
+@dataclass(frozen=True, slots=True)
+class EnvironmentDecisionPlan:
+    parsed_action: ResidualAction | ResidualActionV2 | TargetWeightAction
+    maintained_action: np.ndarray
+    saturated_count: int
+    raw_max_abs: float
+    submitted_hybrid_target: np.ndarray
+    submitted_shadow_target: np.ndarray
+    executed_hybrid_target: np.ndarray
+    executed_shadow_target: np.ndarray
+    next_pending_hybrid_target: np.ndarray | None
+    next_pending_shadow_target: np.ndarray | None
+    execution_delay_warmup: bool
+    bars: int
+
+class EnvironmentDecisionPlanner:
+    def plan(self, request: EnvironmentDecisionRequest) -> EnvironmentDecisionPlan: ...
+```
+
+- [ ] **Step 1: Write failing unit tests**
+
+Cover maintained actions, legacy two-value migration, zero-delay targets, one-decision delay warm-up, pending-target execution, regular cadence, irregular cadence, invalid ended intervals, and returned-array copy isolation.
+
+- [ ] **Step 2: Run tests and confirm RED**
+
+```bash
+uv run pytest -q tests/rl/test_environment_decision_service.py
+```
+
+Expected: import failure for `trade_rl.rl.environment_decision`.
+
+- [ ] **Step 3: Implement minimal planner**
+
+Constructor dependencies are `dataset`, `action_spec`, `composer`, `pre_trade_max_gross`, `alpha_enabled`, `accept_legacy_actions`, `signal_delay_decisions`, `decision_every`, and `decision_hours`. Reuse existing action classes and `BaselineResidualComposer` without changing their behavior.
+
+- [ ] **Step 4: Run focused tests**
+
+```bash
+uv run pytest -q tests/rl/test_environment_decision_service.py tests/rl/test_target_weight_action.py tests/rl/test_environment_time_config.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add trade_rl/rl/environment_decision.py tests/rl/test_environment_decision_service.py
+git commit -m "refactor: extract environment decision planner"
+```
+
+### Task 3: Implement risk projection service
+
+**Files:**
+- Create: `trade_rl/rl/environment_risk.py`
+- Create: `tests/rl/test_environment_risk_service.py`
+
+**Interfaces:**
+- Produces:
+
+```python
+@dataclass(frozen=True, slots=True)
+class EnvironmentRiskRequest:
+    proposal: np.ndarray
+    book: BookState
+    current_index: int
+
+class EnvironmentRiskProjector:
+    def project(self, request: EnvironmentRiskRequest) -> RiskConstrainedTarget: ...
+```
+
+- [ ] **Step 1: Write failing unit tests**
+
+Cover symbol-shape rejection, non-finite rejection, quote-notional and base-volume conversion, emergency flattening, pre-trade reason ordering, advanced covariance/beta/stress input forwarding, missing-provider failure, and projection-distance calculation.
+
+- [ ] **Step 2: Run tests and confirm RED**
+
+```bash
+uv run pytest -q tests/rl/test_environment_risk_service.py
+```
+
+Expected: import failure for `trade_rl.rl.environment_risk`.
+
+- [ ] **Step 3: Implement minimal projector**
+
+Constructor dependencies are `dataset`, `emergency_risk_monitor`, `pre_trade_risk`, `portfolio_risk`, and `portfolio_risk_inputs_provider`. Move `_market_notional` and `_constrain_target` behavior without changing reason order.
+
+- [ ] **Step 4: Run focused tests**
+
+```bash
+uv run pytest -q tests/rl/test_environment_risk_service.py tests/risk tests/rl/test_emergency_drawdown.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add trade_rl/rl/environment_risk.py tests/rl/test_environment_risk_service.py
+git commit -m "refactor: extract environment risk projector"
+```
+
+### Task 4: Implement reward coordinator
+
+**Files:**
+- Create: `trade_rl/rl/environment_reward.py`
+- Create: `tests/rl/test_environment_reward_service.py`
+
+**Interfaces:**
+- Produces:
+
+```python
+@dataclass(frozen=True, slots=True)
+class EnvironmentRewardRequest:
+    hybrid_log_return: float
+    shadow_log_return: float
+    hybrid: BookState
+    shadow: BookState
+    projection_distance: float
+    hybrid_terminated: bool
+    shadow_terminated: bool
+
+class EnvironmentRewardCoordinator:
+    def step(self, request: EnvironmentRewardRequest) -> RewardBreakdown: ...
+```
+
+- [ ] **Step 1: Write failing mapping tests**
+
+Use a recording reward tracker and assert exact drawdown, margin-deficit fraction, equity fractions, projection distance, returns, and termination flags.
+
+- [ ] **Step 2: Run tests and confirm RED**
+
+```bash
+uv run pytest -q tests/rl/test_environment_reward_service.py
+```
+
+Expected: import failure for `trade_rl.rl.environment_reward`.
+
+- [ ] **Step 3: Implement minimal coordinator**
+
+Constructor dependencies are `RewardTracker` and `initial_capital`. Keep drawdown computation numerically identical to the facade implementation.
+
+- [ ] **Step 4: Run focused tests**
+
+```bash
+uv run pytest -q tests/rl/test_environment_reward_service.py tests/rl/test_reward_design.py tests/rl/test_reward_time_scaling.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add trade_rl/rl/environment_reward.py tests/rl/test_environment_reward_service.py
+git commit -m "refactor: extract environment reward coordinator"
+```
+
+### Task 5: Implement information builder
+
+**Files:**
+- Create: `trade_rl/rl/environment_info.py`
+- Create: `tests/rl/test_environment_info_service.py`
+
+**Interfaces:**
+- Produces immutable request dataclasses for step and terminal data plus:
+
+```python
+class EnvironmentInfoBuilder:
+    def step_info(self, request: EnvironmentStepInfoRequest) -> dict[str, object]: ...
+    def terminal_info(self, request: EnvironmentTerminalInfoRequest) -> dict[str, object]: ...
+```
+
+- [ ] **Step 1: Write failing contract tests**
+
+Assert the complete existing key set, reward-context fields, optional discarded target, optional hybrid/shadow liquidation, terminal metric fields, fresh dictionary creation, and copied NumPy targets.
+
+- [ ] **Step 2: Run tests and confirm RED**
+
+```bash
+uv run pytest -q tests/rl/test_environment_info_service.py
+```
+
+Expected: import failure for `trade_rl.rl.environment_info`.
+
+- [ ] **Step 3: Implement minimal builder**
+
+Move `_book_metrics`, `_terminal_info`, and the step `info` literal. Use `evaluate_performance` and `ReturnSeries` exactly as before.
+
+- [ ] **Step 4: Run focused tests**
+
+```bash
+uv run pytest -q tests/rl/test_environment_info_service.py tests/rl/test_environment_timing.py tests/rl/test_pending_order_environment.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add trade_rl/rl/environment_info.py tests/rl/test_environment_info_service.py
+git commit -m "refactor: extract environment info builder"
+```
+
+### Task 6: Integrate services into `ResidualMarketEnv`
+
+**Files:**
+- Modify: `trade_rl/rl/environment.py`
+- Modify: `tests/architecture/test_environment_step_decomposition.py`
+
+**Interfaces:**
+- Consumes all service interfaces from Tasks 2-5.
+- Preserves existing private compatibility methods as thin delegates where tests call them.
+
+- [ ] **Step 1: Add service construction in `__init__`**
+
+Instantiate the planner, projector, reward coordinator, and info builder after their dependencies are validated.
+
+- [ ] **Step 2: Replace direct step logic with orchestration**
+
+Call services in the existing order, apply mutable state only in the facade, and preserve pending-target discard and terminal-liquidation ordering.
+
+- [ ] **Step 3: Run architecture and environment regression tests**
+
+```bash
+uv run pytest -q \
+  tests/architecture/test_environment_step_decomposition.py \
+  tests/rl \
+  tests/serving/test_observation_parity.py \
+  tests/serving/test_observation_snapshot_fail_closed.py \
+  tests/e2e/test_stateful_order_replay.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run static checks**
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy .
+uv run lint-imports
+```
+
+Expected: all commands exit `0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add trade_rl/rl/environment.py tests/architecture/test_environment_step_decomposition.py
+git commit -m "refactor: delegate environment step responsibilities"
+```
+
+### Task 7: Add coverage ratchet and exact-head verification
+
+**Files:**
+- Modify: `pyproject.toml`
+- Create: `docs/verification/2026-07-22-environment-runtime-decomposition.md`
+
+- [ ] **Step 1: Run full coverage before setting threshold**
+
+```bash
+uv run pytest -q --cov=trade_rl --cov-branch --cov-report=json:coverage.json
+```
+
+Expected: full suite passes and writes `coverage.json`.
+
+- [ ] **Step 2: Calculate aggregate branch percentage**
+
+Aggregate covered and total branches for:
+
+```text
+trade_rl/rl/environment_decision.py
+trade_rl/rl/environment_risk.py
+trade_rl/rl/environment_reward.py
+trade_rl/rl/environment_info.py
+```
+
+Set `[tool.trade_rl.critical_coverage.groups.environment_step_services]` to the measured percentage rounded down to a safe tenth. Do not change the existing `environment_runtime` group.
+
+- [ ] **Step 3: Run complete local-equivalent checks**
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy .
+uv run lint-imports
+uv run pytest -q --cov=trade_rl --cov-branch --cov-report=json:coverage.json
+uv run python .github/check_critical_coverage.py coverage.json pyproject.toml
+uv run trade-rl --help
+```
+
+Expected: every command exits `0`.
+
+- [ ] **Step 4: Record RED and GREEN evidence**
+
+Document commit SHAs, workflow run IDs, test count, coverage, new ratchet, artifact IDs/digests, compatibility jobs, training image, and PostgreSQL run.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pyproject.toml docs/verification/2026-07-22-environment-runtime-decomposition.md
+git commit -m "test: ratchet environment step service coverage"
+```
+
+- [ ] **Step 6: Create stacked Draft PR**
+
+Base: `agent/fix-architecture-followup-20260722`
+
+Head: `agent/decompose-environment-runtime-20260722`
+
+The PR body must state that it is stacked on PR #79, remains `NO-GO`, and will be retargeted to `main` after PR #79 merges.

--- a/docs/superpowers/plans/2026-07-22-telemetry-cursor-generation.md
+++ b/docs/superpowers/plans/2026-07-22-telemetry-cursor-generation.md
@@ -1,0 +1,909 @@
+# Generation-Bound Telemetry Polling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bind Studio telemetry cursors to an explicit stream generation, prevent mixed-generation replay, and shorten polling lock duration without weakening process safety.
+
+**Architecture:** Persist a UUID generation in sidecar index v2. Refresh index metadata under the existing cross-process lock, capture an identity-verified file snapshot, then parse the bounded page after releasing the lock. Propagate generation/reset state through Python telemetry contracts, Studio API models, TypeScript guards, API client, and the polling hook.
+
+**Tech Stack:** Python 3.12, dataclasses, pathlib, UUID, pytest, FastAPI/Pydantic, React 19, TypeScript, Vitest, Testing Library, Ruff, Mypy, Import Linter, GitHub Actions.
+
+## Global Constraints
+
+- Preserve telemetry JSONL schema `training_telemetry_v1`.
+- Replace only the internal sidecar schema with `training_telemetry_index_v2`.
+- Keep sequence pagination and the maximum page limit of 2,000 records.
+- New Python dataclass fields must be final fields with defaults so existing positional constructors remain valid.
+- A generation mismatch must return zero records and `reset_required=True`.
+- A no-growth poll must perform zero sidecar writes and zero `fsync` calls through `_write_index()`.
+- Page-body parsing must occur outside the append serialization lock.
+- Existing critical coverage thresholds may not be reduced.
+- Production remains `NO-GO`; direct exchange routing is out of scope.
+
+---
+
+## File map
+
+- Modify `trade_rl/telemetry/training.py`: additive page/status generation fields.
+- Modify `trade_rl/telemetry/indexed_training.py`: index v2, generation validation, change-aware refresh, snapshot capture, generation-aware reads.
+- Modify `tests/telemetry/test_training.py`: deterministic generation, no-op poll, lock duration, and near-tail scaling contracts.
+- Modify `tests/telemetry/test_indexed_process_concurrency.py`: preserve generation and process-safety regression coverage where needed.
+- Modify `trade_rl/studio/telemetry.py`: expose generation/reset in Studio response models and reader methods.
+- Modify `trade_rl/studio/api.py`: accept the expected generation query parameter.
+- Modify `tests/studio/test_telemetry_api.py`: API generation/reset and invalid-query contracts.
+- Modify `studio/src/data/types.ts`: TypeScript response fields.
+- Modify `studio/src/live/telemetryGuards.ts`: strict UUID and reset validation.
+- Modify `studio/src/api/studioApi.ts`: send `stream_generation`.
+- Modify `studio/src/live/useTrainingTelemetry.ts`: generation-bound polling and one retry.
+- Create `studio/src/live/useTrainingTelemetry.test.tsx`: hook-level reset and race tests.
+- Modify frontend mocks that implement `StudioApi`, including `studio/src/pages/LiveTrainingPage.test.tsx` and `studio/src/pages/RuntimePages.test.tsx`.
+- Modify `pyproject.toml`: add a non-regressing telemetry polling coverage group after measuring final coverage.
+- Create `docs/verification/2026-07-22-telemetry-cursor-generation.md`: exact RED/GREEN and CI evidence.
+
+---
+
+### Task 1: Commit Python generation RED contracts
+
+**Files:**
+- Modify: `tests/telemetry/test_training.py`
+
+**Interfaces:**
+- Consumes: existing `TrainingTelemetryWriter`, `read_training_telemetry()`, and `training_telemetry_status()` package exports.
+- Produces: failing contracts for `stream_generation`, `expected_generation`, and `reset_required`.
+
+- [ ] **Step 1: Add generation helpers and failing tests**
+
+Add `import os` and the following tests after `test_index_rebuilds_after_stream_replacement`:
+
+```python
+def _required_generation(value: str | None) -> str:
+    assert value is not None
+    return value
+
+
+def test_generation_remains_stable_across_normal_append(tmp_path: Path) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        writer.append(record(1))
+    first = training_telemetry_status(path)
+
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        writer.append(record(2))
+    second = training_telemetry_status(path)
+
+    assert _required_generation(first.stream_generation) == second.stream_generation
+
+
+def test_old_generation_requests_reset_after_stream_replacement(tmp_path: Path) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        writer.append(record(1))
+        writer.append(record(2))
+    old_generation = _required_generation(
+        training_telemetry_status(path).stream_generation
+    )
+
+    replacement = tmp_path / "replacement.jsonl"
+    replacement.write_text(
+        json.dumps(record(1).to_json_dict(), sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(replacement, path)
+
+    page = read_training_telemetry(
+        path,
+        after_sequence=2,
+        limit=10,
+        expected_generation=old_generation,
+    )
+
+    assert page.items == ()
+    assert page.next_sequence == 0
+    assert page.reset_required is True
+    assert page.stream_generation not in (None, old_generation)
+
+
+def test_index_loss_rotates_generation_and_invalidates_cursor(tmp_path: Path) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        writer.append(record(1))
+    first = training_telemetry_status(path)
+    old_generation = _required_generation(first.stream_generation)
+    path.with_name(f"{path.name}.index.json").unlink()
+
+    page = read_training_telemetry(
+        path,
+        after_sequence=1,
+        limit=10,
+        expected_generation=old_generation,
+    )
+
+    assert page.items == ()
+    assert page.reset_required is True
+    assert page.stream_generation not in (None, old_generation)
+
+
+def test_expected_generation_requires_canonical_uuid(tmp_path: Path) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        writer.append(record(1))
+
+    with pytest.raises(ValueError, match="expected_generation"):
+        read_training_telemetry(
+            path,
+            after_sequence=0,
+            limit=10,
+            expected_generation="not-a-generation",
+        )
+```
+
+- [ ] **Step 2: Run the RED tests**
+
+Run:
+
+```bash
+uv run pytest -q \
+  tests/telemetry/test_training.py::test_generation_remains_stable_across_normal_append \
+  tests/telemetry/test_training.py::test_old_generation_requests_reset_after_stream_replacement \
+  tests/telemetry/test_training.py::test_index_loss_rotates_generation_and_invalidates_cursor \
+  tests/telemetry/test_training.py::test_expected_generation_requires_canonical_uuid
+```
+
+Expected: FAIL because status/page generation fields and `expected_generation` do not exist.
+
+- [ ] **Step 3: Record RED evidence**
+
+Save the pytest output as an Actions artifact or a committed verification note containing the exact failing head, run ID, artifact ID, and SHA-256 digest.
+
+- [ ] **Step 4: Commit the tests**
+
+```bash
+git add tests/telemetry/test_training.py
+git commit -m "test: bind telemetry cursor to stream generation"
+```
+
+---
+
+### Task 2: Commit low-contention polling RED contracts
+
+**Files:**
+- Modify: `tests/telemetry/test_training.py`
+
+**Interfaces:**
+- Consumes: private module hooks `_write_index` and `_parse_record` only inside tests.
+- Produces: deterministic tests proving unchanged polls do not write, page parsing releases the process lock, and near-tail reads are bounded.
+
+- [ ] **Step 1: Add imports**
+
+Add:
+
+```python
+import threading
+
+from trade_rl.telemetry import indexed_training as indexed
+```
+
+- [ ] **Step 2: Add no-growth write test**
+
+```python
+def test_no_growth_polls_do_not_rewrite_index(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        for sequence in range(1, 70):
+            writer.append(record(sequence))
+    assert training_telemetry_status(path).last_sequence == 69
+
+    writes: list[int] = []
+
+    def fail_on_write(_path: Path, _index: object) -> None:
+        writes.append(1)
+
+    monkeypatch.setattr(indexed, "_write_index", fail_on_write)
+
+    status = training_telemetry_status(path)
+    page = read_training_telemetry(path, after_sequence=64, limit=10)
+
+    assert status.last_sequence == 69
+    assert [item.sequence for item in page.items] == [65, 66, 67, 68, 69]
+    assert writes == []
+```
+
+- [ ] **Step 3: Add lock-release test**
+
+```python
+def test_page_parsing_does_not_hold_append_process_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        for sequence in range(1, 131):
+            writer.append(record(sequence))
+    assert training_telemetry_status(path).last_sequence == 130
+
+    original_parse = indexed._parse_record
+    parse_started = threading.Event()
+    release_parse = threading.Event()
+    reader_done = threading.Event()
+    writer_done = threading.Event()
+    errors: list[BaseException] = []
+
+    def blocking_parse(raw_line: bytes):
+        if not parse_started.is_set():
+            parse_started.set()
+            if not release_parse.wait(timeout=10.0):
+                raise TimeoutError("page parse was not released")
+        return original_parse(raw_line)
+
+    monkeypatch.setattr(indexed, "_parse_record", blocking_parse)
+
+    def read_page() -> None:
+        try:
+            read_training_telemetry(path, after_sequence=64, limit=20)
+        except BaseException as error:  # pragma: no cover - asserted below
+            errors.append(error)
+        finally:
+            reader_done.set()
+
+    def append_record() -> None:
+        try:
+            with TrainingTelemetryWriter(path, flush_every=1) as writer:
+                writer.append(record(131))
+        except BaseException as error:  # pragma: no cover - asserted below
+            errors.append(error)
+        finally:
+            writer_done.set()
+
+    reader = threading.Thread(target=read_page)
+    reader.start()
+    assert parse_started.wait(timeout=10.0)
+
+    writer = threading.Thread(target=append_record)
+    writer.start()
+    assert writer_done.wait(timeout=2.0), "writer remained blocked by page parsing"
+
+    release_parse.set()
+    reader.join(timeout=10.0)
+    writer.join(timeout=10.0)
+
+    assert reader_done.is_set()
+    assert errors == []
+    assert training_telemetry_status(path).last_sequence == 131
+```
+
+- [ ] **Step 4: Add deterministic near-tail scaling test**
+
+```python
+def test_near_tail_page_parses_at_most_one_checkpoint_stride(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    with TrainingTelemetryWriter(path, flush_every=256) as writer:
+        for sequence in range(1, 4_097):
+            writer.append(record(sequence))
+    assert training_telemetry_status(path).last_sequence == 4_096
+
+    original_parse = indexed._parse_record
+    parsed = 0
+
+    def counted_parse(raw_line: bytes):
+        nonlocal parsed
+        parsed += 1
+        return original_parse(raw_line)
+
+    monkeypatch.setattr(indexed, "_parse_record", counted_parse)
+    page = read_training_telemetry(path, after_sequence=4_080, limit=20)
+
+    assert [item.sequence for item in page.items] == list(range(4_081, 4_097))
+    assert parsed <= 80
+```
+
+- [ ] **Step 5: Run the RED tests**
+
+Run:
+
+```bash
+uv run pytest -q \
+  tests/telemetry/test_training.py::test_no_growth_polls_do_not_rewrite_index \
+  tests/telemetry/test_training.py::test_page_parsing_does_not_hold_append_process_lock \
+  tests/telemetry/test_training.py::test_near_tail_page_parses_at_most_one_checkpoint_stride
+```
+
+Expected: the no-growth write test and lock-release test FAIL against the current implementation. The near-tail bound may already pass and is retained as a non-regression contract.
+
+- [ ] **Step 6: Commit the tests**
+
+```bash
+git add tests/telemetry/test_training.py
+git commit -m "test: constrain telemetry polling critical section"
+```
+
+---
+
+### Task 3: Implement sidecar generation and snapshot reads
+
+**Files:**
+- Modify: `trade_rl/telemetry/training.py`
+- Modify: `trade_rl/telemetry/indexed_training.py`
+- Test: `tests/telemetry/test_training.py`
+- Test: `tests/telemetry/test_indexed_process_concurrency.py`
+
+**Interfaces:**
+- Produces: `TrainingTelemetryPage.stream_generation`, `TrainingTelemetryPage.reset_required`, `TrainingTelemetryStatus.stream_generation`, and `read_indexed_training_telemetry(..., expected_generation=None)`.
+- Preserves: `TrainingTelemetryWriter`, page size limits, strict record parsing, sequence gap behavior, and process lock path.
+
+- [ ] **Step 1: Add backward-compatible dataclass fields**
+
+In `trade_rl/telemetry/training.py`, change the dataclasses to:
+
+```python
+@dataclass(frozen=True, slots=True)
+class TrainingTelemetryPage:
+    items: tuple[TrainingTelemetryRecord, ...]
+    next_sequence: int
+    truncated: bool
+    malformed_lines: int
+    sequence_gaps: tuple[tuple[int, int], ...]
+    stream_generation: str | None = None
+    reset_required: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class TrainingTelemetryStatus:
+    available: bool
+    record_count: int
+    last_sequence: int
+    malformed_lines: int
+    size_bytes: int
+    stream_generation: str | None = None
+```
+
+- [ ] **Step 2: Add index v2 generation parsing**
+
+In `trade_rl/telemetry/indexed_training.py`:
+
+```python
+from uuid import UUID, uuid4
+
+_INDEX_SCHEMA = "training_telemetry_index_v2"
+
+
+def _canonical_generation(value: object, *, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"telemetry index {field_name} is invalid")
+    try:
+        resolved = str(UUID(value))
+    except (ValueError, AttributeError) as error:
+        raise ValueError(f"telemetry index {field_name} is invalid") from error
+    if resolved != value:
+        raise ValueError(f"telemetry index {field_name} is invalid")
+    return resolved
+```
+
+Add `generation: str` to `_TelemetryIndex`, include it in `to_json_dict()`, and require it in `_load_index()`.
+
+Create new indexes with:
+
+```python
+_TelemetryIndex(
+    device=int(stat.st_dev),
+    inode=int(stat.st_ino),
+    generation=str(uuid4()),
+)
+```
+
+- [ ] **Step 3: Make index refresh change-aware**
+
+Add:
+
+```python
+@dataclass(frozen=True, slots=True)
+class _IndexRefresh:
+    index: _TelemetryIndex | None
+    changed: bool
+```
+
+Refactor `_refresh_index_unlocked()` to return `_IndexRefresh`. Set `changed=True` when:
+
+- no valid index existed;
+- stream device/inode changed;
+- stream size shrank below `indexed_size`;
+- at least one complete line advanced `indexed_size`;
+- malformed/blank complete appended lines changed index counters or size.
+
+Call `_write_index()` only when `changed` is true. Do not mutate `last_scan_start` or write the index on a no-growth poll.
+
+- [ ] **Step 4: Add verified snapshot capture**
+
+Add:
+
+```python
+@dataclass(slots=True)
+class _TelemetrySnapshot:
+    handle: BinaryIO
+    size: int
+    index: _TelemetryIndex
+
+    def close(self) -> None:
+        self.handle.close()
+
+
+def _open_snapshot_unlocked(path: Path, index: _TelemetryIndex) -> _TelemetrySnapshot:
+    handle = path.open("rb")
+    try:
+        stat = os.fstat(handle.fileno())
+        if (int(stat.st_dev), int(stat.st_ino)) != (index.device, index.inode):
+            raise RuntimeError("telemetry stream identity changed")
+        if stat.st_size < index.indexed_size:
+            raise RuntimeError("telemetry stream size regressed")
+        return _TelemetrySnapshot(handle=handle, size=index.indexed_size, index=index)
+    except BaseException:
+        handle.close()
+        raise
+```
+
+- [ ] **Step 5: Implement generation-aware page reads**
+
+Change the signature to:
+
+```python
+def read_indexed_training_telemetry(
+    path: Path,
+    *,
+    after_sequence: int = 0,
+    limit: int = 512,
+    expected_generation: str | None = None,
+) -> _training.TrainingTelemetryPage:
+```
+
+Validate a non-null expected generation with `UUID` canonicalization and a `ValueError` message containing `expected_generation`.
+
+Under `_telemetry_process_lock`:
+
+1. refresh the index;
+2. return the missing-stream page when no index exists;
+3. return an empty reset page when the expected generation differs;
+4. capture `_TelemetrySnapshot` and compute the checkpoint offset.
+
+Release the lock before parsing. Parse only until `snapshot.size`, close the snapshot in `finally`, and return the index generation with `reset_required=False`.
+
+Mismatch return:
+
+```python
+return _training.TrainingTelemetryPage(
+    items=(),
+    next_sequence=0,
+    truncated=False,
+    malformed_lines=index.malformed_lines,
+    sequence_gaps=tuple(index.sequence_gaps),
+    stream_generation=index.generation,
+    reset_required=True,
+)
+```
+
+- [ ] **Step 6: Add generation to status and writer refresh usage**
+
+Update `indexed_training_telemetry_status()` to use `_IndexRefresh.index` and return `stream_generation=index.generation`.
+
+Update writer initialization and append to read `.index` from the refresh result. Preserve descriptor/path identity checks and incomplete-tail rejection.
+
+- [ ] **Step 7: Run focused Python verification**
+
+```bash
+uv run ruff check trade_rl/telemetry tests/telemetry
+uv run ruff format --check trade_rl/telemetry tests/telemetry
+uv run mypy .
+uv run pytest -q \
+  tests/telemetry/test_training.py \
+  tests/telemetry/test_indexed_process_concurrency.py \
+  tests/integrations/test_training_telemetry.py
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add \
+  trade_rl/telemetry/training.py \
+  trade_rl/telemetry/indexed_training.py \
+  tests/telemetry/test_training.py \
+  tests/telemetry/test_indexed_process_concurrency.py
+git commit -m "fix: bind telemetry pages to stream generation"
+```
+
+---
+
+### Task 4: Add Studio backend generation contract
+
+**Files:**
+- Modify: `trade_rl/studio/telemetry.py`
+- Modify: `trade_rl/studio/api.py`
+- Modify: `tests/studio/test_telemetry_api.py`
+
+**Interfaces:**
+- Consumes: Python telemetry page/status generation fields.
+- Produces: camel-case `streamGeneration`, `resetRequired`, and optional `stream_generation` query input.
+
+- [ ] **Step 1: Write failing Studio API tests**
+
+Add tests that assert:
+
+```python
+status_payload = client.get(
+    f"/api/studio/jobs/{job_id}/telemetry/status?seed=7"
+).json()
+assert UUID(status_payload["streamGeneration"])
+
+old_generation = status_payload["streamGeneration"]
+# Replace the JSONL stream with a new sequence-1 stream and remove/rebuild its index.
+reset_payload = client.get(
+    f"/api/studio/jobs/{job_id}/telemetry/events",
+    params={
+        "seed": 7,
+        "after_sequence": 10,
+        "limit": 10,
+        "stream_generation": old_generation,
+    },
+).json()
+assert reset_payload["items"] == []
+assert reset_payload["nextSequence"] == 0
+assert reset_payload["resetRequired"] is True
+assert reset_payload["streamGeneration"] != old_generation
+```
+
+Add an invalid query test:
+
+```python
+response = client.get(
+    f"/api/studio/jobs/{job_id}/telemetry/events",
+    params={"stream_generation": "not-a-uuid"},
+)
+assert response.status_code == 422
+```
+
+- [ ] **Step 2: Run RED Studio tests**
+
+```bash
+uv run pytest -q tests/studio/test_telemetry_api.py
+```
+
+Expected: FAIL because response fields and query input do not exist.
+
+- [ ] **Step 3: Implement response fields**
+
+In `trade_rl/studio/telemetry.py`:
+
+```python
+class TelemetryStatusResponse(StudioModel):
+    ...
+    stream_generation: str | None = None
+
+
+class TelemetryEventsResponse(StudioModel):
+    ...
+    stream_generation: str | None = None
+    reset_required: bool = False
+```
+
+Add `stream_generation: str | None = None` to `StudioTelemetryReader.events()` and pass it as `expected_generation`.
+
+Map page/status generation fields into the response models for both available and unavailable paths.
+
+- [ ] **Step 4: Implement API query validation**
+
+In `trade_rl/studio/api.py`, add:
+
+```python
+stream_generation: str | None = Query(
+    default=None,
+    pattern=r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+),
+```
+
+Pass it to `telemetry_reader.events()`.
+
+- [ ] **Step 5: Verify and commit**
+
+```bash
+uv run ruff check trade_rl/studio tests/studio/test_telemetry_api.py
+uv run ruff format --check trade_rl/studio tests/studio/test_telemetry_api.py
+uv run mypy .
+uv run pytest -q tests/studio/test_telemetry_api.py tests/telemetry tests/integrations/test_training_telemetry.py
+git add trade_rl/studio/telemetry.py trade_rl/studio/api.py tests/studio/test_telemetry_api.py
+git commit -m "feat: expose telemetry stream generation in Studio"
+```
+
+---
+
+### Task 5: Make frontend polling generation-safe
+
+**Files:**
+- Modify: `studio/src/data/types.ts`
+- Modify: `studio/src/live/telemetryGuards.ts`
+- Modify: `studio/src/api/studioApi.ts`
+- Modify: `studio/src/live/useTrainingTelemetry.ts`
+- Create: `studio/src/live/useTrainingTelemetry.test.tsx`
+- Modify: `studio/src/pages/LiveTrainingPage.test.tsx`
+- Modify: `studio/src/pages/RuntimePages.test.tsx`
+
+**Interfaces:**
+- Consumes: `streamGeneration` and `resetRequired` API fields.
+- Produces: generation-bound `loadTelemetryEvents()` calls and a hook that performs at most one reset/race retry.
+
+- [ ] **Step 1: Add failing guard and hook tests**
+
+Create `studio/src/live/useTrainingTelemetry.test.tsx` using `renderHook`, `act`, and `waitFor`.
+
+Test reset behavior with an API mock whose first event response is:
+
+```typescript
+{
+  seed: 7,
+  items: [],
+  nextSequence: 0,
+  truncated: false,
+  malformedLines: 0,
+  sequenceGaps: [],
+  streamGeneration: '22222222-2222-4222-8222-222222222222',
+  resetRequired: true,
+}
+```
+
+and whose retry returns one sequence-1 record for the new generation. Assert:
+
+```typescript
+await waitFor(() => expect(result.current.records.map((item) => item.sequence)).toEqual([1]))
+expect(api.loadTelemetryEvents).toHaveBeenNthCalledWith(
+  1,
+  'job-live',
+  0,
+  512,
+  7,
+  null,
+)
+expect(api.loadTelemetryEvents).toHaveBeenNthCalledWith(
+  2,
+  'job-live',
+  0,
+  512,
+  7,
+  '22222222-2222-4222-8222-222222222222',
+)
+```
+
+Add a generation-race test where status returns generation A and events returns generation B. The retry returns matching generation B. Assert no generation-A records are ever published and exactly two event calls occur.
+
+Add guard tests in the same file or a focused guard test block proving malformed generation strings and `resetRequired` non-booleans are rejected.
+
+- [ ] **Step 2: Run frontend RED**
+
+```bash
+cd studio
+npm test -- --run src/live/useTrainingTelemetry.test.tsx
+```
+
+Expected: FAIL because fields/signatures/retry behavior do not exist.
+
+- [ ] **Step 3: Extend TypeScript contracts and guards**
+
+In `studio/src/data/types.ts`:
+
+```typescript
+export interface TelemetryStatusResponse {
+  ...
+  streamGeneration: string | null
+}
+
+export interface TelemetryEventsResponse {
+  ...
+  streamGeneration: string | null
+  resetRequired: boolean
+}
+```
+
+In `telemetryGuards.ts`, add:
+
+```typescript
+const generationPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+const isNullableGeneration = (value: unknown): value is string | null =>
+  value === null || (typeof value === 'string' && generationPattern.test(value))
+```
+
+Require the generation field in status/events and require `resetRequired` to be boolean.
+
+- [ ] **Step 4: Extend the API client signature**
+
+Change `loadTelemetryEvents()` and `StudioApi.loadTelemetryEvents` to accept:
+
+```typescript
+(
+  jobId: string,
+  afterSequence?: number,
+  limit?: number,
+  seed?: number | null,
+  streamGeneration?: string | null,
+) => Promise<TelemetryEventsResponse>
+```
+
+The exported function may retain `fetcher` as its final sixth parameter. Add `stream_generation` to `URLSearchParams` only when non-null.
+
+Update all StudioApi test mocks to the new signature and add generation/reset fields to response fixtures.
+
+- [ ] **Step 5: Implement one-retry hook behavior**
+
+Add:
+
+```typescript
+const generation = useRef<string | null>(null)
+```
+
+Refactor refresh into an inner function `loadSnapshot(allowRetry: boolean)`.
+
+Rules:
+
+- call events with `generation.current`;
+- if `page.resetRequired`, clear records/status, set sequence to zero, adopt `page.streamGeneration`, and retry once;
+- if status/page generations are both non-null and differ, clear state, set generation to null, and retry once;
+- if either condition repeats when `allowRetry` is false, throw an explicit generation-change error;
+- before accepting records, require the page generation to equal the stored generation;
+- reset generation to null in the job/seed effect cleanup path.
+
+- [ ] **Step 6: Run frontend verification**
+
+```bash
+cd studio
+npm test -- --run
+npm run typecheck
+npm run build
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add \
+  studio/src/data/types.ts \
+  studio/src/live/telemetryGuards.ts \
+  studio/src/api/studioApi.ts \
+  studio/src/live/useTrainingTelemetry.ts \
+  studio/src/live/useTrainingTelemetry.test.tsx \
+  studio/src/pages/LiveTrainingPage.test.tsx \
+  studio/src/pages/RuntimePages.test.tsx
+git commit -m "fix: reset live telemetry on stream generation change"
+```
+
+---
+
+### Task 6: Verify process safety, coverage, and evidence
+
+**Files:**
+- Modify: `pyproject.toml`
+- Create: `docs/verification/2026-07-22-telemetry-cursor-generation.md`
+
+**Interfaces:**
+- Consumes: completed backend/frontend implementation.
+- Produces: a non-regressing branch coverage floor and exact-head verification evidence.
+
+- [ ] **Step 1: Run focused cross-platform process tests**
+
+Run locally or in an exact-head matrix:
+
+```bash
+uv run pytest -q \
+  tests/telemetry/test_training.py \
+  tests/telemetry/test_indexed_process_concurrency.py \
+  tests/integrations/test_training_telemetry.py \
+  tests/studio/test_telemetry_api.py
+```
+
+Run the same focused set on Ubuntu and Windows. Expected: all pass, including native `fcntl` and `msvcrt` paths.
+
+- [ ] **Step 2: Run the full repository verification**
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy .
+uv run lint-imports
+uv run pytest -q --cov=trade_rl --cov-branch --cov-report=term-missing --cov-report=json
+cd studio && npm test -- --run && npm run typecheck && npm run build
+```
+
+Expected: every command exits 0 and overall coverage remains at least 80%.
+
+- [ ] **Step 3: Compute the telemetry polling coverage floor**
+
+Run:
+
+```bash
+python - <<'PY'
+import json
+from math import floor
+
+coverage = json.load(open("coverage.json", encoding="utf-8"))
+summary = coverage["files"]["trade_rl/telemetry/indexed_training.py"]["summary"]
+covered = summary["covered_branches"]
+total = summary["num_branches"]
+percent = 100.0 if total == 0 else covered / total * 100.0
+minimum = floor(percent * 10.0) / 10.0
+print(f"covered={covered} total={total} percent={percent:.4f} minimum={minimum:.1f}")
+PY
+```
+
+Update `pyproject.toml` automatically from the measured result:
+
+```bash
+python - <<'PY'
+import json
+from math import floor
+from pathlib import Path
+
+coverage = json.loads(Path("coverage.json").read_text(encoding="utf-8"))
+summary = coverage["files"]["trade_rl/telemetry/indexed_training.py"]["summary"]
+covered = summary["covered_branches"]
+total = summary["num_branches"]
+percent = 100.0 if total == 0 else covered / total * 100.0
+minimum = floor(percent * 10.0) / 10.0
+
+path = Path("pyproject.toml")
+source = path.read_text(encoding="utf-8")
+header = "[tool.trade_rl.critical_coverage.groups.telemetry_polling]"
+block = (
+    f"\n{header}\n"
+    f"minimum = {minimum:.1f}\n"
+    "paths = [\n"
+    '    "trade_rl/telemetry/indexed_training.py",\n'
+    "]\n"
+)
+if header in source:
+    before, remainder = source.split(header, 1)
+    next_group = remainder.find("\n[tool.")
+    source = before.rstrip() + block + (
+        "" if next_group < 0 else remainder[next_group:]
+    )
+else:
+    source = source.rstrip() + "\n" + block
+path.write_text(source, encoding="utf-8")
+print(
+    f"telemetry_polling: covered={covered} total={total} "
+    f"percent={percent:.4f} minimum={minimum:.1f}"
+)
+PY
+```
+
+Do not modify or lower any existing group.
+
+- [ ] **Step 4: Re-run the full CI command after adding the ratchet**
+
+Expected: critical branch coverage passes with the measured floor.
+
+- [ ] **Step 5: Write verification evidence**
+
+Create `docs/verification/2026-07-22-telemetry-cursor-generation.md` containing:
+
+- design and plan paths;
+- RED commit SHAs and failure summaries;
+- GREEN commit SHA;
+- Ubuntu and Windows run IDs;
+- final exact-head SHA;
+- full test counts, skipped tests, warnings, total coverage, total branch coverage, and telemetry branch coverage;
+- pytest artifact ID and SHA-256 digest;
+- PostgreSQL run ID and each successful step;
+- confirmation that telemetry JSON schema remains v1, index schema is v2, and production remains `NO-GO`.
+
+- [ ] **Step 6: Commit final evidence**
+
+```bash
+git add pyproject.toml docs/verification/2026-07-22-telemetry-cursor-generation.md
+git commit -m "docs: verify generation-bound telemetry polling"
+```
+
+- [ ] **Step 7: Verify the exact final head once more**
+
+Fetch workflow runs for the final documentation commit. Do not claim completion until normal CI and PostgreSQL Catalog both report `completed/success` for that exact SHA.

--- a/docs/superpowers/plans/2026-07-22-telemetry-process-concurrency.md
+++ b/docs/superpowers/plans/2026-07-22-telemetry-process-concurrency.md
@@ -1,0 +1,101 @@
+# Telemetry Process Concurrency Hardening Plan
+
+**Goal:** Make indexed telemetry append, index refresh, page read, and status read
+safe across cooperating Linux and Windows processes without changing public
+schemas or Studio APIs.
+
+**Architecture:** A private cross-platform OS file lock protects one append or one
+index/read snapshot. The indexed writer uses append-only binary writes and
+process-visible sequence validation. Index writes use unique durable temporary
+files and atomic replacement.
+
+## Constraints
+
+- Preserve public telemetry imports and JSON/index schema versions.
+- Preserve the writer constructor and context-manager methods.
+- Preserve duplicate-sequence and closed-writer error behavior.
+- Do not lock for the writer lifetime.
+- Do not silently truncate incomplete evidence.
+- Use spawn-based multiprocessing tests.
+- Keep Windows compatibility green.
+
+## Task 1: Commit RED concurrency contracts
+
+Create `tests/telemetry/test_indexed_process_concurrency.py`.
+
+Tests:
+
+- two already-open writers race sequence `1`; exactly one must succeed;
+- final JSONL contains one valid record and indexed status reports one record;
+- concurrent status/page readers complete without process errors while a writer
+  appends ordered records;
+- incomplete trailing bytes reject a subsequent append;
+- index JSON remains valid and identity-bound.
+
+Run the focused tests before production changes and record the failing workflow
+artifact.
+
+## Task 2: Implement cross-platform process lock
+
+Modify `trade_rl/telemetry/indexed_training.py`.
+
+Add:
+
+- lock sidecar path helper;
+- private context manager using `fcntl.flock` or `msvcrt.locking`;
+- symlink rejection and reliable release;
+- unlocked internal refresh helper to avoid nested lock acquisition.
+
+Add focused tests for lock release after exceptions and repeated acquisition.
+
+## Task 3: Implement process-safe writer
+
+Replace the inherited no-op indexed writer with an API-compatible implementation
+that:
+
+- validates `flush_every`;
+- owns a thread lock and append-only binary descriptor;
+- refreshes latest index under the process lock on every append;
+- rejects duplicate/regressing sequence across processes;
+- rejects incomplete trailing records;
+- writes the complete encoded line with a partial-write loop;
+- uses `fsync` at `flush_every`, explicit `flush`, and `close`.
+
+Run writer, training telemetry, and integration tests.
+
+## Task 4: Make index refresh and reads transactional
+
+Refactor index refresh into `_refresh_index_unlocked()` and a locked wrapper.
+
+- unique PID/token index temporary;
+- write/flush/fsync before `os.replace`;
+- cleanup temporary in `finally`;
+- optional POSIX parent-directory fsync;
+- page read holds lock and stops at snapshot `indexed_size`;
+- status holds lock through refresh and size capture.
+
+Run process concurrency, indexed telemetry, and Studio telemetry tests.
+
+## Task 5: Full verification and coverage ratchet
+
+Run exact-head:
+
+- Ruff and format;
+- Mypy;
+- Import Linter and dead-code report;
+- full Pytest with branch coverage;
+- telemetry and Studio integrations;
+- Ubuntu/Windows compatibility;
+- training image;
+- PostgreSQL Catalog.
+
+Measure branch coverage for `trade_rl/telemetry/indexed_training.py`. Add or raise a
+critical-coverage threshold only to the measured safe value and never reduce an
+existing threshold.
+
+Create
+`docs/verification/2026-07-22-telemetry-process-concurrency.md` with RED/GREEN,
+workflow, artifact, digest, test-count, and coverage evidence.
+
+Create a Draft PR based on PR #80 exact head while targeting `main` for exact-head
+workflow execution. Do not merge.

--- a/docs/superpowers/plans/2026-07-23-telemetry-episode-identity.md
+++ b/docs/superpowers/plans/2026-07-23-telemetry-episode-identity.md
@@ -1,0 +1,86 @@
+# Telemetry Episode Identity Implementation Plan
+
+Date: 2026-07-23
+
+## Scope
+
+Implement the design in `docs/superpowers/specs/2026-07-23-telemetry-episode-identity-design.md` as one independent PR from current `main`.
+
+## Task 1 — Reproduce the missing boundary
+
+Add a frontend regression in `studio/src/live/telemetryStreams.test.ts` where:
+
+- one environment emits records for two explicit episode IDs;
+- terminal flags are absent;
+- `environmentStep` and `marketIndex` remain monotonic;
+- the expected current episode contains only the newest explicit ID.
+
+Verify the focused test fails because the current implementation joins both episodes.
+
+## Task 2 — Add the record contract
+
+Update `trade_rl/telemetry/training.py`:
+
+- add nullable `episode_id`;
+- validate non-negative integer semantics;
+- serialize it in JSON;
+- accept missing or null values as legacy records;
+- reject boolean, negative, and non-integer explicit values.
+
+Add focused record-contract tests.
+
+## Task 3 — Allocate identity in the producer
+
+Update `trade_rl/rl/training_telemetry.py`:
+
+- maintain an active episode ID per vector environment;
+- allocate a new ID for a new environment episode;
+- emit the ID on every retained record;
+- rotate only after writing a terminal or truncated record;
+- clear previous-close and previous-weight fallback state at rotation.
+
+Add integration tests for interleaved environments, stable identity, terminal rotation, and fallback-state reset.
+
+## Task 4 — Expose Studio and browser contracts
+
+Update:
+
+- `trade_rl/studio/telemetry.py`;
+- `studio/src/data/types.ts`;
+- `studio/src/live/telemetryGuards.ts`;
+- affected fixtures.
+
+Require strict explicit values while normalizing legacy omission to `null`.
+
+## Task 5 — Prefer explicit identity in current UI boundary
+
+Update the existing `currentEnvironmentEpisode()` implementation rather than importing the older alternate page/track implementation:
+
+- latest explicit ID selects exact matching records;
+- latest legacy record uses the existing heuristic;
+- existing environment and current-episode UI remains unchanged.
+
+Keep PR #85 behavior and tests intact.
+
+## Task 6 — Add measured coverage and documentation
+
+Measure `trade_rl/rl/training_telemetry.py` branch coverage and add only the supported threshold to the current `pyproject.toml`; do not overwrite later telemetry-generation or environment-runtime ratchets.
+
+Record RED/GREEN evidence, exact commit SHA, workflow runs, test totals, coverage, and artifact digests.
+
+## Verification
+
+Run exact-head CI covering:
+
+- Studio Vitest, TypeScript, production build, and fixed viewport;
+- Ruff and format;
+- Mypy;
+- Import Linter and architecture tests;
+- Serving smoke;
+- complete Pytest and critical branch coverage;
+- CLI smoke;
+- Ubuntu and Windows compatibility;
+- complete training image and non-root probe;
+- PostgreSQL Compose, migration, and integration tests.
+
+Production remains `NO-GO`.

--- a/docs/superpowers/specs/2026-07-22-environment-runtime-decomposition-design.md
+++ b/docs/superpowers/specs/2026-07-22-environment-runtime-decomposition-design.md
@@ -1,0 +1,166 @@
+# Environment Runtime Decomposition Design
+
+## Context
+
+`ResidualMarketEnv` is now a Gymnasium facade over dedicated episode, execution,
+observation, and termination services. Its `step()` path still owns four distinct
+responsibilities:
+
+1. action parsing, composition, signal-delay planning, and decision-bar selection;
+2. emergency, pre-trade, and portfolio risk projection;
+3. reward transition calculation;
+4. step and terminal `info` construction.
+
+Keeping these responsibilities in the facade makes execution-sensitive changes
+hard to review and forces tests to exercise a large mutable object even when only
+one policy boundary changes.
+
+## Approaches considered
+
+### A. Private-method extraction only
+
+Split `step()` into more private methods on `ResidualMarketEnv`.
+
+This is the smallest diff, but it leaves the same ownership problem. The methods
+would still read and mutate broad environment state and would not be independently
+reusable or testable.
+
+### B. Immutable request/result services
+
+Introduce four focused services and immutable request/result dataclasses. Keep
+all Gymnasium state mutation in `ResidualMarketEnv`, while each service receives
+only the inputs required for one decision.
+
+This is the selected approach. It establishes explicit contracts without changing
+public schemas, action semantics, execution ordering, or mutable state ownership.
+
+### C. Full step state machine
+
+Represent the entire step lifecycle as a state machine with persisted phases.
+
+This could support resumable execution later, but it is unnecessarily broad for
+the current local research environment and would increase compatibility risk.
+
+## Selected architecture
+
+### `EnvironmentDecisionPlanner`
+
+Owns:
+
+- legacy and maintained action parsing;
+- baseline/residual composition;
+- submitted hybrid and shadow target creation;
+- one-decision signal-delay resolution;
+- decision-bar count calculation.
+
+It returns an immutable `EnvironmentDecisionPlan` containing the parsed action,
+maintained action vector, diagnostics inputs, submitted targets, executed targets,
+next pending targets, warm-up status, and bar count.
+
+It does not mutate environment pending targets or books.
+
+### `EnvironmentRiskProjector`
+
+Owns:
+
+- proposal shape and finiteness validation;
+- emergency-risk assessment;
+- pre-trade risk constraint;
+- causal advanced portfolio-risk input resolution;
+- portfolio-risk projection;
+- merged reason and projection-distance construction.
+
+It returns the existing `RiskConstrainedTarget`. Dataset and risk models are
+constructor dependencies; current index and book are explicit call inputs.
+
+### `EnvironmentRewardCoordinator`
+
+Owns one reward transition. It receives interval returns, current books,
+projection distance, and termination flags, and delegates to `RewardTracker`.
+It returns the existing reward breakdown. Reward-history pre-roll and reset remain
+in the facade because they belong to episode initialization rather than step
+transition planning.
+
+### `EnvironmentInfoBuilder`
+
+Owns the stable `info` contract:
+
+- per-step action, execution, risk, reward, delay, and termination fields;
+- optional discarded-target and liquidation fields;
+- terminal performance metrics and action diagnostics.
+
+It returns a new dictionary on every call and does not mutate books, reward state,
+or diagnostics. Existing key names and value types remain unchanged.
+
+### `ResidualMarketEnv`
+
+Remains responsible for:
+
+- Gymnasium `reset()` and `step()` methods;
+- mutable books, order books, pending targets, indices, action history, position
+  ages, and diagnostics;
+- ordering the planner, risk, execution, termination, reward, observation, and
+  info services;
+- environment identity and compatibility properties.
+
+The facade applies service results in the same order as the current implementation.
+
+## Step data flow
+
+1. Resolve market inputs.
+2. Ask `EnvironmentDecisionPlanner` for an immutable decision plan.
+3. Project hybrid and shadow executed targets through `EnvironmentRiskProjector`.
+4. Execute both constrained targets through `EnvironmentExecutionCoordinator`.
+5. Apply book, order-book, index, and pending-target state changes in the facade.
+6. Resolve economic and time-limit termination.
+7. Calculate reward through `EnvironmentRewardCoordinator`.
+8. Update execution observation state, previous action, and diagnostics.
+9. Build stable step/terminal information through `EnvironmentInfoBuilder`.
+10. Return the next observation and unchanged Gymnasium tuple contract.
+
+## Compatibility constraints
+
+The implementation must not change:
+
+- `ResidualMarketEnv` constructor or public properties;
+- action, observation, reward, or environment schema versions;
+- environment digest payload;
+- target identity construction or execution order;
+- signal-delay semantics;
+- risk reason ordering;
+- reward calculation order;
+- terminal accounting behavior;
+- any existing `info` key, optional-key condition, or value type;
+- direct exchange routing or production readiness status.
+
+Private compatibility methods may remain as thin delegates where tests or internal
+callers still use them.
+
+## Error handling
+
+Services fail closed on invalid action vectors, target dimensions, non-finite
+values, missing advanced risk inputs, exhausted episode intervals, and invalid
+bar counts. No service catches or downgrades existing domain exceptions.
+
+## Testing strategy
+
+1. Add architecture contracts before production code. They require the four new
+   services and delegation from `ResidualMarketEnv`.
+2. Add focused unit tests for action migration, signal delay, irregular-calendar
+   bar calculation, emergency/portfolio risk merging, reward input mapping, and
+   optional/terminal `info` fields.
+3. Run existing environment, simulation, serving-parity, telemetry, and training
+   integration tests as regression evidence.
+4. Run Ruff, format, Mypy, Import Linter, dead-code analysis, full Pytest with
+   branch coverage, critical coverage, CLI smoke, compatibility jobs, training
+   image build, and PostgreSQL Catalog workflow on the exact PR head.
+5. Add a new branch-coverage ratchet for the extracted step services using the
+   measured post-refactor coverage without reducing the existing environment
+   runtime group threshold.
+
+## Pull-request structure
+
+This is a stacked Draft PR based on
+`agent/fix-architecture-followup-20260722` because PR #79 is not yet merged. Once
+PR #79 lands, this PR can be retargeted to `main` without carrying unrelated
+changes.

--- a/docs/superpowers/specs/2026-07-22-telemetry-cursor-generation-design.md
+++ b/docs/superpowers/specs/2026-07-22-telemetry-cursor-generation-design.md
@@ -1,0 +1,161 @@
+# Generation-Bound Telemetry Polling Design
+
+## Context
+
+Indexed training telemetry is now process-safe, but the polling cursor is still only a sequence number. The sidecar index detects file replacement or truncation and rebuilds itself, while Studio clients continue sending the old `after_sequence` value. If a new stream at the same path restarts sequence numbering, the client can receive empty pages indefinitely or mix records from different stream generations.
+
+Polling also performs unnecessary durable index writes when the stream has not changed, and `read_indexed_training_telemetry()` keeps the exclusive process lock while parsing the returned page. Long page parsing can therefore delay training appends.
+
+## Goals
+
+1. Bind every status and event page to one stable opaque stream generation.
+2. Detect replacement, truncation, or index rebuild without relying on sequence rollback heuristics.
+3. Never return records from a new generation against an old generation cursor.
+4. Reset Studio buffers explicitly before records from a replacement stream are accepted.
+5. Avoid rewriting and `fsync`-ing an unchanged sidecar index.
+6. Hold the process lock only while refreshing index metadata and capturing a consistent file snapshot.
+7. Preserve training telemetry record schema v1, existing sequence semantics within one generation, and the current 2,000-record limit.
+
+## Non-goals
+
+- Replacing sequence pagination with byte cursors.
+- Persisting browser cursor state across page reloads.
+- Repairing malformed, truncated, or manually edited telemetry files.
+- Changing telemetry sampling frequency, training callbacks, job ownership, or artifact publication.
+- Supporting direct exchange execution or changing production `NO-GO` status.
+
+## Chosen approach
+
+Use a persisted opaque generation identifier in the telemetry sidecar index.
+
+The generation is created whenever the index must be rebuilt from stream identity rather than incrementally extended. It remains stable while complete records are appended to the same stream. Index deletion, stream replacement, inode change, or truncation creates a new generation. A conservative generation change after index loss is acceptable because it fails closed and forces a clean client replay.
+
+A sequence-only heuristic was rejected because a replacement stream may have the same or a larger last sequence. A complete byte-cursor API replacement was rejected because it would create unnecessary migration scope for the current Studio API.
+
+## Sidecar index contract
+
+The internal index schema moves from `training_telemetry_index_v1` to `training_telemetry_index_v2` and adds:
+
+- `generation`: canonical lower-case UUID string.
+
+Loading an old or malformed index returns `None`, causing a full rebuild and a new generation. The telemetry JSONL schema remains unchanged.
+
+`_refresh_index_unlocked()` returns an explicit refresh result containing:
+
+- the refreshed index or `None`;
+- whether durable index state changed;
+- snapshot file size;
+- an open binary snapshot handle whose identity was verified against the index when a page read requires one.
+
+The index is written only when it was created, rebuilt, or advanced through at least one complete appended line. A no-growth poll does not create a temporary file, call `fsync`, replace the index, or sync the directory.
+
+## Snapshot and lock boundary
+
+For event reads:
+
+1. Acquire the per-stream process lock.
+2. Load or rebuild the index and scan only bytes after `indexed_size`.
+3. Open the telemetry file, verify its device and inode against the index, and capture `snapshot_size = indexed_size`.
+4. Validate the caller's expected generation.
+5. Release the process lock while keeping the verified snapshot handle open.
+6. Parse only bytes up to `snapshot_size`.
+7. Close the snapshot handle.
+
+Appending after step 5 is allowed. The page never reads beyond its captured size, so new records appear on the next poll. Replacement after step 5 cannot change the already-open snapshot identity. Windows replacement is naturally blocked while the handle is open; POSIX retains the opened inode.
+
+Status polling completes entirely under the short metadata lock and returns index metadata without parsing the page body.
+
+## Public telemetry contracts
+
+`TrainingTelemetryStatus` adds the following final field with a default of `None` so existing positional construction remains compatible:
+
+- `stream_generation: str | None = None`.
+
+`TrainingTelemetryPage` adds the following final fields with defaults so existing five-argument positional construction remains compatible:
+
+- `stream_generation: str | None = None`;
+- `reset_required: bool = False`.
+
+`read_training_telemetry()` adds an optional keyword-only `expected_generation: str | None = None`.
+
+Behavior:
+
+- Missing stream: generation is `None`, page is empty, and `reset_required` is false.
+- Initial request without an expected generation: return the current generation and normal records.
+- Matching expected generation: return normal records.
+- Mismatched expected generation: return no records, `next_sequence=0`, the current generation, and `reset_required=true`.
+- A non-UUID expected generation is rejected as invalid input rather than treated as a legitimate old cursor.
+
+No records are returned on a generation mismatch. The caller must reset before replaying the new stream.
+
+## Studio API contract
+
+`TelemetryStatusResponse` adds `streamGeneration`.
+
+`TelemetryEventsResponse` adds:
+
+- `streamGeneration`;
+- `resetRequired`.
+
+The events endpoint accepts optional `stream_generation` and passes it as `expected_generation` to the telemetry reader. The query value is validated as a canonical UUID string.
+
+Studio preserves the existing camel-case response convention.
+
+## Frontend behavior
+
+`useTrainingTelemetry()` stores both sequence and generation refs.
+
+Polling behavior:
+
+1. Send the current generation with the event request when known.
+2. If `resetRequired` is true, clear buffered records, set sequence to zero, adopt the returned generation, and immediately issue one replacement-generation poll.
+3. If no generation is stored yet, adopt the page generation before accepting records.
+4. Reject a page whose generation unexpectedly differs without `resetRequired`.
+5. Compare the status and event page generations returned by the parallel requests. If both are non-null and differ, discard the responses and retry once rather than publishing a mixed snapshot.
+6. On job or seed change, clear generation, sequence, records, and status together.
+
+A single refresh performs at most one automatic reset or generation-race retry to prevent loops if the stream changes continuously.
+
+## Error handling
+
+- Invalid sidecar generation values invalidate the index and trigger a safe rebuild.
+- File identity drift during snapshot capture raises a runtime telemetry identity error; Studio converts it to `artifact_invalid`.
+- A stream that changes again during the automatic retry leaves the UI delayed/offline with an explicit error rather than combining generations.
+- Incomplete trailing records remain excluded from `indexed_size`; append continues to fail closed until the tail is resolved externally.
+
+## Testing
+
+### RED contracts
+
+1. Replace a stream after the client has cursor sequence 100; an old-generation request must currently return an empty normal page rather than an explicit reset.
+2. Delete the index while preserving the JSONL file; the generation must change and invalidate the old cursor.
+3. Instrument `_write_index`; repeated no-growth status/events polls must currently rewrite the index.
+4. Block record parsing in a reader thread; a writer append must currently remain blocked because parsing holds the process lock.
+5. Frontend receives `resetRequired`; current hook must fail to clear records and replay from zero.
+6. Status and Events return different generations during one parallel refresh; the current hook must fail to discard the mixed snapshot.
+
+### GREEN contracts
+
+- Generation remains stable across normal appends.
+- Replacement, truncation, or index loss changes generation.
+- Old generation returns no records and requests reset.
+- Reset replay returns only the new generation.
+- No-growth polls perform zero durable index writes.
+- Writer append completes while an already-snapshotted page is being parsed.
+- Status and Events generation races are retried once without publishing either response.
+- Linux and Windows compatibility tests pass.
+- Existing strict parsing, duplicate seed, process-concurrency, Studio, and integration tests remain green.
+- Add a deterministic large-stream test proving a near-tail page parses at most one checkpoint stride plus the requested page, rather than the whole file.
+
+## Compatibility and migration
+
+The sidecar index is a cache and may be rebuilt, so the v1-to-v2 transition requires no migration command. Existing telemetry JSONL files remain readable. Python and Studio response models gain additive fields with backward-compatible defaults where direct construction exists. Existing internal call sites that do not pass an expected generation retain initial-request behavior.
+
+## Acceptance criteria
+
+- Old cursor plus changed generation cannot return telemetry records.
+- Studio never combines two generations in one in-memory record buffer.
+- A status/events race cannot publish a mixed generation snapshot.
+- Repeated unchanged polls do not rewrite the index.
+- Page parsing does not hold the append serialization lock.
+- All exact-head CI, PostgreSQL, Ubuntu/Windows compatibility, frontend tests/build, and critical coverage checks pass without lowering existing thresholds.

--- a/docs/superpowers/specs/2026-07-22-telemetry-process-concurrency-design.md
+++ b/docs/superpowers/specs/2026-07-22-telemetry-process-concurrency-design.md
@@ -1,0 +1,172 @@
+# Telemetry Process Concurrency Hardening Design
+
+## Context
+
+`IndexedTrainingTelemetryWriter` currently inherits a writer whose lock is a
+`threading.Lock`. Two processes can therefore open the same JSONL stream, read
+the same `last_sequence`, and both append an identical or out-of-order sequence.
+The resulting stream is syntactically valid but violates the monotonic identity
+contract.
+
+Index refresh has a second race. Every reader writes the same temporary path,
+`.<name>.index.json.tmp`, before replacing the index. Concurrent readers can
+truncate, replace, or remove that shared temporary file while another reader is
+using it.
+
+The live-training UI reads telemetry while training writes it, so locking the
+stream for the entire writer lifetime is not acceptable. The lock boundary must
+be one append or one consistent read/index-refresh transaction.
+
+## Approaches considered
+
+### A. Add a third-party file-lock package
+
+A package such as `filelock` or `portalocker` would reduce implementation code,
+but it introduces a runtime dependency solely for a small OS primitive and would
+need a lock-file compatibility review.
+
+### B. Lifetime writer lock
+
+Acquire an exclusive process lock in the writer constructor and release it on
+close. This prevents competing writers, but also blocks live readers for the
+entire training run.
+
+### C. Cross-platform OS lock per operation
+
+Use a stable sidecar lock file and native advisory locking:
+
+- `fcntl.flock` on POSIX;
+- `msvcrt.locking` on Windows.
+
+Append, index refresh, indexed read, and status operations hold the same exclusive
+lock only for their short critical section. This is the selected approach.
+
+## Selected architecture
+
+### `TelemetryProcessLock`
+
+A private context manager in `indexed_training.py` owns a sidecar path:
+
+`<telemetry-name>.lock`
+
+It opens the lock file in binary read/write mode and obtains an OS-level exclusive
+lock. OS locks are automatically released when a process exits or the handle is
+closed, so crashed processes do not leave a logically held lock.
+
+The implementation must:
+
+- work on Linux and Windows compatibility jobs;
+- reject a lock path that is a symbolic link;
+- create the parent directory before opening the lock file;
+- release the lock in `finally` paths;
+- avoid nested acquisition on the same telemetry path.
+
+### Process-safe writer
+
+`IndexedTrainingTelemetryWriter` remains API-compatible with the base writer but
+owns an append-only binary file descriptor rather than a buffered text handle.
+
+For every append it:
+
+1. acquires the thread lock;
+2. serializes and validates the record before touching the file;
+3. acquires the process lock;
+4. refreshes the index from the latest visible file state;
+5. rejects an incomplete trailing record;
+6. compares the proposed sequence with the process-visible last sequence;
+7. appends one complete UTF-8 JSON line through the append-only descriptor;
+8. releases the process lock.
+
+This ensures two processes racing to append the same sequence cannot both
+succeed. One succeeds; the other observes the new sequence and raises the
+existing monotonic-sequence `ValueError`.
+
+`flush_every` becomes the durability cadence for `fsync`; every `os.write` is
+immediately visible to cooperating processes, while the configured interval
+controls durable synchronization. Explicit `flush()` and `close()` perform
+`fsync`.
+
+### Incomplete-tail fail-closed rule
+
+A process crash can interrupt a low-level write and leave bytes without a final
+newline. Appending another JSON record after those bytes would turn both records
+into one malformed line.
+
+While holding the process lock, the writer compares the refreshed
+`indexed_size` with the current file size. If the file contains an incomplete
+trailing record, append fails with a `RuntimeError`. The writer never silently
+truncates research evidence. Repair remains an explicit operator action.
+
+### Consistent indexed reads
+
+`read_indexed_training_telemetry()` holds the process lock across:
+
+- index refresh;
+- checkpoint selection;
+- JSONL scan.
+
+The scan stops at the refreshed `indexed_size`, creating a consistent snapshot.
+Records appended after the lock is released are returned by the next read rather
+than being mixed with index metadata from an earlier snapshot.
+
+`indexed_training_telemetry_status()` similarly holds the lock through refresh
+and final size capture.
+
+### Atomic index replacement
+
+Index persistence uses a process-unique temporary path containing the PID and a
+random token. It writes, flushes, and `fsync`s the temporary file before
+`os.replace`. The temporary is removed in a `finally` block. On POSIX, the parent
+directory is synchronized after replacement when supported.
+
+The process lock is still mandatory; unique temporary paths protect cleanup and
+crash recovery, not index lost-update semantics.
+
+## Compatibility constraints
+
+The change must preserve:
+
+- telemetry JSONL schema and record serialization;
+- public writer constructor, `append`, `flush`, `close`, and context-manager API;
+- strict monotonic sequence error text;
+- indexed page and status dataclasses;
+- index schema version and checkpoint stride;
+- handling of malformed complete lines and sequence gaps;
+- live Studio telemetry endpoints;
+- Linux and Windows compatibility.
+
+No database, broker, direct-exchange, or production-readiness behavior changes.
+
+## Error handling
+
+- Duplicate or regressing sequence: existing `ValueError`.
+- Append after close: existing `RuntimeError`.
+- Incomplete trailing record: explicit `RuntimeError`.
+- Lock path symbolic link: explicit `RuntimeError`.
+- Invalid or stale index: rebuild under the process lock.
+- Index temporary write failure: propagate the original exception and remove the
+  process-unique temporary where possible.
+
+## Testing strategy
+
+1. Commit process-concurrency tests before production changes.
+2. Use `multiprocessing.get_context("spawn")` so tests exercise Windows-compatible
+   process semantics on every platform.
+3. Start two writers before a shared event, then race the same sequence. Assert
+   exactly one append succeeds and the stream contains exactly one record.
+4. Run multiple processes repeatedly reading status and pages while a writer
+   appends; assert no process error, no duplicate sequence, valid index JSON, and
+   complete final status.
+5. Verify incomplete-tail fail-closed behavior.
+6. Verify explicit flush/close durability and append-after-close behavior.
+7. Run existing telemetry, Studio API, training integration, Windows/Ubuntu
+   compatibility, full suite, and critical coverage on the exact head.
+8. Add or raise a telemetry branch-coverage ratchet only from measured coverage;
+   do not reduce any existing threshold.
+
+## Pull-request structure
+
+This is a stacked Draft PR based on PR #80 exact head
+`88f7e486b6db56fdc16ab89db5a77ef599c8f48f`. It targets `main` so repository
+workflows run. After PR #79 and PR #80 merge, its effective diff will reduce to
+the telemetry hardening files.

--- a/docs/superpowers/specs/2026-07-23-telemetry-episode-identity-design.md
+++ b/docs/superpowers/specs/2026-07-23-telemetry-episode-identity-design.md
@@ -1,0 +1,76 @@
+# Telemetry Episode Identity Design
+
+Date: 2026-07-23
+
+## Problem
+
+Live Training already isolates vector environments and conservatively detects the current episode from terminal records or counter rollback. That browser-side boundary prevents the confirmed visualization defect, but it is still inferential. An auto-reset environment can begin a new episode while `environment_step` and `market_index` remain monotonic and no retained terminal record is available. In that case, the current fallback can join two episodes.
+
+## Goal
+
+Add a producer-issued, nullable episode identity to training telemetry without changing the existing JSONL schema identifier or replacing the current Live Training UI.
+
+## Invariants
+
+- `schema_version` remains `training_telemetry_v1`.
+- `episode_id` is additive and nullable so historical records remain readable.
+- A sampler assigns one non-negative episode ID per vector environment.
+- Records from the same active environment episode retain the same ID.
+- A terminal or truncated transition is written with its current ID; the next record for that environment receives a new ID.
+- Episode allocation is stream-local and collision-free for records emitted after sampler startup.
+- Producer state for previous close and previous weights is cleared when the episode ends.
+- Studio normalizes the field to `episodeId` and validates explicit values strictly.
+- Live Training prefers an explicit ID when the latest selected-environment record has one.
+- Legacy records with no ID continue to use the existing terminal/rollback boundary.
+- Explicit and legacy records are never silently combined into one authoritative episode when the latest record is explicit.
+
+## Data contract
+
+`TrainingTelemetryRecord` gains:
+
+```text
+episode_id: int | None = None
+```
+
+JSON gains:
+
+```json
+{"episode_id": 12}
+```
+
+or, for legacy/unknown identity:
+
+```json
+{"episode_id": null}
+```
+
+The field does not alter sequence, stream generation, sparse-index, process-lock, cursor reset, or evidence-file identity contracts.
+
+## Producer allocation
+
+`TrainingTelemetrySampler` owns:
+
+- a mapping from `environment_id` to active `episode_id`;
+- a monotonically increasing next-ID counter initialized above the existing stream sequence.
+
+The sequence-derived start avoids reusing an ID after appending to a pre-existing stream without scanning all historical optional IDs. The ID is not claimed to be globally unique outside one telemetry stream.
+
+## Browser selection
+
+For one selected environment:
+
+1. Sort records by global telemetry sequence.
+2. Inspect the latest record.
+3. When its `episodeId` is non-null, return only records with that exact ID.
+4. When it is null, retain the current conservative terminal, environment-step rollback, and market-index rollback logic.
+
+This keeps legacy compatibility while ensuring explicit producer identity takes precedence.
+
+## Non-goals
+
+- No alternate Live Training page or selector design.
+- No rewrite of historical JSONL evidence.
+- No change to training, checkpoint selection, sealed evaluation, Serving, release, or execution.
+- No production-readiness claim.
+
+Production remains `NO-GO`.

--- a/docs/verification/2026-07-22-environment-runtime-decomposition.md
+++ b/docs/verification/2026-07-22-environment-runtime-decomposition.md
@@ -1,13 +1,12 @@
 # Environment Runtime Decomposition Verification
 
-Date: 2026-07-22
+Date: 2026-07-23
 
-Branch: `agent/decompose-environment-runtime-20260722`
+Merged pull request: #92
 
-Pull request: #80
+Merge commit: `6cf23b98698f5d53ec40629dd723efc4bd4cfbb6`
 
-Dependency base: PR #79 head
-`edaa6930ffb0b351ae5a8aa9afa6c80d47ca5e27`
+Verified implementation head: `86874d7122beef9247c67f89d41a3266a1164492`
 
 ## Scope
 
@@ -62,70 +61,95 @@ Service implementation verification:
 - workflow run: `29908220862`
 - job: `88884667478`
 - Ruff formatting: passed
-- Mypy across the repository: passed
+- repository-wide Mypy: passed
 - focused service tests: 18 passed
-- source and tests committed and pushed by the verified job
 
 Facade integration verification:
 
 - workflow run: `29909051489`, rerun attempt
 - job: `88887782701`
 - strict source transformation anchors: passed
-- Ruff/static integration: passed
+- Ruff and static integration: passed
 - Mypy: passed
-- environment, serving-parity, and stateful-replay regression tests: passed
-- integration commit and push: passed
+- environment, Serving-parity, and stateful-replay regression tests: passed
 
 The first integration attempt exposed a pre-existing nondeterministic Torch
 gradient comparison outside the modified environment code. The exact same job was
 rerun without code changes and passed. No production tolerance or test threshold
 was changed.
 
-## Exact-head full verification
+## Clean current-main reconstruction
 
-Code and coverage-ratchet head:
+The original PR #80 was stacked on the unsquashed PR #79 history. After PR #79 was
+squash-merged, the history could not be synchronized cleanly without repeating
+already-merged files.
 
-`549e5b9870931364caabb5d0ad00ffdfcd653c92`
+PR #92 therefore recreated the already-verified decomposition directly from
+current `main` at `464c14669bd2355b6922e6813870030bcf6cc745`.
 
-GitHub Actions CI run `29909971144`: success.
+The effective change contained exactly 14 files:
+
+- four new environment runtime service modules;
+- `ResidualMarketEnv` orchestration changes;
+- one architecture ownership contract;
+- four focused service test modules;
+- one measured branch-coverage group;
+- design, implementation-plan, and verification documentation.
+
+No PR #79 implementation file was repeated. No temporary transplant workflow,
+patch script, or generated file remained in the merged diff.
+
+## Exact-head verification
+
+GitHub Actions CI run `29955899116`: success.
 
 - exact-head checkout: passed
-- Studio tests, TypeScript checking, production build, and fixed-viewport layout:
+- Studio Vitest, TypeScript, production build, and fixed-viewport validation:
   passed
 - workflow-security validation: passed
-- Ruff and format check: passed
+- Ruff and format: passed
 - Mypy: passed
 - Import Linter architecture contracts: passed
 - dead-code report: passed
 - recovery and structured Serving smoke: passed
-- full Pytest: `1184 passed, 2 skipped, 11 warnings`
-- full-suite duration: 89.61 seconds
+- full Pytest: `1193 passed, 2 skipped, 11 warnings`
 - total coverage: `83.55%`
 - total branch coverage: `70.46%`
-- critical branch-coverage checker: passed
+- critical branch-coverage ratchets: passed
 - CLI smoke: passed
 - Ubuntu compatibility: passed
 - Windows compatibility: passed
 - complete training-image build and packaged non-root runtime probe: passed
 
-Pytest diagnostics artifact:
+Exact-head artifacts:
 
-- artifact: `8525525728`
-- digest:
-  `sha256:ecf7e7f8e362927aca7fd018602328c83865ff260fb6c65121643a7a227ef738`
+- Pytest diagnostics: `8544086297`, digest
+  `sha256:f44664ca5384e1d7335e5501b9d6aa84fb58397778d1dca1637f954dd8e1a0e9`
+- architecture diagnostics: `8544044684`, digest
+  `sha256:08af2ea2c1e9e3ba1d7ad77845ddff083d8e15191979126fe89f41e1886050b2`
+- static diagnostics: `8544044262`, digest
+  `sha256:fed4e3ed151393f7e2950916761bdbc9a03a37a966f290fbf9c08a2b274d6b91`
+- training-image evidence: `8544037302`, digest
+  `sha256:e4311e0ef41c348d88b764c40a205b2ee554c4cb3c66f0c6ddf4feeeaa42589c`
+- Studio layout diagnostics: `8544033273`, digest
+  `sha256:a6c369cd0ffd0617d1154cff2a92f7f23a4a18b8a1e47c3f6e9aae465f4c7cdf`
+- Windows compatibility: `8544028938`, digest
+  `sha256:9a68f30cc46cf0c84a3d37056c79a9ae43e0df8f5b1b22ee49f3c6160bc6185e`
+- Ubuntu compatibility: `8544024734`, digest
+  `sha256:6f87cfa29f825a4a6c13c626ae54e1f9dcd2d2b5bf42f44d41c248c97f9cbaa4`
 
-PostgreSQL Catalog run `29909971171`: success.
+PostgreSQL Catalog run `29955899222`: success.
 
 - exact-head checkout: passed
 - Compose validation: passed
 - PostgreSQL startup and readiness: passed
-- migration: passed
+- installation and migration: passed
 - unit and integration tests: passed
-- volume cleanup: passed
+- shutdown and cleanup: passed
 
 ## Coverage ratchet
 
-The new service group contains:
+The environment-step service group contains:
 
 - `trade_rl/rl/environment_decision.py`
 - `trade_rl/rl/environment_risk.py`
@@ -139,36 +163,28 @@ Observed aggregate branch coverage:
 - observed: `86.8421%`
 - configured minimum: `86.8%`
 
-The existing `environment_runtime` minimum remains `64.0%`; it was not reduced.
+The existing `environment_runtime` minimum remains unchanged at `64.0%`.
 
-## Compatibility review
+## Architecture review
 
-A commit comparison from PR #79 head to the ratchet head showed the P2-specific
-change is limited to the four service modules, `ResidualMarketEnv`, focused tests,
-coverage configuration, and design/plan documentation.
-
-Review conclusions:
-
-- books, order books, pending targets, indices, position age, previous action, and
-  diagnostics remain mutable only in `ResidualMarketEnv`;
-- services return new dataclass results or dictionaries and do not mutate facade
-  state;
+- books, order books, pending targets, indices, position ages, previous action,
+  and diagnostics remain mutable only in `ResidualMarketEnv`;
+- the extracted services consume explicit request dataclasses and return results
+  which the facade applies in the previous order;
 - legacy two-value residual action migration is preserved;
 - zero-delay and one-decision-delay target semantics are preserved;
 - emergency, pre-trade, and portfolio-risk reason ordering is preserved;
-- reward inputs remain numerically identical to the previous facade code;
+- reward inputs remain numerically equivalent to the previous facade mapping;
 - optional discarded-target and liquidation information conditions are
   preserved;
-- terminal performance metrics use the same return-series and evaluation
-  functions as before;
-- no temporary patch script or temporary verification workflow remains in the
-  pull-request diff.
-
-No critical or important review issue remained at this checkpoint.
+- terminal performance metrics retain the same return-series and evaluation
+  functions;
+- no unresolved critical or important review issue remained before merge.
 
 ## Safety boundary
 
 - production remains `NO-GO`;
 - direct exchange routing is not implemented;
 - no profitability or exchange-equivalent fill claim is introduced;
-- PR #80 remains Draft and is not merged.
+- this verification records an architecture and regression result, not production
+  authorization.

--- a/docs/verification/2026-07-22-environment-runtime-decomposition.md
+++ b/docs/verification/2026-07-22-environment-runtime-decomposition.md
@@ -1,0 +1,174 @@
+# Environment Runtime Decomposition Verification
+
+Date: 2026-07-22
+
+Branch: `agent/decompose-environment-runtime-20260722`
+
+Pull request: #80
+
+Dependency base: PR #79 head
+`edaa6930ffb0b351ae5a8aa9afa6c80d47ca5e27`
+
+## Scope
+
+This change extracts four responsibilities from `ResidualMarketEnv.step()` while
+keeping all Gymnasium mutable state in the facade:
+
+- `EnvironmentDecisionPlanner`: action parsing, residual/target composition,
+  signal-delay handling, and decision-bar planning;
+- `EnvironmentRiskProjector`: emergency, pre-trade, and portfolio-risk
+  projection;
+- `EnvironmentRewardCoordinator`: reward-transition input mapping;
+- `EnvironmentInfoBuilder`: stable step and terminal information construction.
+
+The constructor, public properties, schema versions, environment digest payload,
+target identity, execution order, signal-delay semantics, risk-reason order,
+reward order, terminal accounting, and existing information keys remain unchanged.
+
+## TDD RED evidence
+
+Architecture contracts were committed before production services existed.
+
+Initial architecture RED:
+
+- head: `dc49660eb386eabcd5762ec2317c503f48a56dfd`
+- workflow run: `29906923608`
+- result: failed as intended
+- artifact: `8524221206`
+- artifact digest:
+  `sha256:daa32bbb061a793879adf8a42cd52a8331f2b53e2738f77c6cf4f325abd92d1d`
+
+The failures required the four service modules, facade construction and
+delegation, removal of direct composition/reward/info ownership from `step()`,
+and terminal information delegation.
+
+Expanded service-contract RED:
+
+- head: `29f2e6468d8e7f53e5c89beb06af3576e32cb766`
+- workflow run: `29907379481`
+- result: failed as intended with `ModuleNotFoundError` for all four service
+  modules
+- artifact: `8524403476`
+- artifact digest:
+  `sha256:2008b8ac18aa45ee08e71e4fdb27bd9578882057a39c5c8d556e467f3fe2fe1e`
+
+The RED failures were caused by missing production modules rather than malformed
+test fixtures.
+
+## Focused GREEN evidence
+
+Service implementation verification:
+
+- workflow run: `29908220862`
+- job: `88884667478`
+- Ruff formatting: passed
+- Mypy across the repository: passed
+- focused service tests: 18 passed
+- source and tests committed and pushed by the verified job
+
+Facade integration verification:
+
+- workflow run: `29909051489`, rerun attempt
+- job: `88887782701`
+- strict source transformation anchors: passed
+- Ruff/static integration: passed
+- Mypy: passed
+- environment, serving-parity, and stateful-replay regression tests: passed
+- integration commit and push: passed
+
+The first integration attempt exposed a pre-existing nondeterministic Torch
+gradient comparison outside the modified environment code. The exact same job was
+rerun without code changes and passed. No production tolerance or test threshold
+was changed.
+
+## Exact-head full verification
+
+Code and coverage-ratchet head:
+
+`549e5b9870931364caabb5d0ad00ffdfcd653c92`
+
+GitHub Actions CI run `29909971144`: success.
+
+- exact-head checkout: passed
+- Studio tests, TypeScript checking, production build, and fixed-viewport layout:
+  passed
+- workflow-security validation: passed
+- Ruff and format check: passed
+- Mypy: passed
+- Import Linter architecture contracts: passed
+- dead-code report: passed
+- recovery and structured Serving smoke: passed
+- full Pytest: `1184 passed, 2 skipped, 11 warnings`
+- full-suite duration: 89.61 seconds
+- total coverage: `83.55%`
+- total branch coverage: `70.46%`
+- critical branch-coverage checker: passed
+- CLI smoke: passed
+- Ubuntu compatibility: passed
+- Windows compatibility: passed
+- complete training-image build and packaged non-root runtime probe: passed
+
+Pytest diagnostics artifact:
+
+- artifact: `8525525728`
+- digest:
+  `sha256:ecf7e7f8e362927aca7fd018602328c83865ff260fb6c65121643a7a227ef738`
+
+PostgreSQL Catalog run `29909971171`: success.
+
+- exact-head checkout: passed
+- Compose validation: passed
+- PostgreSQL startup and readiness: passed
+- migration: passed
+- unit and integration tests: passed
+- volume cleanup: passed
+
+## Coverage ratchet
+
+The new service group contains:
+
+- `trade_rl/rl/environment_decision.py`
+- `trade_rl/rl/environment_risk.py`
+- `trade_rl/rl/environment_reward.py`
+- `trade_rl/rl/environment_info.py`
+
+Observed aggregate branch coverage:
+
+- covered branches: 33
+- total branches: 38
+- observed: `86.8421%`
+- configured minimum: `86.8%`
+
+The existing `environment_runtime` minimum remains `64.0%`; it was not reduced.
+
+## Compatibility review
+
+A commit comparison from PR #79 head to the ratchet head showed the P2-specific
+change is limited to the four service modules, `ResidualMarketEnv`, focused tests,
+coverage configuration, and design/plan documentation.
+
+Review conclusions:
+
+- books, order books, pending targets, indices, position age, previous action, and
+  diagnostics remain mutable only in `ResidualMarketEnv`;
+- services return new dataclass results or dictionaries and do not mutate facade
+  state;
+- legacy two-value residual action migration is preserved;
+- zero-delay and one-decision-delay target semantics are preserved;
+- emergency, pre-trade, and portfolio-risk reason ordering is preserved;
+- reward inputs remain numerically identical to the previous facade code;
+- optional discarded-target and liquidation information conditions are
+  preserved;
+- terminal performance metrics use the same return-series and evaluation
+  functions as before;
+- no temporary patch script or temporary verification workflow remains in the
+  pull-request diff.
+
+No critical or important review issue remained at this checkpoint.
+
+## Safety boundary
+
+- production remains `NO-GO`;
+- direct exchange routing is not implemented;
+- no profitability or exchange-equivalent fill claim is introduced;
+- PR #80 remains Draft and is not merged.

--- a/docs/verification/2026-07-22-telemetry-cursor-generation.md
+++ b/docs/verification/2026-07-22-telemetry-cursor-generation.md
@@ -1,273 +1,176 @@
 # Generation-Bound Telemetry Polling Verification
 
-Date: 2026-07-22
+Date: 2026-07-23
+
+Merged pull request: #99
+
+Merge commit: `7bf93eaa7775903fa9d08b65dd3b77c052313404`
+
+Verified implementation head: `1c96d0c4e85f7bc84027e586db2bbae8bbff2849`
+
+Replacement for stacked Draft PR #83, rebuilt directly on current `main` after the architecture, environment-runtime, Live Training, and process-concurrency remediations were merged independently.
 
 ## Scope
 
-This verification covers the generation-bound telemetry polling change implemented in Draft PR #83.
+This change binds telemetry sequence cursors to an opaque stream generation so Studio cannot silently reuse an old cursor after the JSONL path is replaced, truncated, or re-indexed.
 
-Design:
+Implemented contracts:
 
-- `docs/superpowers/specs/2026-07-22-telemetry-cursor-generation-design.md`
+- the rebuildable sidecar index schema is `training_telemetry_index_v2`;
+- primary telemetry JSONL evidence remains `training_telemetry_v1`;
+- every valid sidecar index contains a canonical lower-case UUID generation;
+- normal append and no-growth polling preserve the generation;
+- path replacement, truncation, invalid index state, or index loss creates a new generation;
+- a stale expected generation returns no records, `next_sequence=0`, and `reset_required=true`;
+- unchanged status and event polls do not rewrite or `fsync` the sidecar index;
+- the reader captures an identity-verified, size-bounded file snapshot under the per-stream process lock;
+- page-body parsing occurs after the append serialization lock is released;
+- Studio API responses expose `streamGeneration` and `resetRequired`;
+- the endpoint accepts only canonical lower-case UUID generation queries;
+- the frontend clears its buffer and sequence cursor before replaying a replacement generation;
+- Status and Events responses from different generations are discarded and retried once before records are published;
+- the existing connection-state contract, 2,048-record cap, stale-request cancellation, OS file locking, append-only evidence, and fail-closed corruption behavior remain intact.
 
-Implementation plan:
+## Architecture boundary
 
-- `docs/superpowers/plans/2026-07-22-telemetry-cursor-generation.md`
+The generation is cursor/cache identity, not business or evidentiary identity.
 
-The branch starts from PR #81 exact head:
+- JSONL remains the primary append-only telemetry evidence.
+- The sidecar index may be rebuilt and may rotate generation without rewriting JSONL.
+- An open snapshot may finish reading its bounded old-generation inode after replacement; the next Status/Events comparison detects the new generation before mixed records are published.
+- No generation field is used by training, checkpoint selection, sealed evaluation, promotion, release, Serving, or execution.
 
-- `2e56fd7b42f2677dc0440ff9ec3cc03a55e5c786`
+## TDD RED evidence
 
-## Implemented contract
+### Python telemetry
 
-- The internal sidecar index schema is `training_telemetry_index_v2`.
-- The telemetry JSONL record schema remains `training_telemetry_v1`.
-- Every valid index has a canonical lower-case UUID stream generation.
-- A normal append preserves the generation.
-- Stream replacement, truncation, invalid index state, or index loss creates a new generation.
-- A request with a stale expected generation receives no records, `next_sequence=0`, and `reset_required=True`.
-- No-growth status and event polls do not rewrite or `fsync` the sidecar index.
-- The process lock is released after an identity-verified bounded snapshot is captured; page-body parsing occurs outside the append serialization lock.
-- Studio API responses expose `streamGeneration` and `resetRequired`.
-- The frontend clears its in-memory buffer and sequence cursor before replaying a replacement generation.
-- Status and Events responses from different generations are discarded and retried once rather than published as a mixed snapshot.
-- The existing frontend `connection` contract, 2,048-record buffer cap, and stale-request cancellation behavior remain intact.
+RED head: `6407c5496e402dce36c71375a7f64de05e379771`
 
-## TDD evidence
+Workflow run `29915043603`: expected failure.
 
-### Python telemetry RED
+- artifact: `8527504146`
+- digest: `sha256:c6c97b601316a984bfad1092a0f2f2a38a2628e550515d8622ecd60c35871dc6`
 
-Exact head:
+The run reproduced missing generation/reset contracts, unchanged-poll index rewrites, and page parsing that held the append process lock. The near-tail bounded-parse contract already passed and was retained.
 
-- `6407c5496e402dce36c71375a7f64de05e379771`
+### Studio backend
 
-Workflow:
+Workflow run `29915513524`: expected failure.
 
-- Run `29915043603`
-- Conclusion: expected failure
+- artifact: `8527690750`
+- digest: `sha256:1e08ab17ac5482b763f1dc24777d20058f7a5c9c9f5a2670e13b7cc1a8372896`
 
-Artifact:
+The endpoint did not expose generation/reset fields, ignored stale generation queries, and did not reject invalid generation syntax.
 
-- ID `8527504146`
-- Digest `sha256:c6c97b601316a984bfad1092a0f2f2a38a2628e550515d8622ecd60c35871dc6`
+### Frontend
 
-Observed failures before implementation:
+Workflow run `29916129060`: expected failure.
 
-- telemetry status and pages had no generation fields;
-- the reader accepted no expected-generation cursor;
-- stream replacement and index loss could not request an explicit reset;
-- unchanged polls rewrote the index;
-- page parsing held the process lock and blocked an append.
+- artifact: `8527945463`
+- digest: `sha256:78b78936309483c08bea9bc37c6b48210860f5456d83a1dd6085495072dd6987`
 
-The deterministic near-tail bounded-parse test already passed and was retained as a regression contract.
+The hook did not reset and replay a replacement generation, could publish mixed Status/Events generations, and accepted malformed generation/reset values.
 
-### Python telemetry GREEN
+## Focused GREEN evidence
 
-Implementation head:
+Python implementation head `c04f4084375e6e56b91ffe415ed69026fa4d6389` passed workflow run `29915319097`, including Ruff, format, repository-wide Mypy, telemetry tests, spawn process-concurrency tests, and training integration tests.
 
-- `c04f4084375e6e56b91ffe415ed69026fa4d6389`
+Studio backend implementation head `ec6f7cdc76bdb355dadcaf6d717ab7d113887ce7` passed workflow run `29915833168`.
 
-Workflow:
+Frontend implementation head `69ff12afa4672b810bc4a74b775b49596e753967` passed workflow run `29917535977`, including focused hook tests, complete Vitest, TypeScript, and production build.
 
-- Run `29915319097`
-- Conclusion: success
+Cross-platform workflow run `29917703239` passed on Linux and Windows:
 
-Verification included:
+- Linux artifact `8528622708`, digest `sha256:95065be9c178d7942bff925ea464033e33e645729f21505f1fdbad727b695575`;
+- Windows artifact `8528621179`, digest `sha256:9d36bfb92bc44ae85a20bedc164450e266566702a9d20375af05ce1dbca844bc`.
 
-- Ruff formatting and linting;
-- Mypy across the Python project;
-- telemetry unit tests;
-- spawn-based process-concurrency tests;
-- training telemetry integration tests.
+Windows exercised native `msvcrt.locking`.
 
-### Studio backend RED
+## Original stacked-head verification
 
-Workflow:
+Original PR #83 final head: `b2ac0df43c2b254653bdcd8089d23f37a28c70d9`.
 
-- Run `29915513524`
-- Conclusion: expected failure
+- CI run `29918835669`: success;
+- PostgreSQL Catalog run `29918835603`: success;
+- final Pytest artifact `8529103393`;
+- digest `sha256:219adb2987dcd4a6b4caf310113099269bd2c14953a2584e4565311e1cae9873`.
 
-Artifact:
+The original branch was not merged because it contained the full unsquashed histories of its dependency PRs.
 
-- ID `8527690750`
-- Digest `sha256:1e08ab17ac5482b763f1dc24777d20058f7a5c9c9f5a2670e13b7cc1a8372896`
+## Clean current-main reconstruction
 
-Observed failures before implementation:
+PR #99 was created directly from current `main` at `c449f424d556bf7e7d4fe1f43625c786c0243dc0`. During verification, main advanced by documentation-only PR #98 at `b51cd9e840da28d987c1056bbe2f7d7532ca932a`; that change did not overlap the 16-file implementation scope.
 
-- status and event responses did not expose a stream generation;
-- stale generation queries were ignored;
-- invalid generation queries were not rejected by the endpoint contract.
+The effective pull-request scope contained exactly:
 
-### Studio backend GREEN
+- three design/plan/verification documents;
+- one measured coverage-ratchet change;
+- five Studio frontend API/type/guard/hook/test changes;
+- two Studio backend API/reader changes;
+- two Python telemetry record/index changes;
+- two Python regression suites;
+- one existing Live Training test fixture update.
 
-Implementation head:
+No temporary workflow or patch file remained. No PR #79, #92, #95, or #98 implementation was repeated.
 
-- `ec6f7cdc76bdb355dadcaf6d717ab7d113887ce7`
-
-Workflow:
-
-- Run `29915833168`
-- Conclusion: success
-
-Verification included Studio API tests, telemetry tests, process tests, integration tests, Ruff, formatting, and Mypy.
-
-### Frontend RED
-
-Workflow:
-
-- Run `29916129060`
-- Conclusion: expected failure
-
-Artifact:
-
-- ID `8527945463`
-- Digest `sha256:78b78936309483c08bea9bc37c6b48210860f5456d83a1dd6085495072dd6987`
-
-Observed failures before implementation:
-
-- stale generation responses did not trigger a replay from sequence zero;
-- mixed Status and Events generations were published instead of retried;
-- malformed generation values were accepted by guards;
-- non-boolean reset flags were accepted by guards.
-
-### Frontend GREEN
-
-Implementation head:
-
-- `69ff12afa4672b810bc4a74b775b49596e753967`
-
-Workflow:
-
-- Run `29917535977`
-- Conclusion: success
-
-Verification included:
-
-- focused generation-reset hook tests;
-- the complete Vitest suite;
-- TypeScript type checking;
-- production frontend build.
-
-## Cross-platform verification
-
-Focused cross-platform workflow:
-
-- Run `29917703239`
-- Conclusion: success
-
-Linux artifact:
-
-- ID `8528622708`
-- Digest `sha256:95065be9c178d7942bff925ea464033e33e645729f21505f1fdbad727b695575`
-
-Windows artifact:
-
-- ID `8528621179`
-- Digest `sha256:9d36bfb92bc44ae85a20bedc164450e266566702a9d20375af05ce1dbca844bc`
-
-Both platforms passed the telemetry generation, process-concurrency, integration, and Studio API focused suites. Linux additionally passed Ruff, format checking, and Mypy. The Windows run exercised the native `msvcrt.locking` path.
-
-## Full-suite verification and flaky-test disposition
-
-Cleanup head:
-
-- `dc66ac1558a4b317ef3f02b26d7fbc352966ec3b`
-
-The first Core attempt reached the full test suite and produced:
-
-- `1196 passed, 1 failed, 2 skipped, 11 warnings`;
-- total coverage `83.45%`.
-
-The single failure was the existing Torch gradient comparison:
-
-- `tests/rl/test_sequence_policy_core.py::test_projection_after_selection_matches_legacy_outputs_and_gradients`
-- observed maximum absolute difference `4.112720489501953e-06` against tolerance `1e-06`.
-
-That same test had previously shown the same non-deterministic behavior outside this telemetry change. The failed Core job was rerun without changing source or tests.
-
-Same-head rerun:
-
-- CI run `29917834673`
-- Rerun Core job `88916816325`
-- Conclusion: success
-
-The rerun produced:
-
-- `1197 passed, 2 skipped, 11 warnings`;
-- total coverage `83.45%`;
-- total branch coverage `70.35%`;
-- `trade_rl/telemetry/indexed_training.py`: `76/110 = 69.09%` branch coverage.
-
-Successful rerun artifact:
-
-- ID `8528843820`
-- Digest `sha256:270768dc6ea6e5f4a0d609d34af38d3b56fe9ca2088f187d21c9e31ce95e0496`
-
-Because the failure did not reproduce on the identical head and the telemetry-focused Linux/Windows suites were already green, no unrelated Torch test tolerance change was included in this PR.
-
-## Coverage ratchet verification
-
-Ratchet head:
-
-- `664e8cd956a3d9ef62139a46cbdc5f62376807ec`
-
-The per-file critical branch threshold for `trade_rl/telemetry/indexed_training.py` was raised from `68.0%` to `69.0%`. No existing threshold was reduced.
-
-GitHub Actions:
-
-- CI run `29918540093`: success
-- PostgreSQL Catalog run `29918540139`: success
-
-Core checks:
-
-- Studio frontend tests: success
-- fixed viewport verification: success
-- workflow security: success
-- Ruff: success
-- Ruff format check: success
-- Mypy: success
-- import architecture: success
-- dead-code report: success
-- recovery and structured serving smoke: success
-- full tests and coverage: success
-- critical branch coverage: success
-- CLI smoke: success
-- Ubuntu compatibility: success
-- Windows compatibility: success
-- training image build and non-root packaged runtime probe: success
-
-Full-suite result:
-
-- `1197 passed, 2 skipped, 11 warnings`
-- total coverage `83.45%`
-- total branch coverage `70.35%`
-- indexed telemetry branch coverage `69.09%`
-- critical telemetry threshold `69.09% >= 69.0%`
-
-Pytest artifact:
-
-- ID `8528980253`
-- Digest `sha256:48d40000ee917171166d47297567af2ded2db20cddc49ba831403b1f2f26949c`
-
-PostgreSQL steps passed:
-
-- Compose validation;
-- PostgreSQL startup and readiness;
-- dependency installation;
-- migrations;
-- unit and integration tests;
-- clean shutdown.
+## Clean exact-head verification
+
+GitHub Actions CI run `29957142356`: success.
+
+- exact-head checkout: passed;
+- Studio Vitest, TypeScript, production build, and fixed viewport: passed;
+- workflow security: passed;
+- Ruff and format: passed;
+- Mypy: passed;
+- Import Linter architecture contracts: passed;
+- dead-code report: passed;
+- recovery and structured Serving smoke: passed;
+- full Pytest: `1206 passed, 2 skipped, 11 warnings`;
+- total coverage: `83.45%`;
+- total branch coverage: `70.35%`;
+- indexed telemetry branch coverage: `76 / 110 = 69.09%`;
+- critical threshold: `69.09% >= 69.0%`;
+- CLI smoke: passed;
+- Ubuntu compatibility and generation/process-concurrency regressions: passed;
+- Windows compatibility, native locking, and generation regressions: passed;
+- complete training-image build and packaged non-root runtime probe: passed.
+
+Exact-head artifacts:
+
+- Pytest diagnostics `8544561261`, digest `sha256:85df4d375e4c409e709df914e497385c14ffd9428ea20d2d63b8a3be8971fe83`;
+- architecture diagnostics `8544516089`, digest `sha256:fa87b745a44a7615edca253764b3054b017650127cf444c5e05dfb23d2b6d975`;
+- static diagnostics `8544515628`, digest `sha256:a98315d2d8c74b6c3c3180e59b3a7d40df4e97f2e42c6bb04015b4a56f344d1e`;
+- training-image evidence `8544510019`, digest `sha256:62cefb4020eecad1b2d1311dc24c34f4486eb124828696a077c3cc3ddc016596`;
+- Studio layout diagnostics `8544504573`, digest `sha256:dcbfc3f54835bb4ea98124a5022f9815589d1007b9d138cc6131edd7e5e6826d`;
+- Windows compatibility `8544500680`, digest `sha256:a05554f464e201a4ae35a3e6706b09ff49ec005da86b5307f847d4f580a94b9d`;
+- Ubuntu compatibility `8544494654`, digest `sha256:839bec87feacf897364d63f7b69257ec456a5fa7ec2256a431f7aa111374ccc8`.
+
+PostgreSQL Catalog run `29957142448`: success.
+
+- exact-head checkout: passed;
+- Compose validation: passed;
+- PostgreSQL startup/readiness: passed;
+- installation and migration: passed;
+- unit and integration tests: passed;
+- shutdown and cleanup: passed.
+
+## Review result
+
+- the sidecar generation is validated canonically in Python and at the HTTP boundary;
+- replacement, truncation, invalid/lost index, stale cursor, and mixed-generation response paths are covered;
+- no-growth polling avoids unnecessary durable index writes;
+- page parsing no longer serializes append work after a bounded snapshot is captured;
+- PR #95 process locking and obsolete-inode safeguards remain present;
+- PR #85 Live Training environment/episode isolation tests remain present;
+- public telemetry record schema identifier remains v1;
+- no unresolved critical or important review issue remained before merge.
 
 ## Safety boundary
 
-- Production remains `NO-GO`.
-- Direct exchange routing is not implemented.
-- The telemetry JSONL evidence schema remains v1.
-- The index is still a rebuildable cache and is not treated as primary evidence.
-- No malformed or truncated telemetry evidence is automatically repaired.
-- No record from a replacement generation is returned against an old generation cursor.
-- PR #83 remains Draft and is not merged.
-
-## Final-head requirement
-
-This document commit creates a new exact head. Normal CI and PostgreSQL Catalog must both report `completed/success` for that documentation head before the PR is described as fully verified.
+- production remains `NO-GO`;
+- direct exchange routing is not implemented;
+- no profitability or exchange-equivalent fill claim is introduced;
+- malformed or truncated telemetry evidence is not automatically repaired;
+- no replacement-generation record is returned against an old-generation cursor;
+- the index remains rebuildable cache state rather than primary evidence;
+- this documentation-only head must pass normal CI before merge.

--- a/docs/verification/2026-07-22-telemetry-cursor-generation.md
+++ b/docs/verification/2026-07-22-telemetry-cursor-generation.md
@@ -1,0 +1,273 @@
+# Generation-Bound Telemetry Polling Verification
+
+Date: 2026-07-22
+
+## Scope
+
+This verification covers the generation-bound telemetry polling change implemented in Draft PR #83.
+
+Design:
+
+- `docs/superpowers/specs/2026-07-22-telemetry-cursor-generation-design.md`
+
+Implementation plan:
+
+- `docs/superpowers/plans/2026-07-22-telemetry-cursor-generation.md`
+
+The branch starts from PR #81 exact head:
+
+- `2e56fd7b42f2677dc0440ff9ec3cc03a55e5c786`
+
+## Implemented contract
+
+- The internal sidecar index schema is `training_telemetry_index_v2`.
+- The telemetry JSONL record schema remains `training_telemetry_v1`.
+- Every valid index has a canonical lower-case UUID stream generation.
+- A normal append preserves the generation.
+- Stream replacement, truncation, invalid index state, or index loss creates a new generation.
+- A request with a stale expected generation receives no records, `next_sequence=0`, and `reset_required=True`.
+- No-growth status and event polls do not rewrite or `fsync` the sidecar index.
+- The process lock is released after an identity-verified bounded snapshot is captured; page-body parsing occurs outside the append serialization lock.
+- Studio API responses expose `streamGeneration` and `resetRequired`.
+- The frontend clears its in-memory buffer and sequence cursor before replaying a replacement generation.
+- Status and Events responses from different generations are discarded and retried once rather than published as a mixed snapshot.
+- The existing frontend `connection` contract, 2,048-record buffer cap, and stale-request cancellation behavior remain intact.
+
+## TDD evidence
+
+### Python telemetry RED
+
+Exact head:
+
+- `6407c5496e402dce36c71375a7f64de05e379771`
+
+Workflow:
+
+- Run `29915043603`
+- Conclusion: expected failure
+
+Artifact:
+
+- ID `8527504146`
+- Digest `sha256:c6c97b601316a984bfad1092a0f2f2a38a2628e550515d8622ecd60c35871dc6`
+
+Observed failures before implementation:
+
+- telemetry status and pages had no generation fields;
+- the reader accepted no expected-generation cursor;
+- stream replacement and index loss could not request an explicit reset;
+- unchanged polls rewrote the index;
+- page parsing held the process lock and blocked an append.
+
+The deterministic near-tail bounded-parse test already passed and was retained as a regression contract.
+
+### Python telemetry GREEN
+
+Implementation head:
+
+- `c04f4084375e6e56b91ffe415ed69026fa4d6389`
+
+Workflow:
+
+- Run `29915319097`
+- Conclusion: success
+
+Verification included:
+
+- Ruff formatting and linting;
+- Mypy across the Python project;
+- telemetry unit tests;
+- spawn-based process-concurrency tests;
+- training telemetry integration tests.
+
+### Studio backend RED
+
+Workflow:
+
+- Run `29915513524`
+- Conclusion: expected failure
+
+Artifact:
+
+- ID `8527690750`
+- Digest `sha256:1e08ab17ac5482b763f1dc24777d20058f7a5c9c9f5a2670e13b7cc1a8372896`
+
+Observed failures before implementation:
+
+- status and event responses did not expose a stream generation;
+- stale generation queries were ignored;
+- invalid generation queries were not rejected by the endpoint contract.
+
+### Studio backend GREEN
+
+Implementation head:
+
+- `ec6f7cdc76bdb355dadcaf6d717ab7d113887ce7`
+
+Workflow:
+
+- Run `29915833168`
+- Conclusion: success
+
+Verification included Studio API tests, telemetry tests, process tests, integration tests, Ruff, formatting, and Mypy.
+
+### Frontend RED
+
+Workflow:
+
+- Run `29916129060`
+- Conclusion: expected failure
+
+Artifact:
+
+- ID `8527945463`
+- Digest `sha256:78b78936309483c08bea9bc37c6b48210860f5456d83a1dd6085495072dd6987`
+
+Observed failures before implementation:
+
+- stale generation responses did not trigger a replay from sequence zero;
+- mixed Status and Events generations were published instead of retried;
+- malformed generation values were accepted by guards;
+- non-boolean reset flags were accepted by guards.
+
+### Frontend GREEN
+
+Implementation head:
+
+- `69ff12afa4672b810bc4a74b775b49596e753967`
+
+Workflow:
+
+- Run `29917535977`
+- Conclusion: success
+
+Verification included:
+
+- focused generation-reset hook tests;
+- the complete Vitest suite;
+- TypeScript type checking;
+- production frontend build.
+
+## Cross-platform verification
+
+Focused cross-platform workflow:
+
+- Run `29917703239`
+- Conclusion: success
+
+Linux artifact:
+
+- ID `8528622708`
+- Digest `sha256:95065be9c178d7942bff925ea464033e33e645729f21505f1fdbad727b695575`
+
+Windows artifact:
+
+- ID `8528621179`
+- Digest `sha256:9d36bfb92bc44ae85a20bedc164450e266566702a9d20375af05ce1dbca844bc`
+
+Both platforms passed the telemetry generation, process-concurrency, integration, and Studio API focused suites. Linux additionally passed Ruff, format checking, and Mypy. The Windows run exercised the native `msvcrt.locking` path.
+
+## Full-suite verification and flaky-test disposition
+
+Cleanup head:
+
+- `dc66ac1558a4b317ef3f02b26d7fbc352966ec3b`
+
+The first Core attempt reached the full test suite and produced:
+
+- `1196 passed, 1 failed, 2 skipped, 11 warnings`;
+- total coverage `83.45%`.
+
+The single failure was the existing Torch gradient comparison:
+
+- `tests/rl/test_sequence_policy_core.py::test_projection_after_selection_matches_legacy_outputs_and_gradients`
+- observed maximum absolute difference `4.112720489501953e-06` against tolerance `1e-06`.
+
+That same test had previously shown the same non-deterministic behavior outside this telemetry change. The failed Core job was rerun without changing source or tests.
+
+Same-head rerun:
+
+- CI run `29917834673`
+- Rerun Core job `88916816325`
+- Conclusion: success
+
+The rerun produced:
+
+- `1197 passed, 2 skipped, 11 warnings`;
+- total coverage `83.45%`;
+- total branch coverage `70.35%`;
+- `trade_rl/telemetry/indexed_training.py`: `76/110 = 69.09%` branch coverage.
+
+Successful rerun artifact:
+
+- ID `8528843820`
+- Digest `sha256:270768dc6ea6e5f4a0d609d34af38d3b56fe9ca2088f187d21c9e31ce95e0496`
+
+Because the failure did not reproduce on the identical head and the telemetry-focused Linux/Windows suites were already green, no unrelated Torch test tolerance change was included in this PR.
+
+## Coverage ratchet verification
+
+Ratchet head:
+
+- `664e8cd956a3d9ef62139a46cbdc5f62376807ec`
+
+The per-file critical branch threshold for `trade_rl/telemetry/indexed_training.py` was raised from `68.0%` to `69.0%`. No existing threshold was reduced.
+
+GitHub Actions:
+
+- CI run `29918540093`: success
+- PostgreSQL Catalog run `29918540139`: success
+
+Core checks:
+
+- Studio frontend tests: success
+- fixed viewport verification: success
+- workflow security: success
+- Ruff: success
+- Ruff format check: success
+- Mypy: success
+- import architecture: success
+- dead-code report: success
+- recovery and structured serving smoke: success
+- full tests and coverage: success
+- critical branch coverage: success
+- CLI smoke: success
+- Ubuntu compatibility: success
+- Windows compatibility: success
+- training image build and non-root packaged runtime probe: success
+
+Full-suite result:
+
+- `1197 passed, 2 skipped, 11 warnings`
+- total coverage `83.45%`
+- total branch coverage `70.35%`
+- indexed telemetry branch coverage `69.09%`
+- critical telemetry threshold `69.09% >= 69.0%`
+
+Pytest artifact:
+
+- ID `8528980253`
+- Digest `sha256:48d40000ee917171166d47297567af2ded2db20cddc49ba831403b1f2f26949c`
+
+PostgreSQL steps passed:
+
+- Compose validation;
+- PostgreSQL startup and readiness;
+- dependency installation;
+- migrations;
+- unit and integration tests;
+- clean shutdown.
+
+## Safety boundary
+
+- Production remains `NO-GO`.
+- Direct exchange routing is not implemented.
+- The telemetry JSONL evidence schema remains v1.
+- The index is still a rebuildable cache and is not treated as primary evidence.
+- No malformed or truncated telemetry evidence is automatically repaired.
+- No record from a replacement generation is returned against an old generation cursor.
+- PR #83 remains Draft and is not merged.
+
+## Final-head requirement
+
+This document commit creates a new exact head. Normal CI and PostgreSQL Catalog must both report `completed/success` for that documentation head before the PR is described as fully verified.

--- a/docs/verification/2026-07-22-telemetry-process-concurrency.md
+++ b/docs/verification/2026-07-22-telemetry-process-concurrency.md
@@ -1,0 +1,222 @@
+# Telemetry Process Concurrency Verification
+
+Date: 2026-07-22
+
+Branch: `agent/harden-telemetry-process-concurrency-20260722`
+
+Pull request: #81
+
+Dependency base: PR #80 exact head
+`88f7e486b6db56fdc16ab89db5a77ef599c8f48f`
+
+## Scope
+
+This change hardens indexed training telemetry for cooperating Linux and Windows
+processes while preserving the JSONL schema, index schema, public writer API,
+indexed page/status contracts, and Studio telemetry endpoints.
+
+Implemented boundaries:
+
+- per-stream sidecar OS lock using `fcntl.flock` on POSIX and `msvcrt.locking`
+  on Windows;
+- one append or one read/index snapshot per lock acquisition rather than a
+  writer-lifetime lock;
+- process-visible sequence validation before every append;
+- append-only binary writes with a partial-write loop;
+- fail-closed rejection of incomplete trailing records;
+- fail-closed rejection when an open writer descriptor no longer identifies the
+  current telemetry path;
+- process-unique index temporary files, file `fsync`, atomic replacement, and
+  best-effort parent-directory synchronization;
+- indexed reads bounded by the refreshed `indexed_size` snapshot;
+- explicit `flush()` and `close()` durability with configurable append cadence.
+
+No evidence repair, truncation, database migration, direct exchange routing, or
+production-readiness change is included.
+
+## TDD RED evidence
+
+### Process sequence, tail, and index races
+
+RED head:
+
+`d74e639f9d0835b3a35fe00a912b725d095e73ee`
+
+Workflow run `29911288413` failed as intended on both Linux and Windows.
+
+Linux artifact:
+
+- artifact: `8525980884`
+- digest:
+  `sha256:054442d9b61ba1edb8a16b4872df696dc5951a1f6096ffc8eb53141e0e22e3f8`
+
+Windows artifact:
+
+- artifact: `8525984305`
+- digest:
+  `sha256:79f115ef017487868897507f32fdbc452626475ffe4689b431f9af0834e0ceae`
+
+The valid RED run demonstrated:
+
+1. two already-open processes both accepted sequence `1`;
+2. the writer appended after incomplete trailing JSON bytes instead of failing
+   closed;
+3. concurrent readers raced on the shared fixed `.tmp` index path, producing
+   file-not-found/replacement failures.
+
+The earlier readiness-queue test-fixture defect was corrected before this RED run;
+these failures were produced by the existing production implementation.
+
+### Open-writer stream identity drift
+
+RED head:
+
+`b63f4615075f469780e556d79ab29f6da13dafbe`
+
+Workflow run `29912033107` failed as intended because a writer whose path was
+atomically replaced continued writing to its old inode and did not raise.
+
+- artifact: `8526267296`
+- digest:
+  `sha256:63741401c5a48721f424165dd2d6d537fb9bff4d1e30ada8459881c7405effa8`
+
+The production fix compares `fstat(writer_fd)` with `stat(telemetry_path)` while
+holding the process lock and raises `RuntimeError` when the identities differ.
+
+## Focused GREEN evidence
+
+### Cross-platform process locking
+
+Workflow run `29911808844` passed on Linux and Windows.
+
+Linux artifact:
+
+- artifact: `8526200257`
+- digest:
+  `sha256:fb9c56d0e53d239dd97dbfb00f1c550642e38bfab0f775db691f0cf0b30de7e5`
+
+Windows artifact:
+
+- artifact: `8526200535`
+- digest:
+  `sha256:928b57b58e889641cee7b6c6df1658eb8b0d95caff43b91357d9a73c346f71c6`
+
+The run verified Ruff, formatting, repository-wide Mypy on Linux, native
+`msvcrt` locking on Windows, spawn-based duplicate-writer races, incomplete-tail
+rejection, concurrent page/status reads, existing telemetry contracts, training
+integration, and Studio telemetry API tests.
+
+### Stream identity fix
+
+Workflow run `29912184255`, job `88897470828`, passed source transformation,
+Ruff/format, repository-wide Mypy, process-concurrency tests, existing telemetry
+contracts, training integration, Studio API tests, commit, and push.
+
+No test tolerance or schema version was changed.
+
+## Cleanup-head full verification
+
+Cleanup head:
+
+`b203f0816b45aa26c7940961bbf929fb9c0b424c`
+
+GitHub Actions CI run `29912311501`: success.
+
+- exact-head checkout: passed;
+- Studio tests, TypeScript check, production build, and fixed viewport: passed;
+- workflow-security validation: passed;
+- Ruff and format: passed;
+- Mypy: passed;
+- Import Linter: passed;
+- dead-code report: passed;
+- recovery and structured Serving smoke: passed;
+- full Pytest: `1188 passed, 2 skipped, 11 warnings`;
+- total coverage: `83.43%`;
+- total branch coverage: `70.34%`;
+- critical branch coverage: passed;
+- CLI smoke: passed;
+- Ubuntu and Windows compatibility: passed;
+- complete training-image build and packaged non-root runtime probe: passed.
+
+Pytest diagnostics:
+
+- artifact: `8526483274`
+- digest:
+  `sha256:22463e164a4499afa62a9a39ffd18660b93d46c68b4d63be26d5a48fd720ef4f`
+
+PostgreSQL Catalog run `29912311550`: success.
+
+## Coverage ratchet
+
+Measured `trade_rl/telemetry/indexed_training.py` branch coverage:
+
+- covered branches: 64;
+- total branches: 94;
+- observed: `68.0851%`;
+- configured minimum: `68.0%`.
+
+No existing critical-coverage threshold was reduced.
+
+Ratchet head:
+
+`7ff3e98511a9a3438277bee442587f6f55f89a6f`
+
+GitHub Actions CI run `29912659864`: success.
+
+- full Pytest: `1188 passed, 2 skipped, 11 warnings`;
+- total coverage: `83.43%`;
+- total branch coverage: `70.34%`;
+- indexed telemetry branch ratchet: `68.09% >= 68.0%`;
+- all static, architecture, serving, CLI, compatibility, and training-image jobs:
+  passed.
+
+Ratchet-head Pytest diagnostics:
+
+- artifact: `8526594309`
+- digest:
+  `sha256:3450bc292a9da0a55b71168b6290a24bc574cfe92f86a672279825ea8cf0c19f`
+
+PostgreSQL Catalog run `29912659868`: success.
+
+- exact-head checkout: passed;
+- Compose validation: passed;
+- PostgreSQL startup and readiness: passed;
+- migration: passed;
+- unit and integration tests: passed;
+- cleanup: passed.
+
+## Compatibility and review
+
+Comparison from PR #80 exact head to the cleanup head was limited to four files:
+
+- the design document;
+- the implementation plan;
+- spawn-based process-concurrency tests;
+- `trade_rl/telemetry/indexed_training.py`.
+
+The coverage ratchet and this verification document are the only additional final
+files.
+
+Review conclusions:
+
+- public telemetry exports and schemas are unchanged;
+- `flush_every`, `append`, `flush`, `close`, and context-manager usage remain
+  source compatible;
+- the existing strictly-increasing sequence error text is preserved;
+- live readers are blocked only for short append/read/index transactions;
+- crashed processes release advisory locks through handle closure;
+- index temporary names no longer collide across processes;
+- incomplete evidence is never truncated or automatically repaired;
+- an open descriptor cannot silently write to a replaced telemetry inode;
+- no repository caller relies on the base writer's former private text handle;
+- no temporary verification workflow or patch script remains in the intended
+  final diff.
+
+No critical or important review issue remained at this checkpoint.
+
+## Safety boundary
+
+- production remains `NO-GO`;
+- direct exchange routing is not implemented;
+- no profitability or exchange-equivalent fill claim is introduced;
+- PR #81 remains Draft and is not merged.

--- a/docs/verification/2026-07-22-telemetry-process-concurrency.md
+++ b/docs/verification/2026-07-22-telemetry-process-concurrency.md
@@ -1,19 +1,18 @@
 # Telemetry Process Concurrency Verification
 
-Date: 2026-07-22
+Date: 2026-07-23
 
-Branch: `agent/harden-telemetry-process-concurrency-20260722`
+Merged pull request: #95
 
-Pull request: #81
+Merge commit: `e9888e792cf4b1e3477f62987834ec4eb221e39e`
 
-Dependency base: PR #80 exact head
-`88f7e486b6db56fdc16ab89db5a77ef599c8f48f`
+Verified implementation head: `0e22094485c0b530b64da3a0c70f96b5410b2c66`
 
 ## Scope
 
 This change hardens indexed training telemetry for cooperating Linux and Windows
-processes while preserving the JSONL schema, index schema, public writer API,
-indexed page/status contracts, and Studio telemetry endpoints.
+processes while preserving the JSONL schema, sparse-index schema, public writer
+API, indexed page/status contracts, and Studio telemetry endpoints.
 
 Implemented boundaries:
 
@@ -21,14 +20,15 @@ Implemented boundaries:
   on Windows;
 - one append or one read/index snapshot per lock acquisition rather than a
   writer-lifetime lock;
-- process-visible sequence validation before every append;
+- latest process-visible sequence validation before every append;
+- exactly-one-writer behavior when processes race to append the same sequence;
 - append-only binary writes with a partial-write loop;
 - fail-closed rejection of incomplete trailing records;
 - fail-closed rejection when an open writer descriptor no longer identifies the
   current telemetry path;
 - process-unique index temporary files, file `fsync`, atomic replacement, and
   best-effort parent-directory synchronization;
-- indexed reads bounded by the refreshed `indexed_size` snapshot;
+- indexed reads bounded by one locked refreshed-index and JSONL snapshot;
 - explicit `flush()` and `close()` durability with configurable append cadence.
 
 No evidence repair, truncation, database migration, direct exchange routing, or
@@ -38,11 +38,9 @@ production-readiness change is included.
 
 ### Process sequence, tail, and index races
 
-RED head:
+RED head: `d74e639f9d0835b3a35fe00a912b725d095e73ee`
 
-`d74e639f9d0835b3a35fe00a912b725d095e73ee`
-
-Workflow run `29911288413` failed as intended on both Linux and Windows.
+Workflow run `29911288413` failed as intended on Linux and Windows.
 
 Linux artifact:
 
@@ -58,20 +56,14 @@ Windows artifact:
 
 The valid RED run demonstrated:
 
-1. two already-open processes both accepted sequence `1`;
+1. two already-open processes could both accept sequence `1`;
 2. the writer appended after incomplete trailing JSON bytes instead of failing
    closed;
-3. concurrent readers raced on the shared fixed `.tmp` index path, producing
-   file-not-found/replacement failures.
-
-The earlier readiness-queue test-fixture defect was corrected before this RED run;
-these failures were produced by the existing production implementation.
+3. concurrent readers raced on the shared fixed `.tmp` index path.
 
 ### Open-writer stream identity drift
 
-RED head:
-
-`b63f4615075f469780e556d79ab29f6da13dafbe`
+RED head: `b63f4615075f469780e556d79ab29f6da13dafbe`
 
 Workflow run `29912033107` failed as intended because a writer whose path was
 atomically replaced continued writing to its old inode and did not raise.
@@ -81,13 +73,11 @@ atomically replaced continued writing to its old inode and did not raise.
   `sha256:63741401c5a48721f424165dd2d6d537fb9bff4d1e30ada8459881c7405effa8`
 
 The production fix compares `fstat(writer_fd)` with `stat(telemetry_path)` while
-holding the process lock and raises `RuntimeError` when the identities differ.
+holding the process lock and raises when the identities differ.
 
 ## Focused GREEN evidence
 
-### Cross-platform process locking
-
-Workflow run `29911808844` passed on Linux and Windows.
+Workflow run `29911808844` passed the cross-platform locking contracts.
 
 Linux artifact:
 
@@ -101,50 +91,80 @@ Windows artifact:
 - digest:
   `sha256:928b57b58e889641cee7b6c6df1658eb8b0d95caff43b91357d9a73c346f71c6`
 
-The run verified Ruff, formatting, repository-wide Mypy on Linux, native
-`msvcrt` locking on Windows, spawn-based duplicate-writer races, incomplete-tail
-rejection, concurrent page/status reads, existing telemetry contracts, training
-integration, and Studio telemetry API tests.
+The run verified Ruff, formatting, repository-wide Mypy, native Windows locking,
+spawn-based duplicate-writer races, incomplete-tail rejection, concurrent
+page/status reads, existing telemetry contracts, training integration, and Studio
+telemetry API tests.
 
-### Stream identity fix
-
-Workflow run `29912184255`, job `88897470828`, passed source transformation,
-Ruff/format, repository-wide Mypy, process-concurrency tests, existing telemetry
-contracts, training integration, Studio API tests, commit, and push.
+Workflow run `29912184255`, job `88897470828`, verified the stream-identity fix
+with source transformation, Ruff/format, Mypy, process-concurrency regressions,
+existing telemetry contracts, training integration, and Studio API tests.
 
 No test tolerance or schema version was changed.
 
-## Cleanup-head full verification
+## Clean current-main reconstruction
 
-Cleanup head:
+The original PR #81 was stacked on the unsquashed PR #80 history. After its
+architecture dependencies were squash-merged independently, PR #95 recreated only
+the telemetry-concurrency delta directly from current `main` at
+`6cf23b98698f5d53ec40629dd723efc4bd4cfbb6`.
 
-`b203f0816b45aa26c7940961bbf929fb9c0b424c`
+The effective diff contained exactly six files:
 
-GitHub Actions CI run `29912311501`: success.
+- `trade_rl/telemetry/indexed_training.py`;
+- `tests/telemetry/test_indexed_process_concurrency.py`;
+- one measured telemetry coverage-threshold entry in `pyproject.toml`;
+- design, implementation-plan, and verification documentation.
+
+No environment-runtime or PR #79 implementation file was repeated. No temporary
+workflow, generated patch, or migration remained in the merged diff.
+
+## Exact-head verification
+
+GitHub Actions CI run `29956385683`: success.
 
 - exact-head checkout: passed;
-- Studio tests, TypeScript check, production build, and fixed viewport: passed;
+- Studio Vitest, TypeScript, production build, and fixed viewport: passed;
 - workflow-security validation: passed;
 - Ruff and format: passed;
 - Mypy: passed;
-- Import Linter: passed;
+- Import Linter architecture contracts: passed;
 - dead-code report: passed;
 - recovery and structured Serving smoke: passed;
-- full Pytest: `1188 passed, 2 skipped, 11 warnings`;
+- full Pytest: `1197 passed, 2 skipped, 11 warnings`;
 - total coverage: `83.43%`;
 - total branch coverage: `70.34%`;
-- critical branch coverage: passed;
+- critical branch-coverage ratchets: passed;
 - CLI smoke: passed;
-- Ubuntu and Windows compatibility: passed;
+- Ubuntu compatibility and spawn multiprocessing regressions: passed;
+- Windows compatibility and spawn multiprocessing regressions: passed;
 - complete training-image build and packaged non-root runtime probe: passed.
 
-Pytest diagnostics:
+Exact-head artifacts:
 
-- artifact: `8526483274`
-- digest:
-  `sha256:22463e164a4499afa62a9a39ffd18660b93d46c68b4d63be26d5a48fd720ef4f`
+- Pytest diagnostics: `8544270458`, digest
+  `sha256:eb3af56b36c057495d96bdba85f9be894cac3dd96e18bdaf1ddcc4407b3bdf84`
+- architecture diagnostics: `8544227996`, digest
+  `sha256:141c5b3f3bf4b4443a73754899d79effb96c21dc0bd8989125f37606722fd81b`
+- static diagnostics: `8544227415`, digest
+  `sha256:095c032b677c6af423add78e5093813bd7ae7d7f71bbe9bb38ef708f5f1858ea`
+- training-image evidence: `8544221968`, digest
+  `sha256:b06b24a42458cf6be0a00ad2dec46671761c02eeb314cb28c1e7f8e8b3e304ef`
+- Studio layout diagnostics: `8544216788`, digest
+  `sha256:03f7e919f7b5169aeaf7ac2c84ba122015ee764e04c3d7a7e093db5c1e530932`
+- Windows compatibility: `8544216083`, digest
+  `sha256:92e00bdd1ea56592e4bafa87c6662b4603097cc5d0393b8aae8a012803d9ee01`
+- Ubuntu compatibility: `8544208737`, digest
+  `sha256:d3d7cd79eb2bae8bab4e6219ebccf9ae9555ea9f766b21443f6d48b1480d5bed`
 
-PostgreSQL Catalog run `29912311550`: success.
+PostgreSQL Catalog run `29956385705`: success.
+
+- exact-head checkout: passed;
+- Compose validation: passed;
+- PostgreSQL startup and readiness: passed;
+- installation and migration: passed;
+- unit and integration tests: passed;
+- shutdown and cleanup: passed.
 
 ## Coverage ratchet
 
@@ -157,66 +177,26 @@ Measured `trade_rl/telemetry/indexed_training.py` branch coverage:
 
 No existing critical-coverage threshold was reduced.
 
-Ratchet head:
-
-`7ff3e98511a9a3438277bee442587f6f55f89a6f`
-
-GitHub Actions CI run `29912659864`: success.
-
-- full Pytest: `1188 passed, 2 skipped, 11 warnings`;
-- total coverage: `83.43%`;
-- total branch coverage: `70.34%`;
-- indexed telemetry branch ratchet: `68.09% >= 68.0%`;
-- all static, architecture, serving, CLI, compatibility, and training-image jobs:
-  passed.
-
-Ratchet-head Pytest diagnostics:
-
-- artifact: `8526594309`
-- digest:
-  `sha256:3450bc292a9da0a55b71168b6290a24bc574cfe92f86a672279825ea8cf0c19f`
-
-PostgreSQL Catalog run `29912659868`: success.
-
-- exact-head checkout: passed;
-- Compose validation: passed;
-- PostgreSQL startup and readiness: passed;
-- migration: passed;
-- unit and integration tests: passed;
-- cleanup: passed.
-
-## Compatibility and review
-
-Comparison from PR #80 exact head to the cleanup head was limited to four files:
-
-- the design document;
-- the implementation plan;
-- spawn-based process-concurrency tests;
-- `trade_rl/telemetry/indexed_training.py`.
-
-The coverage ratchet and this verification document are the only additional final
-files.
-
-Review conclusions:
+## Compatibility and architecture review
 
 - public telemetry exports and schemas are unchanged;
 - `flush_every`, `append`, `flush`, `close`, and context-manager usage remain
   source compatible;
-- the existing strictly-increasing sequence error text is preserved;
+- the existing strictly-increasing sequence error contract is preserved;
 - live readers are blocked only for short append/read/index transactions;
 - crashed processes release advisory locks through handle closure;
-- index temporary names no longer collide across processes;
+- index temporary names cannot collide across cooperating processes;
 - incomplete evidence is never truncated or automatically repaired;
 - an open descriptor cannot silently write to a replaced telemetry inode;
+- read/index refresh is observed as one locked process-visible snapshot;
 - no repository caller relies on the base writer's former private text handle;
-- no temporary verification workflow or patch script remains in the intended
-  final diff.
-
-No critical or important review issue remained at this checkpoint.
+- no unresolved critical or important review issue remained before merge.
 
 ## Safety boundary
 
 - production remains `NO-GO`;
 - direct exchange routing is not implemented;
 - no profitability or exchange-equivalent fill claim is introduced;
-- PR #81 remains Draft and is not merged.
+- JSONL and sparse-index schemas remain unchanged;
+- this verification records corruption prevention and regression evidence, not
+  production authorization.

--- a/docs/verification/2026-07-23-telemetry-episode-identity.md
+++ b/docs/verification/2026-07-23-telemetry-episode-identity.md
@@ -1,0 +1,130 @@
+# Telemetry Episode Identity Verification
+
+Date: 2026-07-23
+
+## Scope
+
+This verification covers Draft PR #103, which adds producer-issued episode identity to the existing Live Training environment/current-episode isolation boundary.
+
+Design:
+
+- `docs/superpowers/specs/2026-07-23-telemetry-episode-identity-design.md`
+
+Implementation plan:
+
+- `docs/superpowers/plans/2026-07-23-telemetry-episode-identity.md`
+
+The implementation intentionally does not import the alternate Live Training page or track architecture from stacked Draft PR #84. The existing environment selector and current-episode presentation merged through PR #85 remain in place.
+
+## Implemented contract
+
+- Primary JSONL evidence remains `training_telemetry_v1`.
+- `episode_id` is additive and nullable, so historical records remain readable.
+- The telemetry sampler owns one active non-negative episode ID per vector environment.
+- The same environment episode retains one ID across retained records.
+- A terminal or truncated record is emitted with the current ID.
+- The next retained record for that environment receives a new ID.
+- Reopening an existing telemetry stream starts allocation above the existing sequence/episode range and does not reuse an earlier producer-issued ID.
+- Producer fallback state for previous close and previous weights is cleared when the episode ends.
+- Studio normalizes the field to `episodeId`.
+- Python, Studio, and browser guards reject boolean, negative, and non-integer explicit values.
+- Live Training prefers the latest explicit episode ID for the selected environment.
+- Historical records with `null` identity continue to use the existing terminal and counter-rollback boundary.
+- Stream generation, sequence, sparse-index, process-lock, cursor-reset, and JSONL file-identity contracts are unchanged.
+
+## TDD RED evidence
+
+RED head:
+
+- `75204910275e7034eca0f66325645a6f9699db21`
+
+GitHub Actions CI run:
+
+- `29957910685`
+- expected failure in `Verify Studio frontend`
+
+The regression used one environment with explicit episode IDs `41` and `42` while `environmentStep` and `marketIndex` remained monotonic and no terminal marker was retained. The pre-change heuristic returned all four records instead of only the two records from episode `42`.
+
+Ubuntu and Windows compatibility jobs passed at the RED head, confirming that the failure was isolated to the newly introduced frontend contract.
+
+## GREEN implementation
+
+The implementation adds:
+
+- nullable record serialization and strict parsing;
+- per-environment producer allocation and post-terminal rotation;
+- restart-safe stream-local allocation which remains above existing IDs;
+- Studio API normalization;
+- TypeScript type and runtime guard support;
+- explicit-ID-first current-episode selection;
+- legacy-null fallback behavior;
+- focused Python, Studio, integration, and frontend tests;
+- a measured critical branch-coverage threshold for `trade_rl/rl/training_telemetry.py`.
+
+No production training, checkpoint selection, sealed evaluation, promotion, release, Serving, or execution logic changes.
+
+## Exact-head verification
+
+Final verified implementation-and-test head before this documentation-only commit:
+
+- `9e806f5fd5ceac751fa77e25a1b72b140de1e6a7`
+
+GitHub Actions CI run `29958798560`: success.
+
+- exact-head checkout: passed;
+- complete Studio Vitest suite: passed;
+- TypeScript type checking: passed;
+- Studio production build: passed;
+- fixed viewport verification: passed;
+- workflow security: passed;
+- Ruff and format: passed;
+- Mypy: passed;
+- Import Linter architecture contracts: passed;
+- dead-code report: passed;
+- recovery and structured Serving smoke: passed;
+- full Pytest: `1214 passed, 2 skipped, 11 warnings`;
+- total coverage: `83.47%`;
+- total branch coverage: `4868 / 6916 = 70.39%`;
+- sampler branch coverage: `55 / 70 = 78.57% >= 78.5%`;
+- indexed telemetry branch coverage remains `76 / 110 = 69.09% >= 69.0%`;
+- all critical branch-coverage ratchets: passed;
+- CLI smoke: passed;
+- Ubuntu compatibility: passed;
+- Windows compatibility: passed;
+- complete training-image build and packaged non-root runtime probe: passed.
+
+PostgreSQL Catalog run `29958798616`: success.
+
+- exact-head checkout: passed;
+- Compose validation: passed;
+- PostgreSQL startup and readiness: passed;
+- installation and migration: passed;
+- unit and integration tests: passed;
+- shutdown and cleanup: passed.
+
+## Exact-head artifacts
+
+- Pytest diagnostics: ID `8545202616`, digest `sha256:208ccbe2158aed8d08f60c36f92af1e3bcc0e96a5da3728c859211bdb2157db2`;
+- architecture diagnostics: ID `8545161810`, digest `sha256:ea475021bd459ac56700141adfe4f5ddec2436309ce8fa3da939fa0ddf5391bc`;
+- static diagnostics: ID `8545161251`, digest `sha256:67442ae066d7a71180a7ac3a04c7797c612a0b471b4890ecefc7b9d7d9bf5eeb`;
+- training-image evidence: ID `8545154614`, digest `sha256:cb13c90ecaba02860ceffaea829b2fb762afc69f39a875a19649c67c905ba474`;
+- Studio layout diagnostics: ID `8545151953`, digest `sha256:6b580c8a33aee11623e1938d85899e172a0ad5b2963e411bb515014134ed6291`;
+- Windows compatibility: ID `8545146264`, digest `sha256:4ec32c60a6b5fdbd188cf2d65336b9f2816907d748ad3b4735c5199ffbf2d6da`;
+- Ubuntu compatibility: ID `8545143616`, digest `sha256:1756aefbb47f6b54f74fa033aec117708964a597cd3c303154128716f954d520`.
+
+This verification file is documentation-only. The final PR head must pass exact-head CI again before merge.
+
+## Review result
+
+The effective comparison from current `main` contains exactly 16 implementation/test/design files before this verification note. It does not include the alternate page and track implementation from old PR #84. The current Live Training environment and episode-isolation tests remain intact.
+
+The restart regression closes the remaining stream-local allocation ambiguity: a newly constructed sampler reading an existing JSONL continues both sequence and episode identity monotonically instead of reusing the first episode ID.
+
+No critical or important review issue remains.
+
+## Safety boundary
+
+- Production remains `NO-GO`.
+- Direct exchange routing is not implemented.
+- No profitability or exchange-equivalent fill claim is introduced.
+- Historical telemetry is not rewritten or repaired.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,7 @@ target = 90.0
 "trade_rl/risk/pretrade.py" = 90.0
 "trade_rl/rl/rewards.py" = 97.0
 "trade_rl/evaluation/gates.py" = 100.0
-"trade_rl/telemetry/indexed_training.py" = 68.0
+"trade_rl/telemetry/indexed_training.py" = 69.0
 
 [tool.trade_rl.critical_coverage.groups.artifacts]
 minimum = 90.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ target = 90.0
 "trade_rl/rl/rewards.py" = 97.0
 "trade_rl/evaluation/gates.py" = 100.0
 "trade_rl/telemetry/indexed_training.py" = 69.0
+"trade_rl/rl/training_telemetry.py" = 78.5
 
 [tool.trade_rl.critical_coverage.groups.artifacts]
 minimum = 90.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,3 +155,12 @@ paths = [
     "trade_rl/rl/environment_observation.py",
     "trade_rl/rl/environment_transition.py",
 ]
+
+[tool.trade_rl.critical_coverage.groups.environment_step_services]
+minimum = 86.8
+paths = [
+    "trade_rl/rl/environment_decision.py",
+    "trade_rl/rl/environment_risk.py",
+    "trade_rl/rl/environment_reward.py",
+    "trade_rl/rl/environment_info.py",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ target = 90.0
 "trade_rl/risk/pretrade.py" = 90.0
 "trade_rl/rl/rewards.py" = 97.0
 "trade_rl/evaluation/gates.py" = 100.0
+"trade_rl/telemetry/indexed_training.py" = 68.0
 
 [tool.trade_rl.critical_coverage.groups.artifacts]
 minimum = 90.0

--- a/studio/src/api/studioApi.ts
+++ b/studio/src/api/studioApi.ts
@@ -149,6 +149,7 @@ export function loadTelemetryEvents(
   afterSequence = 0,
   limit = 512,
   seed: number | null = null,
+  streamGeneration: string | null = null,
   fetcher: typeof fetch = fetch,
 ): Promise<TelemetryEventsResponse> {
   const parameters = new URLSearchParams({
@@ -156,6 +157,9 @@ export function loadTelemetryEvents(
     limit: String(limit),
   })
   if (seed !== null) parameters.set('seed', String(seed))
+  if (streamGeneration !== null) {
+    parameters.set('stream_generation', streamGeneration)
+  }
   return requestJson(
     `/api/studio/jobs/${encodeURIComponent(jobId)}/telemetry/events?${parameters.toString()}`,
     fetcher,
@@ -200,7 +204,7 @@ export interface StudioApi {
   cancelJob: (jobId: string) => Promise<JobSummary>
   loadJobLog: (jobId: string) => Promise<JobLogResponse>
   loadTelemetryStatus: (jobId: string, seed?: number | null) => Promise<TelemetryStatusResponse>
-  loadTelemetryEvents: (jobId: string, afterSequence?: number, limit?: number, seed?: number | null) => Promise<TelemetryEventsResponse>
+  loadTelemetryEvents: (jobId: string, afterSequence?: number, limit?: number, seed?: number | null, streamGeneration?: string | null) => Promise<TelemetryEventsResponse>
   loadCheckpointEvaluations?: (jobId: string) => Promise<CheckpointEvaluationsResponse>
   loadRunComparison: (leftResourceId: string, rightResourceId: string) => Promise<RunComparison>
   loadEvidenceReport: (runResourceId: string) => Promise<EvidenceReport>

--- a/studio/src/data/types.ts
+++ b/studio/src/data/types.ts
@@ -123,6 +123,7 @@ export interface TrainingTelemetryRecord {
   environmentStep: number
   seed: number
   environmentId: number
+  episodeId: number | null
   eventType: TelemetryEventType
   marketIndex: number | null
   marketTime: string | null

--- a/studio/src/data/types.ts
+++ b/studio/src/data/types.ts
@@ -156,6 +156,7 @@ export interface TelemetryStatusResponse {
   malformedLines: number
   sizeBytes: number
   source: string | null
+  streamGeneration: string | null
 }
 
 export interface TelemetryEventsResponse {
@@ -165,6 +166,8 @@ export interface TelemetryEventsResponse {
   truncated: boolean
   malformedLines: number
   sequenceGaps: [number, number][]
+  streamGeneration: string | null
+  resetRequired: boolean
 }
 
 export interface CheckpointEvaluationItem {

--- a/studio/src/live/telemetryGuards.test.ts
+++ b/studio/src/live/telemetryGuards.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import type { TrainingTelemetryRecord } from '../data/types'
+import { isTrainingTelemetryRecord } from './telemetryGuards'
+
+function record(episodeId: number | null): TrainingTelemetryRecord {
+  return {
+    schemaVersion: 'training_telemetry_v1',
+    sequence: 1,
+    recordedAt: '2026-07-22T13:00:00+00:00',
+    globalStep: 32,
+    environmentStep: 1,
+    seed: 7,
+    environmentId: 0,
+    episodeId,
+    eventType: 'rollout',
+    marketIndex: 101,
+    marketTime: '2026-07-22T12:55:00.000000000',
+    symbol: 'BTCUSDT',
+    open: 100,
+    high: 101,
+    low: 99,
+    close: 100.5,
+    action: [0.2],
+    executedTarget: [0.2],
+    weightsBefore: [0.1],
+    weightsAfter: [0.2],
+    portfolioValue: 1_000,
+    baselinePortfolioValue: 990,
+    reward: 0.1,
+    drawdown: 0,
+    intervalCost: 0,
+    intervalReturn: 0.001,
+    riskReasons: [],
+    emergencyDeleverage: false,
+    terminated: false,
+    truncated: false,
+  }
+}
+
+describe('isTrainingTelemetryRecord episode identity', () => {
+  it('accepts explicit and normalized legacy identities', () => {
+    expect(isTrainingTelemetryRecord(record(4))).toBe(true)
+    expect(isTrainingTelemetryRecord(record(null))).toBe(true)
+  })
+
+  it('rejects missing, negative, and boolean episode identities', () => {
+    const missing = { ...record(null) } as Record<string, unknown>
+    delete missing.episodeId
+
+    expect(isTrainingTelemetryRecord(missing)).toBe(false)
+    expect(isTrainingTelemetryRecord({ ...record(null), episodeId: -1 })).toBe(false)
+    expect(isTrainingTelemetryRecord({ ...record(null), episodeId: true })).toBe(false)
+  })
+})

--- a/studio/src/live/telemetryGuards.ts
+++ b/studio/src/live/telemetryGuards.ts
@@ -38,6 +38,7 @@ export function isTrainingTelemetryRecord(value: unknown): value is TrainingTele
     && isNonNegativeInteger(value.environmentStep)
     && isNonNegativeInteger(value.seed)
     && isNonNegativeInteger(value.environmentId)
+    && (value.episodeId === null || isNonNegativeInteger(value.episodeId))
     && typeof value.eventType === 'string' && eventTypes.has(value.eventType)
     && (value.marketIndex === null || isNonNegativeInteger(value.marketIndex))
     && (value.marketTime === null || typeof value.marketTime === 'string')

--- a/studio/src/live/telemetryGuards.ts
+++ b/studio/src/live/telemetryGuards.ts
@@ -17,6 +17,9 @@ const isNumberArray = (value: unknown): value is number[] =>
   Array.isArray(value) && value.every(isFiniteNumber)
 const isStringArray = (value: unknown): value is string[] =>
   Array.isArray(value) && value.every((item) => typeof item === 'string')
+const generationPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+const isNullableGeneration = (value: unknown): value is string | null =>
+  value === null || (typeof value === 'string' && generationPattern.test(value))
 const eventTypes = new Set([
   'rollout',
   'position',
@@ -71,6 +74,7 @@ export function isTelemetryStatus(value: unknown): value is TelemetryStatusRespo
     && isNonNegativeInteger(value.malformedLines)
     && isNonNegativeInteger(value.sizeBytes)
     && (value.source === null || typeof value.source === 'string')
+    && isNullableGeneration(value.streamGeneration)
 }
 
 export function isTelemetryEvents(value: unknown): value is TelemetryEventsResponse {
@@ -88,6 +92,9 @@ export function isTelemetryEvents(value: unknown): value is TelemetryEventsRespo
     && typeof value.truncated === 'boolean'
     && isNonNegativeInteger(value.malformedLines)
     && Array.isArray(value.sequenceGaps)
+    && isNullableGeneration(value.streamGeneration)
+    && typeof value.resetRequired === 'boolean'
+    && (!value.resetRequired || (value.items.length === 0 && value.nextSequence === 0))
     && value.sequenceGaps.every((gap) =>
       Array.isArray(gap)
       && gap.length === 2

--- a/studio/src/live/telemetryStreams.test.ts
+++ b/studio/src/live/telemetryStreams.test.ts
@@ -3,10 +3,12 @@ import { describe, expect, it } from 'vitest'
 import type { TrainingTelemetryRecord } from '../data/types'
 import { currentEnvironmentEpisode, telemetryEnvironmentIds } from './telemetryStreams'
 
+type RecordOverrides = Partial<TrainingTelemetryRecord>
+
 function record(
   sequence: number,
   environmentId: number,
-  overrides: Partial<TrainingTelemetryRecord> = {},
+  overrides: RecordOverrides = {},
 ): TrainingTelemetryRecord {
   return {
     schemaVersion: 'training_telemetry_v1',
@@ -16,6 +18,7 @@ function record(
     environmentStep: sequence,
     seed: 7,
     environmentId,
+    episodeId: null,
     eventType: 'rollout',
     marketIndex: 100 + sequence,
     marketTime: `2026-07-23T00:00:${String(sequence).padStart(2, '0')}.000000000`,
@@ -64,6 +67,17 @@ describe('telemetry stream selection', () => {
 
     expect(currentEnvironmentEpisode(records, 0).map((item) => item.sequence)).toEqual([5, 6])
     expect(currentEnvironmentEpisode(records, 1).map((item) => item.sequence)).toEqual([2, 4])
+  })
+
+  it('prefers producer episode identity when counters remain monotonic', () => {
+    const records = [
+      record(1, 0, { episodeId: 41, environmentStep: 10, marketIndex: 110 }),
+      record(2, 0, { episodeId: 41, environmentStep: 11, marketIndex: 111 }),
+      record(3, 0, { episodeId: 42, environmentStep: 12, marketIndex: 112 }),
+      record(4, 0, { episodeId: 42, environmentStep: 13, marketIndex: 113 }),
+    ]
+
+    expect(currentEnvironmentEpisode(records, 0).map((item) => item.sequence)).toEqual([3, 4])
   })
 
   it('starts a new episode when environment counters roll back', () => {

--- a/studio/src/live/telemetryStreams.ts
+++ b/studio/src/live/telemetryStreams.ts
@@ -29,6 +29,11 @@ export function currentEnvironmentEpisode(
     .sort((left, right) => left.sequence - right.sequence)
   if (environmentRecords.length === 0) return []
 
+  const latestEpisodeId = environmentRecords.at(-1)?.episodeId ?? null
+  if (latestEpisodeId !== null) {
+    return environmentRecords.filter((record) => record.episodeId === latestEpisodeId)
+  }
+
   let episodeStart = 0
   for (let index = 1; index < environmentRecords.length; index += 1) {
     if (crossesEpisodeBoundary(environmentRecords[index - 1], environmentRecords[index])) {

--- a/studio/src/live/useTrainingTelemetry.test.tsx
+++ b/studio/src/live/useTrainingTelemetry.test.tsx
@@ -1,0 +1,175 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { StudioApi } from '../api/studioApi'
+import type {
+  TelemetryEventsResponse,
+  TelemetryStatusResponse,
+  TrainingTelemetryRecord,
+} from '../data/types'
+import { isTelemetryEvents, isTelemetryStatus } from './telemetryGuards'
+import { useTrainingTelemetry } from './useTrainingTelemetry'
+
+const GENERATION_A = '11111111-1111-4111-8111-111111111111'
+const GENERATION_B = '22222222-2222-4222-8222-222222222222'
+
+function telemetry(sequence: number): TrainingTelemetryRecord {
+  return {
+    schemaVersion: 'training_telemetry_v1',
+    sequence,
+    recordedAt: '2026-07-22T11:00:00+00:00',
+    globalStep: sequence * 32,
+    environmentStep: sequence,
+    seed: 7,
+    environmentId: 0,
+    eventType: 'rollout',
+    marketIndex: 100 + sequence,
+    marketTime: '2026-07-22T10:55:00.000000000',
+    symbol: 'BTCUSDT',
+    open: 67_500,
+    high: 67_900,
+    low: 67_400,
+    close: 67_842.3,
+    action: [0.4],
+    executedTarget: [0.4],
+    weightsBefore: [0.2],
+    weightsAfter: [0.4],
+    portfolioValue: 101_342.85,
+    baselinePortfolioValue: 100_400,
+    reward: 0.214,
+    drawdown: 0.0086,
+    intervalCost: 4.25,
+    intervalReturn: 0.0012,
+    riskReasons: [],
+    emergencyDeleverage: false,
+    terminated: false,
+    truncated: false,
+  }
+}
+
+function status(generation: string): TelemetryStatusResponse {
+  return {
+    available: true,
+    selectedSeed: 7,
+    availableSeeds: [7],
+    recordCount: 1,
+    lastSequence: 1,
+    malformedLines: 0,
+    sizeBytes: 1024,
+    source: 'research/.staging/live/seed-7/telemetry/training-telemetry.jsonl',
+    streamGeneration: generation,
+  } as unknown as TelemetryStatusResponse
+}
+
+function page(
+  generation: string,
+  items: TrainingTelemetryRecord[],
+  resetRequired = false,
+): TelemetryEventsResponse {
+  return {
+    seed: 7,
+    items,
+    nextSequence: items.at(-1)?.sequence ?? 0,
+    truncated: false,
+    malformedLines: 0,
+    sequenceGaps: [],
+    streamGeneration: generation,
+    resetRequired,
+  } as unknown as TelemetryEventsResponse
+}
+
+function api(
+  loadTelemetryStatus: ReturnType<typeof vi.fn>,
+  loadTelemetryEvents: ReturnType<typeof vi.fn>,
+): StudioApi {
+  const unused = vi.fn().mockRejectedValue(new Error('not used'))
+  return {
+    loadDatasets: unused,
+    loadRuns: unused,
+    loadConfigs: unused,
+    loadJobs: unused,
+    submitTrainingJob: unused,
+    cancelJob: unused,
+    loadJobLog: unused,
+    loadTelemetryStatus,
+    loadTelemetryEvents,
+    loadCheckpointEvaluations: unused,
+    loadRunComparison: unused,
+    loadEvidenceReport: unused,
+    loadServingMonitor: unused,
+  } as unknown as StudioApi
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('useTrainingTelemetry generation handling', () => {
+  it('clears a stale cursor and immediately replays the replacement generation', async () => {
+    const loadStatus = vi.fn().mockResolvedValue(status(GENERATION_B))
+    const loadEvents = vi.fn()
+      .mockResolvedValueOnce(page(GENERATION_B, [], true))
+      .mockResolvedValueOnce(page(GENERATION_B, [telemetry(1)]))
+    const runtimeApi = api(loadStatus, loadEvents)
+
+    const { result, unmount } = renderHook(() =>
+      useTrainingTelemetry('job-live', runtimeApi, 7))
+
+    await waitFor(() => expect(loadEvents).toHaveBeenCalledTimes(2), { timeout: 300 })
+    await waitFor(() =>
+      expect(result.current.records.map((item) => item.sequence)).toEqual([1]))
+
+    expect(loadEvents).toHaveBeenNthCalledWith(
+      1,
+      'job-live',
+      0,
+      512,
+      7,
+      null,
+    )
+    expect(loadEvents).toHaveBeenNthCalledWith(
+      2,
+      'job-live',
+      0,
+      512,
+      7,
+      GENERATION_B,
+    )
+    unmount()
+  })
+
+  it('discards a mixed status and events generation before publishing records', async () => {
+    const loadStatus = vi.fn()
+      .mockResolvedValueOnce(status(GENERATION_A))
+      .mockResolvedValueOnce(status(GENERATION_B))
+    const loadEvents = vi.fn()
+      .mockResolvedValueOnce(page(GENERATION_B, [telemetry(99)]))
+      .mockResolvedValueOnce(page(GENERATION_B, [telemetry(1)]))
+    const runtimeApi = api(loadStatus, loadEvents)
+
+    const { result, unmount } = renderHook(() =>
+      useTrainingTelemetry('job-live', runtimeApi, 7))
+
+    await waitFor(() => expect(loadEvents).toHaveBeenCalledTimes(2), { timeout: 300 })
+    await waitFor(() =>
+      expect(result.current.records.map((item) => item.sequence)).toEqual([1]))
+    expect(result.current.records.some((item) => item.sequence === 99)).toBe(false)
+    unmount()
+  })
+})
+
+describe('telemetry generation guards', () => {
+  it('rejects an invalid status generation', () => {
+    expect(isTelemetryStatus({
+      ...status(GENERATION_A),
+      streamGeneration: 'not-a-generation',
+    })).toBe(false)
+  })
+
+  it('rejects a non-boolean reset flag', () => {
+    expect(isTelemetryEvents({
+      ...page(GENERATION_A, []),
+      resetRequired: 'yes',
+    })).toBe(false)
+  })
+})

--- a/studio/src/live/useTrainingTelemetry.test.tsx
+++ b/studio/src/live/useTrainingTelemetry.test.tsx
@@ -22,6 +22,7 @@ function telemetry(sequence: number): TrainingTelemetryRecord {
     environmentStep: sequence,
     seed: 7,
     environmentId: 0,
+    episodeId: 1,
     eventType: 'rollout',
     marketIndex: 100 + sequence,
     marketTime: '2026-07-22T10:55:00.000000000',

--- a/studio/src/live/useTrainingTelemetry.ts
+++ b/studio/src/live/useTrainingTelemetry.ts
@@ -17,6 +17,18 @@ export interface TrainingTelemetryState {
   refresh: () => Promise<void>
 }
 
+function mergeRecords(
+  current: TrainingTelemetryRecord[],
+  incoming: TrainingTelemetryRecord[],
+): TrainingTelemetryRecord[] {
+  if (incoming.length === 0) return current
+  const bySequence = new Map(current.map((item) => [item.sequence, item]))
+  for (const item of incoming) bySequence.set(item.sequence, item)
+  return [...bySequence.values()]
+    .sort((left, right) => left.sequence - right.sequence)
+    .slice(-MAX_BUFFERED_RECORDS)
+}
+
 export function useTrainingTelemetry(
   jobId: string | null,
   api: StudioApi = studioApi,
@@ -28,6 +40,7 @@ export function useTrainingTelemetry(
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const sequence = useRef(0)
+  const generation = useRef<string | null>(null)
   const request = useRef(0)
 
   const refresh = useCallback(async () => {
@@ -36,32 +49,102 @@ export function useTrainingTelemetry(
       setConnection('offline')
       return
     }
+    const resolvedJobId = jobId
     const currentRequest = ++request.current
-    try {
+    setLoading(true)
+
+    async function loadSnapshot(allowRetry: boolean): Promise<void> {
+      const expectedGeneration = generation.current
       const [nextStatus, page] = await Promise.all([
-        api.loadTelemetryStatus(jobId, seed),
-        api.loadTelemetryEvents(jobId, sequence.current, 512, seed),
+        api.loadTelemetryStatus(resolvedJobId, seed),
+        api.loadTelemetryEvents(
+          resolvedJobId,
+          sequence.current,
+          512,
+          seed,
+          expectedGeneration,
+        ),
       ])
       if (currentRequest !== request.current) return
+
+      const retry = async (
+        nextGeneration: string | null,
+        reason: string,
+      ): Promise<void> => {
+        setRecords([])
+        setStatus(null)
+        setConnection('connecting')
+        sequence.current = 0
+        generation.current = nextGeneration
+        if (!allowRetry) {
+          throw new Error(`Telemetry stream changed repeatedly: ${reason}`)
+        }
+        await loadSnapshot(false)
+      }
+
+      if (page.resetRequired) {
+        if (page.streamGeneration === null) {
+          throw new Error('Telemetry reset response has no stream generation')
+        }
+        await retry(page.streamGeneration, 'cursor generation is stale')
+        return
+      }
+
+      if (
+        nextStatus.streamGeneration !== null
+        && page.streamGeneration !== null
+        && nextStatus.streamGeneration !== page.streamGeneration
+      ) {
+        await retry(null, 'status and events generations differ')
+        return
+      }
+
+      if (
+        nextStatus.available
+        && (
+          nextStatus.streamGeneration === null
+          || page.streamGeneration === null
+        )
+      ) {
+        throw new Error('Available telemetry response has no stream generation')
+      }
+
+      const resolvedGeneration = page.streamGeneration
+        ?? nextStatus.streamGeneration
+      if (generation.current === null) {
+        generation.current = resolvedGeneration
+      } else if (
+        resolvedGeneration !== null
+        && generation.current !== resolvedGeneration
+      ) {
+        throw new Error('Telemetry generation changed without a reset response')
+      }
+
       setStatus(nextStatus)
       if (page.items.length > 0) {
-        const accepted = page.items.filter((item) => item.sequence > sequence.current)
+        const accepted = page.items.filter(
+          (item) => item.sequence > sequence.current,
+        )
         if (accepted.length > 0) {
-          sequence.current = Math.max(sequence.current, page.nextSequence)
-          setRecords((current) => {
-            const bySequence = new Map(current.map((item) => [item.sequence, item]))
-            for (const item of accepted) bySequence.set(item.sequence, item)
-            return [...bySequence.values()]
-              .sort((left, right) => left.sequence - right.sequence)
-              .slice(-MAX_BUFFERED_RECORDS)
-          })
+          setRecords((current) => mergeRecords(current, accepted))
         }
       }
+      sequence.current = Math.max(sequence.current, page.nextSequence)
       setError(null)
-      setConnection(nextStatus.available ? (page.truncated ? 'delayed' : 'live') : 'delayed')
+      setConnection(
+        nextStatus.available ? (page.truncated ? 'delayed' : 'live') : 'delayed',
+      )
+    }
+
+    try {
+      await loadSnapshot(true)
     } catch (reason) {
       if (currentRequest !== request.current) return
-      setError(reason instanceof Error ? reason.message : 'テレメトリを取得できませんでした。')
+      setError(
+        reason instanceof Error
+          ? reason.message
+          : 'テレメトリを取得できませんでした。',
+      )
       setConnection('offline')
     } finally {
       if (currentRequest === request.current) setLoading(false)
@@ -71,6 +154,7 @@ export function useTrainingTelemetry(
   useEffect(() => {
     request.current += 1
     sequence.current = 0
+    generation.current = null
     setRecords([])
     setStatus(null)
     setConnection(jobId ? 'connecting' : 'offline')

--- a/studio/src/pages/LiveTrainingPage.test.tsx
+++ b/studio/src/pages/LiveTrainingPage.test.tsx
@@ -44,6 +44,7 @@ function telemetry(
     environmentStep: sequence,
     seed,
     environmentId: 0,
+    episodeId: null,
     eventType: sequence === 2 ? 'position' : 'rollout',
     marketIndex: 100 + sequence,
     marketTime: `2026-07-21T08:0${sequence}:00.000000000`,

--- a/studio/src/pages/LiveTrainingPage.test.tsx
+++ b/studio/src/pages/LiveTrainingPage.test.tsx
@@ -110,6 +110,7 @@ function api(): StudioApi {
         malformedLines: 0,
         sizeBytes: 2048,
         source: items.length > 0 ? `research/.staging/btc-live-001/seed-${selected}/telemetry/training-telemetry.jsonl` : null,
+        streamGeneration: items.length > 0 ? '33333333-3333-4333-8333-333333333333' : null,
       })
     }),
     loadTelemetryEvents: vi.fn().mockImplementation((
@@ -127,6 +128,8 @@ function api(): StudioApi {
         truncated: false,
         malformedLines: 0,
         sequenceGaps: [],
+        streamGeneration: '33333333-3333-4333-8333-333333333333',
+        resetRequired: false,
       })
     }),
     loadCheckpointEvaluations: vi.fn().mockResolvedValue({
@@ -243,6 +246,7 @@ describe('LiveTrainingPage', () => {
       malformedLines: 0,
       sizeBytes: 4096,
       source: 'research/.staging/btc-live-001/seed-7/telemetry/training-telemetry.jsonl',
+      streamGeneration: '33333333-3333-4333-8333-333333333333',
     })
     runtimeApi.loadTelemetryEvents = vi.fn().mockImplementation((
       _jobId: string,
@@ -254,6 +258,8 @@ describe('LiveTrainingPage', () => {
       truncated: false,
       malformedLines: 0,
       sequenceGaps: [],
+      streamGeneration: '33333333-3333-4333-8333-333333333333',
+      resetRequired: false,
     }))
 
     render(<LiveTrainingPage api={runtimeApi} />)

--- a/tests/architecture/test_environment_step_decomposition.py
+++ b/tests/architecture/test_environment_step_decomposition.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+ENVIRONMENT = ROOT / "trade_rl" / "rl" / "environment.py"
+SERVICE_PATHS = (
+    ROOT / "trade_rl" / "rl" / "environment_decision.py",
+    ROOT / "trade_rl" / "rl" / "environment_risk.py",
+    ROOT / "trade_rl" / "rl" / "environment_reward.py",
+    ROOT / "trade_rl" / "rl" / "environment_info.py",
+)
+SERVICE_ATTRIBUTES = (
+    ("EnvironmentDecisionPlanner", "self._decision_planner"),
+    ("EnvironmentRiskProjector", "self._risk_projector"),
+    ("EnvironmentRewardCoordinator", "self._reward_coordinator"),
+    ("EnvironmentInfoBuilder", "self._info_builder"),
+)
+
+
+def _source(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_environment_step_services_have_dedicated_modules() -> None:
+    missing = [
+        path.relative_to(ROOT).as_posix()
+        for path in SERVICE_PATHS
+        if not path.is_file()
+    ]
+
+    assert missing == []
+
+
+def test_environment_constructs_all_step_services() -> None:
+    source = _source(ENVIRONMENT)
+
+    for symbol, attribute in SERVICE_ATTRIBUTES:
+        assert symbol in source
+        assert attribute in source
+
+
+def test_environment_step_delegates_action_risk_reward_and_info() -> None:
+    source = _source(ENVIRONMENT)
+    step_source = source.split("    def step(\n", maxsplit=1)[1]
+
+    assert "self._decision_planner.plan(" in step_source
+    assert "self._risk_projector.project(" in step_source
+    assert "self._reward_coordinator.step(" in step_source
+    assert "self._info_builder.step_info(" in step_source
+
+
+def test_environment_step_no_longer_owns_extracted_policy_logic() -> None:
+    source = _source(ENVIRONMENT)
+    step_source = source.split("    def step(\n", maxsplit=1)[1]
+
+    assert "self.composer.compose(" not in step_source
+    assert "self.reward_tracker.step(" not in step_source
+    assert "self.emergency_risk_monitor.assess(" not in step_source
+    assert "info: dict[str, object] = {" not in step_source
+
+
+def test_terminal_information_is_built_by_info_service() -> None:
+    source = _source(ENVIRONMENT)
+
+    assert "self._info_builder.terminal_info(" in source
+    assert "def _book_metrics(" not in source

--- a/tests/integrations/test_training_telemetry_episode_identity.py
+++ b/tests/integrations/test_training_telemetry_episode_identity.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+
+from trade_rl.integrations.training_telemetry import TrainingTelemetrySampler
+from trade_rl.telemetry import read_training_telemetry
+
+
+def _info(
+    step: int,
+    *,
+    price: float = 100.0,
+    before: tuple[float, ...] | None = (0.2,),
+    after: tuple[float, ...] = (0.2,),
+    exact_market: bool = True,
+    terminated: bool = False,
+    truncated: bool = False,
+) -> dict[str, object]:
+    book = SimpleNamespace(
+        weights=np.asarray(after, dtype=np.float64),
+        portfolio_value=1_000.0 + step,
+        mark_prices=np.asarray([price], dtype=np.float64),
+    )
+    result: dict[str, object] = {
+        "decision_step_index": step,
+        "telemetry_symbol": "BTCUSDT",
+        "telemetry_weights_after": np.asarray(after, dtype=np.float64),
+        "hybrid_execution": SimpleNamespace(book=book),
+        "portfolio_value_after": 1_000.0 + step,
+        "baseline_portfolio_value_after": 1_000.0,
+        "reward_total_scaled": 0.0,
+        "drawdown_after": 0.0,
+        "interval_cost": 0.0,
+        "interval_net_return": 0.0,
+        "telemetry_risk_reasons": (),
+        "emergency_deleverage": False,
+        "hybrid_terminated": terminated,
+        "TimeLimit.truncated": truncated,
+    }
+    if before is not None:
+        result["telemetry_weights_before"] = np.asarray(before, dtype=np.float64)
+    if exact_market:
+        result.update(
+            {
+                "telemetry_market_index": 100 + step,
+                "telemetry_market_time": "2026-07-22T12:00:00.000000000",
+                "telemetry_ohlc": (price, price, price, price),
+            }
+        )
+    return result
+
+
+def test_vector_environments_receive_distinct_episode_ids_and_rotate_after_done(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    sampler = TrainingTelemetrySampler(path, seed=3, sample_every=1)
+
+    assert (
+        sampler.consume(
+            global_step=2,
+            actions=np.asarray([[0.1], [0.2]], dtype=np.float32),
+            rewards=np.asarray([0.0, 0.0], dtype=np.float32),
+            dones=np.asarray([False, False]),
+            infos=(_info(1), _info(1, price=600.0)),
+        )
+        == 2
+    )
+    assert (
+        sampler.consume(
+            global_step=4,
+            actions=np.asarray([[0.0], [0.2]], dtype=np.float32),
+            rewards=np.asarray([0.0, 0.0], dtype=np.float32),
+            dones=np.asarray([True, False]),
+            infos=(
+                _info(2, terminated=True),
+                _info(2, price=601.0),
+            ),
+        )
+        == 2
+    )
+    assert (
+        sampler.consume(
+            global_step=6,
+            actions=np.asarray([[0.3], [0.2]], dtype=np.float32),
+            rewards=np.asarray([0.0, 0.0], dtype=np.float32),
+            dones=np.asarray([False, False]),
+            infos=(
+                _info(0, price=200.0),
+                _info(3, price=602.0),
+            ),
+        )
+        == 2
+    )
+    sampler.close()
+
+    items = read_training_telemetry(path, limit=20).items
+    environment_zero = [item for item in items if item.environment_id == 0]
+    environment_one = [item for item in items if item.environment_id == 1]
+
+    assert environment_zero[0].episode_id == environment_zero[1].episode_id
+    assert environment_zero[2].episode_id not in (
+        None,
+        environment_zero[1].episode_id,
+    )
+    assert len({item.episode_id for item in environment_one}) == 1
+    assert environment_zero[0].episode_id != environment_one[0].episode_id
+
+
+def test_terminal_transition_clears_visual_fallback_state_for_next_episode(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    sampler = TrainingTelemetrySampler(path, seed=5, sample_every=1)
+
+    assert (
+        sampler.consume(
+            global_step=1,
+            actions=np.asarray([[0.8]], dtype=np.float32),
+            rewards=np.asarray([0.0], dtype=np.float32),
+            dones=np.asarray([True]),
+            infos=(
+                _info(
+                    8,
+                    price=100.0,
+                    before=(0.2,),
+                    after=(0.8,),
+                    terminated=True,
+                ),
+            ),
+        )
+        == 1
+    )
+    assert (
+        sampler.consume(
+            global_step=2,
+            actions=np.asarray([[0.1]], dtype=np.float32),
+            rewards=np.asarray([0.0], dtype=np.float32),
+            dones=np.asarray([False]),
+            infos=(
+                _info(
+                    0,
+                    price=600.0,
+                    before=None,
+                    after=(0.1,),
+                    exact_market=False,
+                ),
+            ),
+        )
+        == 1
+    )
+    sampler.close()
+
+    first, second = read_training_telemetry(path, limit=10).items
+
+    assert second.episode_id not in (None, first.episode_id)
+    assert second.open == 600.0
+    assert second.close == 600.0
+    assert second.weights_before == (0.0,)
+
+
+def test_sampler_restart_does_not_reuse_existing_stream_episode_id(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    first_sampler = TrainingTelemetrySampler(path, seed=9, sample_every=1)
+
+    assert (
+        first_sampler.consume(
+            global_step=1,
+            actions=np.asarray([[0.1]], dtype=np.float32),
+            rewards=np.asarray([0.0], dtype=np.float32),
+            dones=np.asarray([False]),
+            infos=(_info(1),),
+        )
+        == 1
+    )
+    first_sampler.close()
+
+    resumed_sampler = TrainingTelemetrySampler(path, seed=9, sample_every=1)
+    assert (
+        resumed_sampler.consume(
+            global_step=2,
+            actions=np.asarray([[0.2]], dtype=np.float32),
+            rewards=np.asarray([0.0], dtype=np.float32),
+            dones=np.asarray([False]),
+            infos=(_info(2, price=101.0),),
+        )
+        == 1
+    )
+    resumed_sampler.close()
+
+    first, resumed = read_training_telemetry(path, limit=10).items
+
+    assert first.episode_id is not None
+    assert resumed.episode_id is not None
+    assert resumed.episode_id > first.episode_id
+    assert resumed.sequence == first.sequence + 1

--- a/tests/rl/test_environment_decision_service.py
+++ b/tests/rl/test_environment_decision_service.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from trade_rl.rl.actions import (
+    ActionMode,
+    ActionSpec,
+    BaselineResidualComposer,
+    ResidualAction,
+)
+from trade_rl.rl.environment_decision import (
+    EnvironmentDecisionPlanner,
+    EnvironmentDecisionRequest,
+)
+from trade_rl.strategies.trend import TrendTargets
+
+
+class _RegularDataset:
+    regular_cadence = True
+
+    @staticmethod
+    def bars_for_hours(hours: float) -> int:
+        return int(hours)
+
+    @staticmethod
+    def bars_until(start: int, hours: float, *, maximum_index: int) -> int:
+        del start, hours, maximum_index
+        raise AssertionError("regular cadence must not call bars_until")
+
+
+class _IrregularDataset:
+    regular_cadence = False
+
+    @staticmethod
+    def bars_for_hours(hours: float) -> int:
+        del hours
+        raise AssertionError("irregular cadence must not call bars_for_hours")
+
+    @staticmethod
+    def bars_until(start: int, hours: float, *, maximum_index: int) -> int:
+        assert start == 3
+        assert hours == 2.0
+        assert maximum_index == 9
+        return 4
+
+
+def _trends() -> TrendTargets:
+    return TrendTargets(
+        fast=np.array([0.4, -0.1]),
+        base=np.array([0.2, -0.1]),
+        slow=np.array([0.1, -0.2]),
+    )
+
+
+def _target_planner(*, delay: int = 0) -> EnvironmentDecisionPlanner:
+    return EnvironmentDecisionPlanner(
+        _RegularDataset(),
+        action_spec=ActionSpec(
+            mode=ActionMode.TARGET_WEIGHT,
+            risk_tilt_enabled=False,
+            target_weight_count=2,
+        ),
+        composer=BaselineResidualComposer(),
+        max_gross=1.0,
+        alpha_enabled=False,
+        accept_legacy_actions=False,
+        signal_delay_decisions=delay,
+        decision_every=2,
+        decision_hours=2.0,
+    )
+
+
+def _request(
+    action: np.ndarray,
+    *,
+    pending_hybrid: np.ndarray | None = None,
+    pending_shadow: np.ndarray | None = None,
+) -> EnvironmentDecisionRequest:
+    return EnvironmentDecisionRequest(
+        action=action,
+        trends=_trends(),
+        alpha=np.zeros(2),
+        factor_basis=np.empty((0, 2)),
+        hybrid_weights=np.array([0.05, -0.05]),
+        shadow_weights=np.array([0.1, -0.1]),
+        pending_hybrid_target=pending_hybrid,
+        pending_shadow_target=pending_shadow,
+        current_index=3,
+        end_index=9,
+    )
+
+
+def test_target_weight_plan_preserves_maintained_action_and_composes_target() -> None:
+    plan = _target_planner().plan(_request(np.array([1.4, -0.25])))
+
+    np.testing.assert_allclose(plan.maintained_action, np.array([1.0, -0.25]))
+    np.testing.assert_allclose(plan.submitted_hybrid_target, np.array([0.8, -0.2]))
+    np.testing.assert_allclose(plan.executed_hybrid_target, np.array([0.8, -0.2]))
+    np.testing.assert_allclose(plan.submitted_shadow_target, _trends().base)
+    assert plan.saturated_count == 1
+    assert plan.raw_max_abs == pytest.approx(1.4)
+    assert plan.execution_delay_warmup is False
+    assert plan.bars == 2
+
+
+def test_signal_delay_warmup_executes_current_weights_and_queues_submission() -> None:
+    plan = _target_planner(delay=1).plan(_request(np.array([0.3, -0.2])))
+
+    np.testing.assert_allclose(plan.executed_hybrid_target, np.array([0.05, -0.05]))
+    np.testing.assert_allclose(plan.executed_shadow_target, np.array([0.1, -0.1]))
+    np.testing.assert_allclose(plan.next_pending_hybrid_target, np.array([0.3, -0.2]))
+    np.testing.assert_allclose(plan.next_pending_shadow_target, _trends().base)
+    assert plan.execution_delay_warmup is True
+
+
+def test_signal_delay_executes_previous_pending_targets() -> None:
+    pending_hybrid = np.array([-0.2, 0.4])
+    pending_shadow = np.array([0.05, -0.05])
+
+    plan = _target_planner(delay=1).plan(
+        _request(
+            np.array([0.3, -0.2]),
+            pending_hybrid=pending_hybrid,
+            pending_shadow=pending_shadow,
+        )
+    )
+
+    np.testing.assert_allclose(plan.executed_hybrid_target, pending_hybrid)
+    np.testing.assert_allclose(plan.executed_shadow_target, pending_shadow)
+    assert plan.execution_delay_warmup is False
+    assert plan.executed_hybrid_target is not pending_hybrid
+    assert plan.executed_shadow_target is not pending_shadow
+
+
+def test_legacy_action_is_migrated_to_maintained_layout() -> None:
+    planner = EnvironmentDecisionPlanner(
+        _RegularDataset(),
+        action_spec=ActionSpec(alpha_enabled=True),
+        composer=BaselineResidualComposer(),
+        max_gross=1.0,
+        alpha_enabled=True,
+        accept_legacy_actions=True,
+        signal_delay_decisions=0,
+        decision_every=2,
+        decision_hours=2.0,
+    )
+
+    plan = planner.plan(
+        EnvironmentDecisionRequest(
+            action=np.array([0.5, 0.25]),
+            trends=_trends(),
+            alpha=np.array([0.3, -0.3]),
+            factor_basis=np.empty((0, 2)),
+            hybrid_weights=np.zeros(2),
+            shadow_weights=np.zeros(2),
+            pending_hybrid_target=None,
+            pending_shadow_target=None,
+            current_index=3,
+            end_index=9,
+        )
+    )
+
+    assert isinstance(plan.parsed_action, ResidualAction)
+    np.testing.assert_allclose(plan.maintained_action, np.array([0.5, 0.0, 0.0, 0.25]))
+
+
+def test_irregular_calendar_uses_dataset_bar_boundary() -> None:
+    planner = EnvironmentDecisionPlanner(
+        _IrregularDataset(),
+        action_spec=ActionSpec(
+            mode=ActionMode.TARGET_WEIGHT,
+            risk_tilt_enabled=False,
+            target_weight_count=2,
+        ),
+        composer=BaselineResidualComposer(),
+        max_gross=1.0,
+        alpha_enabled=False,
+        accept_legacy_actions=False,
+        signal_delay_decisions=0,
+        decision_every=None,
+        decision_hours=2.0,
+    )
+
+    assert planner.decision_bar_count(current_index=3, end_index=9) == 4
+
+
+def test_decision_bar_count_fails_after_episode_end() -> None:
+    with pytest.raises(RuntimeError, match="step called after the episode ended"):
+        _target_planner().decision_bar_count(current_index=9, end_index=9)

--- a/tests/rl/test_environment_info_service.py
+++ b/tests/rl/test_environment_info_service.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from trade_rl.rl.environment_info import (
+    EnvironmentInfoBuilder,
+    EnvironmentStepInfoRequest,
+    EnvironmentTerminalInfoRequest,
+)
+from trade_rl.rl.rewards import RewardBreakdown, RewardConfig, RewardContext
+from trade_rl.simulation.accounting import BookState
+
+
+class _Dataset:
+    periods_per_year = 365
+
+
+class _RewardTracker:
+    config = RewardConfig(baseline_underperformance_weight=0.1)
+    last_context_before = RewardContext(
+        rolling_hybrid_log_growth=0.01,
+        rolling_shadow_log_growth=0.02,
+        baseline_shortfall=0.01,
+        baseline_tolerance=0.015,
+        baseline_penalty=0.0,
+        hybrid_drawdown=0.1,
+        drawdown_severity=0.05,
+        history_bars=3,
+    )
+    last_context_after = RewardContext(
+        rolling_hybrid_log_growth=0.03,
+        rolling_shadow_log_growth=0.025,
+        baseline_shortfall=0.0,
+        baseline_tolerance=0.015,
+        baseline_penalty=0.0,
+        hybrid_drawdown=0.08,
+        drawdown_severity=0.03,
+        history_bars=4,
+    )
+
+
+def _reward() -> RewardBreakdown:
+    return RewardBreakdown(
+        absolute_log_growth=0.02,
+        excess_log_growth=0.01,
+        incremental_drawdown=0.03,
+        rolling_baseline_underperformance=0.0,
+        projection_distance=0.4,
+        terminal_equity_shortfall=0.0,
+        margin_deficit=0.0,
+        absolute_component=0.02,
+        excess_component=0.0,
+        drawdown_penalty=0.004,
+        baseline_penalty=0.002,
+        projection_penalty=0.0,
+        terminal_penalty=0.0,
+        margin_penalty=0.0,
+        unscaled_total=0.014,
+        scaled_total=1.4,
+    )
+
+
+def _book(*, cash: float = 100.0) -> BookState:
+    book = BookState.zero(2, 100.0, np.array([10.0, 20.0]))
+    book.cash = cash
+    return book
+
+
+def _execution() -> SimpleNamespace:
+    return SimpleNamespace(
+        bars_advanced=2,
+        interval_cost=0.5,
+        interval_funding=-0.1,
+        interval_gross_return=0.03,
+        interval_net_return=0.02,
+    )
+
+
+def _step_request(**overrides: object) -> EnvironmentStepInfoRequest:
+    values: dict[str, object] = {
+        "action_delta_l1": 0.3,
+        "raw_max_abs": 1.2,
+        "saturated_count": 1,
+        "composition": SimpleNamespace(proposal=np.array([0.4, -0.2])),
+        "decision_step_index": 4,
+        "hybrid_log_return": 0.02,
+        "shadow_log_return": 0.01,
+        "emergency_deleverage": False,
+        "execution_delay_warmup": True,
+        "submitted_target": np.array([0.4, -0.2]),
+        "executed_target": np.array([0.1, -0.1]),
+        "hybrid": _book(cash=95.0),
+        "reward_breakdown": _reward(),
+        "hybrid_execution": _execution(),
+        "hybrid_risk": SimpleNamespace(projection_l1=0.4),
+        "hybrid_terminated": False,
+        "shadow_execution": _execution(),
+        "shadow_risk": SimpleNamespace(projection_l1=0.0),
+        "shadow_terminated": False,
+        "liquidation_complete": True,
+        "liquidation_terminal": False,
+        "termination_reason": None,
+        "terminal_accounting_mode": "mark_to_market",
+        "terminal_liquidation_cost": 0.0,
+        "pending_target_discarded": False,
+        "discarded_pending_target": None,
+        "hybrid_liquidation": None,
+        "shadow_liquidation": None,
+    }
+    values.update(overrides)
+    return EnvironmentStepInfoRequest(**values)  # type: ignore[arg-type]
+
+
+def test_step_info_preserves_complete_stable_key_set() -> None:
+    builder = EnvironmentInfoBuilder(_Dataset(), _RewardTracker())
+
+    info = builder.step_info(_step_request())
+
+    assert set(info) == {
+        "action_delta_l1",
+        "action_raw_max_abs",
+        "action_saturated_count",
+        "bars_advanced",
+        "composition",
+        "decision_step_index",
+        "excess_log_return",
+        "emergency_deleverage",
+        "execution_delay_warmup",
+        "submitted_target",
+        "executed_target",
+        "drawdown_after",
+        "portfolio_value_after",
+        "reward_growth_raw",
+        "reward_baseline_penalty_delta",
+        "reward_baseline_penalty_weighted",
+        "reward_drawdown_penalty_delta",
+        "reward_drawdown_penalty_weighted",
+        "reward_total_raw",
+        "reward_total_scaled",
+        "reward_context_before",
+        "reward_context_after",
+        "rolling_hybrid_log_growth",
+        "rolling_baseline_log_growth",
+        "rolling_growth_gap",
+        "hybrid_execution",
+        "hybrid_risk",
+        "hybrid_terminated",
+        "interval_cost",
+        "interval_funding",
+        "interval_gross_return",
+        "interval_net_return",
+        "liquidation_complete",
+        "liquidation_terminal",
+        "projection_distance_l1",
+        "reward_breakdown",
+        "shadow_execution",
+        "shadow_interval_net_return",
+        "shadow_risk",
+        "shadow_terminated",
+        "termination_reason",
+        "terminal_accounting_mode",
+        "terminal_liquidation_cost",
+        "pending_target_discarded",
+    }
+    assert info["reward_baseline_penalty_delta"] == 0.02
+    assert info["rolling_growth_gap"] == pytest.approx(0.005)
+
+
+def test_step_info_copies_targets_and_adds_optional_fields() -> None:
+    submitted = np.array([0.4, -0.2])
+    executed = np.array([0.1, -0.1])
+    discarded = np.array([0.2, 0.0])
+    hybrid_liquidation = object()
+    shadow_liquidation = object()
+    builder = EnvironmentInfoBuilder(_Dataset(), _RewardTracker())
+
+    info = builder.step_info(
+        _step_request(
+            submitted_target=submitted,
+            executed_target=executed,
+            discarded_pending_target=discarded,
+            hybrid_liquidation=hybrid_liquidation,
+            shadow_liquidation=shadow_liquidation,
+        )
+    )
+
+    np.testing.assert_allclose(info["submitted_target"], submitted)
+    np.testing.assert_allclose(info["executed_target"], executed)
+    np.testing.assert_allclose(info["discarded_pending_target"], discarded)
+    assert info["submitted_target"] is not submitted
+    assert info["executed_target"] is not executed
+    assert info["discarded_pending_target"] is not discarded
+    assert info["hybrid_liquidation"] is hybrid_liquidation
+    assert info["shadow_liquidation"] is shadow_liquidation
+
+
+def test_terminal_info_builds_metrics_and_diagnostics() -> None:
+    hybrid = _book()
+    shadow = _book()
+    hybrid.returns_history.extend([0.01, -0.005])
+    shadow.returns_history.extend([0.005, -0.002])
+    hybrid.turnover_total = 0.4
+    shadow.turnover_total = 0.2
+    hybrid.total_cost = 0.01
+    shadow.total_cost = 0.005
+    diagnostics = object()
+    builder = EnvironmentInfoBuilder(_Dataset(), _RewardTracker())
+
+    info = builder.terminal_info(
+        EnvironmentTerminalInfoRequest(
+            episode_hours=48.0,
+            episode_seed=7,
+            action_diagnostics=diagnostics,
+            hybrid=hybrid,
+            shadow=shadow,
+            initial_state_mode="cash",
+        )
+    )
+
+    assert info["episode_hours"] == 48.0
+    assert info["episode_seed"] == 7
+    assert info["action_diagnostics"] is diagnostics
+    assert info["initial_state_mode"] == "cash"
+    assert info["hybrid_metrics"].turnover_total == 0.4
+    assert info["shadow_metrics"].turnover_total == 0.2
+    assert info["excess_total_return"] == (
+        info["hybrid_metrics"].total_return - info["shadow_metrics"].total_return
+    )

--- a/tests/rl/test_environment_reward_service.py
+++ b/tests/rl/test_environment_reward_service.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from trade_rl.rl.environment_reward import (
+    EnvironmentRewardCoordinator,
+    EnvironmentRewardRequest,
+)
+from trade_rl.rl.rewards import RewardBreakdown
+from trade_rl.simulation.accounting import BookState
+
+
+def _breakdown() -> RewardBreakdown:
+    return RewardBreakdown(
+        absolute_log_growth=0.01,
+        excess_log_growth=0.005,
+        incremental_drawdown=0.0,
+        rolling_baseline_underperformance=0.0,
+        projection_distance=0.2,
+        terminal_equity_shortfall=0.0,
+        margin_deficit=0.05,
+        absolute_component=0.01,
+        excess_component=0.0,
+        drawdown_penalty=0.0,
+        baseline_penalty=0.0,
+        projection_penalty=0.0,
+        terminal_penalty=0.0,
+        margin_penalty=0.05,
+        unscaled_total=-0.04,
+        scaled_total=-4.0,
+    )
+
+
+class _RecordingTracker:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.result = _breakdown()
+
+    def step(self, **kwargs: Any) -> RewardBreakdown:
+        self.calls.append(kwargs)
+        return self.result
+
+
+def _book(*, cash: float, peak: float, margin_deficit: float = 0.0) -> BookState:
+    book = BookState.zero(2, 100.0, np.array([10.0, 20.0]))
+    book.cash = cash
+    book.peak_value = peak
+    book.margin_deficit = margin_deficit
+    return book
+
+
+def test_reward_coordinator_maps_books_to_tracker_inputs() -> None:
+    tracker = _RecordingTracker()
+    coordinator = EnvironmentRewardCoordinator(tracker, initial_capital=100.0)
+    hybrid = _book(cash=50.0, peak=100.0, margin_deficit=5.0)
+    shadow = _book(cash=80.0, peak=100.0)
+
+    result = coordinator.step(
+        EnvironmentRewardRequest(
+            hybrid_log_return=0.01,
+            shadow_log_return=0.005,
+            hybrid=hybrid,
+            shadow=shadow,
+            projection_distance=0.2,
+            hybrid_terminated=True,
+            shadow_terminated=False,
+        )
+    )
+
+    assert result is tracker.result
+    assert tracker.calls == [
+        {
+            "hybrid_log_return": 0.01,
+            "shadow_log_return": 0.005,
+            "hybrid_drawdown": 0.5,
+            "shadow_drawdown": pytest.approx(0.2),
+            "projection_distance": 0.2,
+            "hybrid_margin_deficit_fraction": 0.05,
+            "hybrid_equity_fraction": 0.5,
+            "shadow_equity_fraction": 0.8,
+            "hybrid_terminated": True,
+            "shadow_terminated": False,
+        }
+    ]
+
+
+def test_reward_coordinator_clamps_negative_equity_fraction_to_zero() -> None:
+    tracker = _RecordingTracker()
+    coordinator = EnvironmentRewardCoordinator(tracker, initial_capital=100.0)
+    hybrid = _book(cash=-1.0, peak=100.0)
+    shadow = _book(cash=100.0, peak=100.0)
+
+    coordinator.step(
+        EnvironmentRewardRequest(
+            hybrid_log_return=-0.1,
+            shadow_log_return=0.0,
+            hybrid=hybrid,
+            shadow=shadow,
+            projection_distance=0.0,
+            hybrid_terminated=True,
+            shadow_terminated=False,
+        )
+    )
+
+    assert tracker.calls[0]["hybrid_equity_fraction"] == 0.0
+    assert tracker.calls[0]["hybrid_drawdown"] == 1.0
+
+
+def test_reward_coordinator_requires_positive_initial_capital() -> None:
+    with pytest.raises(ValueError, match="initial_capital must be positive"):
+        EnvironmentRewardCoordinator(_RecordingTracker(), initial_capital=0.0)

--- a/tests/rl/test_environment_risk_service.py
+++ b/tests/rl/test_environment_risk_service.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from trade_rl.risk.inputs import PortfolioRiskInputs
+from trade_rl.risk.portfolio import PortfolioRiskConfig, PortfolioRiskModel
+from trade_rl.risk.pretrade import PreTradeRisk, PreTradeRiskConfig
+from trade_rl.rl.environment_risk import (
+    EnvironmentRiskProjector,
+    EnvironmentRiskRequest,
+)
+from trade_rl.simulation.accounting import BookState
+
+
+class _Dataset:
+    n_symbols = 2
+    close = np.array([[10.0, 20.0], [11.0, 25.0]])
+    volume = np.array([[100.0, 5.0], [120.0, 4.0]])
+    volume_units = ("quote_notional", "base_units")
+
+
+class _EmergencyMonitor:
+    def __init__(self, *, flatten: tuple[bool, bool], reasons: tuple[str, ...]) -> None:
+        self.flatten = np.asarray(flatten, dtype=np.bool_)
+        self.reasons = reasons
+
+    def assess(
+        self,
+        dataset: object,
+        *,
+        index: int,
+        weights: np.ndarray,
+    ) -> SimpleNamespace:
+        assert dataset is not None
+        assert index == 1
+        assert weights.shape == (2,)
+        return SimpleNamespace(flatten_mask=self.flatten, reasons=self.reasons)
+
+
+class _AdvancedProvider:
+    identity_digest = "0" * 64
+    minimum_index = 1
+
+    def __init__(self) -> None:
+        self.calls: list[int] = []
+
+    def inputs(self, dataset: object, *, index: int) -> PortfolioRiskInputs:
+        assert dataset is not None
+        self.calls.append(index)
+        return PortfolioRiskInputs(
+            covariance=np.eye(2) * 0.04,
+            beta=np.array([1.0, -0.5]),
+            stress_losses=np.array([-0.2, -0.1]),
+            as_of_index=index,
+            provider_digest=self.identity_digest,
+            observation_count=10,
+        )
+
+
+def _book() -> BookState:
+    return BookState.from_weights(
+        weights=np.array([0.2, -0.2]),
+        capital=100.0,
+        prices=np.array([11.0, 25.0]),
+        max_gross=1.0,
+    )
+
+
+def test_market_notional_respects_quote_and_base_volume_units() -> None:
+    projector = EnvironmentRiskProjector(
+        _Dataset(),
+        emergency_risk_monitor=_EmergencyMonitor(flatten=(False, False), reasons=()),
+        pre_trade_risk=PreTradeRisk(),
+        portfolio_risk=PortfolioRiskModel(),
+        portfolio_risk_inputs_provider=None,
+    )
+
+    np.testing.assert_allclose(projector.market_notional(1), np.array([120.0, 100.0]))
+
+
+def test_projection_preserves_reason_order_and_projection_distance() -> None:
+    projector = EnvironmentRiskProjector(
+        _Dataset(),
+        emergency_risk_monitor=_EmergencyMonitor(
+            flatten=(False, True),
+            reasons=("market_halt",),
+        ),
+        pre_trade_risk=PreTradeRisk(
+            PreTradeRiskConfig(
+                max_gross=1.0,
+                max_abs_weight=0.4,
+                max_turnover=2.0,
+            )
+        ),
+        portfolio_risk=PortfolioRiskModel(PortfolioRiskConfig(max_net_exposure=0.2)),
+        portfolio_risk_inputs_provider=None,
+    )
+
+    result = projector.project(
+        EnvironmentRiskRequest(
+            proposal=np.array([0.8, 0.3]),
+            book=_book(),
+            current_index=1,
+        )
+    )
+
+    np.testing.assert_allclose(result.weights, np.array([0.2, 0.0]))
+    assert result.reasons == (
+        "emergency_flatten",
+        "max_abs_weight",
+        "emergency_turnover_override",
+        "market_halt",
+        "portfolio:max_net_exposure",
+    )
+    assert result.projection_l1 == pytest.approx(0.9)
+    assert result.was_constrained is True
+
+
+@pytest.mark.parametrize(
+    "proposal",
+    [np.array([0.1]), np.array([0.1, np.nan])],
+)
+def test_projection_rejects_invalid_proposals(proposal: np.ndarray) -> None:
+    projector = EnvironmentRiskProjector(
+        _Dataset(),
+        emergency_risk_monitor=_EmergencyMonitor(flatten=(False, False), reasons=()),
+        pre_trade_risk=PreTradeRisk(),
+        portfolio_risk=PortfolioRiskModel(),
+        portfolio_risk_inputs_provider=None,
+    )
+
+    with pytest.raises(ValueError, match="proposal does not match dataset symbols"):
+        projector.project(
+            EnvironmentRiskRequest(
+                proposal=proposal,
+                book=_book(),
+                current_index=1,
+            )
+        )
+
+
+def test_advanced_risk_fails_closed_without_causal_provider() -> None:
+    projector = EnvironmentRiskProjector(
+        _Dataset(),
+        emergency_risk_monitor=_EmergencyMonitor(flatten=(False, False), reasons=()),
+        pre_trade_risk=PreTradeRisk(),
+        portfolio_risk=PortfolioRiskModel(PortfolioRiskConfig(volatility_target=0.1)),
+        portfolio_risk_inputs_provider=None,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="advanced portfolio risk requires a causal input provider",
+    ):
+        projector.project(
+            EnvironmentRiskRequest(
+                proposal=np.array([0.2, -0.1]),
+                book=_book(),
+                current_index=1,
+            )
+        )
+
+
+def test_advanced_risk_uses_inputs_from_current_index() -> None:
+    provider = _AdvancedProvider()
+    projector = EnvironmentRiskProjector(
+        _Dataset(),
+        emergency_risk_monitor=_EmergencyMonitor(flatten=(False, False), reasons=()),
+        pre_trade_risk=PreTradeRisk(
+            PreTradeRiskConfig(max_abs_weight=1.0, max_turnover=2.0)
+        ),
+        portfolio_risk=PortfolioRiskModel(
+            PortfolioRiskConfig(
+                volatility_target=0.1,
+                max_abs_beta=0.2,
+                max_stress_loss=0.03,
+            )
+        ),
+        portfolio_risk_inputs_provider=provider,
+    )
+
+    result = projector.project(
+        EnvironmentRiskRequest(
+            proposal=np.array([0.5, -0.25]),
+            book=_book(),
+            current_index=1,
+        )
+    )
+
+    assert provider.calls == [1]
+    assert any(reason.startswith("portfolio:") for reason in result.reasons)

--- a/tests/studio/test_telemetry_api.py
+++ b/tests/studio/test_telemetry_api.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import json
+import os
 from pathlib import Path
+from uuid import UUID
 
 from trade_rl.telemetry.training import TrainingTelemetryRecord, TrainingTelemetryWriter
 
@@ -79,7 +82,10 @@ def test_telemetry_status_and_cursor_page_are_scoped_to_known_job(
     )
 
     assert status.status_code == 200
-    assert status.json() == {
+    status_payload = status.json()
+    generation = status_payload.pop("streamGeneration")
+    assert str(UUID(generation)) == generation
+    assert status_payload == {
         "available": True,
         "selectedSeed": 7,
         "availableSeeds": [7],
@@ -94,6 +100,8 @@ def test_telemetry_status_and_cursor_page_are_scoped_to_known_job(
     assert [item["sequence"] for item in page.json()["items"]] == [2]
     assert page.json()["nextSequence"] == 2
     assert page.json()["truncated"] is False
+    assert page.json()["streamGeneration"] == generation
+    assert page.json()["resetRequired"] is False
 
 
 def test_telemetry_can_select_independent_seed_streams(tmp_path: Path) -> None:
@@ -146,6 +154,7 @@ def test_telemetry_reports_unavailable_and_rejects_unknown_job(tmp_path: Path) -
     assert unavailable.json()["selectedSeed"] is None
     assert unavailable.json()["availableSeeds"] == []
     assert unavailable.json()["source"] is None
+    assert unavailable.json()["streamGeneration"] is None
     assert missing.status_code == 404
     assert missing.json()["detail"]["code"] == "resource_not_found"
 
@@ -167,3 +176,62 @@ def test_telemetry_rejects_multiple_streams_for_one_seed(tmp_path: Path) -> None
 
     assert response.status_code != 200
     assert response.json()["detail"]["code"] == "artifact_invalid"
+
+
+def test_old_stream_generation_requests_reset_without_returning_records(
+    tmp_path: Path,
+) -> None:
+    api, _, catalog, _ = client(tmp_path)
+    created = api.post(
+        "/api/studio/jobs/training",
+        json=request(catalog, run_id="live-reset").model_dump(by_alias=True),
+    ).json()
+    stream = stream_path(tmp_path, "live-reset", 7)
+    with TrainingTelemetryWriter(stream, flush_every=1) as writer:
+        writer.append(record(1))
+        writer.append(record(2))
+    old_generation = api.get(
+        f"/api/studio/jobs/{created['id']}/telemetry/status"
+    ).json()["streamGeneration"]
+
+    replacement = tmp_path / "replacement.jsonl"
+    replacement.write_text(
+        json.dumps(record(1).to_json_dict(), sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(replacement, stream)
+
+    response = api.get(
+        f"/api/studio/jobs/{created['id']}/telemetry/events",
+        params={
+            "seed": 7,
+            "after_sequence": 2,
+            "limit": 10,
+            "stream_generation": old_generation,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["items"] == []
+    assert payload["nextSequence"] == 0
+    assert payload["resetRequired"] is True
+    assert payload["streamGeneration"] != old_generation
+    assert str(UUID(payload["streamGeneration"])) == payload["streamGeneration"]
+
+
+def test_telemetry_events_reject_invalid_stream_generation(tmp_path: Path) -> None:
+    api, _, catalog, _ = client(tmp_path)
+    created = api.post(
+        "/api/studio/jobs/training",
+        json=request(catalog, run_id="live-invalid-generation").model_dump(
+            by_alias=True
+        ),
+    ).json()
+
+    response = api.get(
+        f"/api/studio/jobs/{created['id']}/telemetry/events",
+        params={"stream_generation": "not-a-uuid"},
+    )
+
+    assert response.status_code == 422

--- a/tests/studio/test_telemetry_episode_api.py
+++ b/tests/studio/test_telemetry_episode_api.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+
+from .test_api import client
+from .test_jobs import request
+from .test_telemetry_api import record, stream_path
+
+
+def test_telemetry_api_exposes_explicit_and_legacy_episode_identity(
+    tmp_path: Path,
+) -> None:
+    api, _, catalog, _ = client(tmp_path)
+    created = api.post(
+        "/api/studio/jobs/training",
+        json=request(catalog, run_id="live-episode-api").model_dump(by_alias=True),
+    ).json()
+    stream = stream_path(tmp_path, "live-episode-api", 7)
+    stream.parent.mkdir(parents=True, exist_ok=True)
+
+    explicit = replace(record(1), episode_id=5).to_json_dict()
+    legacy = record(2).to_json_dict()
+    legacy.pop("episode_id")
+    stream.write_text(
+        "\n".join(
+            (
+                json.dumps(explicit, sort_keys=True, separators=(",", ":")),
+                json.dumps(legacy, sort_keys=True, separators=(",", ":")),
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    response = api.get(
+        f"/api/studio/jobs/{created['id']}/telemetry/events",
+        params={"seed": 7, "limit": 10},
+    )
+
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert [item["sequence"] for item in items] == [1, 2]
+    assert [item["episodeId"] for item in items] == [5, None]

--- a/tests/telemetry/test_episode_identity_contract.py
+++ b/tests/telemetry/test_episode_identity_contract.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pytest
+
+from trade_rl.telemetry import TrainingTelemetryRecord
+
+
+def _record(sequence: int, *, episode_id: int | None = None) -> TrainingTelemetryRecord:
+    values: dict[str, object] = {
+        "sequence": sequence,
+        "recorded_at": "2026-07-22T12:00:00+00:00",
+        "global_step": sequence * 32,
+        "environment_step": sequence,
+        "seed": 7,
+        "environment_id": 0,
+        "event_type": "rollout",
+        "market_index": 100 + sequence,
+        "market_time": "2026-07-22T11:55:00.000000000",
+        "symbol": "BTCUSDT",
+        "open": 67_500.0,
+        "high": 67_900.0,
+        "low": 67_400.0,
+        "close": 67_842.3,
+        "action": (0.4,),
+        "executed_target": (0.4,),
+        "weights_before": (0.2,),
+        "weights_after": (0.4,),
+        "portfolio_value": 101_342.85,
+        "baseline_portfolio_value": 100_400.0,
+        "reward": 0.214,
+        "drawdown": 0.0086,
+        "interval_cost": 4.25,
+        "interval_return": 0.0012,
+        "risk_reasons": (),
+        "emergency_deleverage": False,
+        "terminated": False,
+        "truncated": False,
+    }
+    if episode_id is not None:
+        values["episode_id"] = episode_id
+    return TrainingTelemetryRecord(**values)  # type: ignore[arg-type]
+
+
+def test_episode_id_round_trip_is_explicit() -> None:
+    original = _record(1, episode_id=9)
+
+    restored = TrainingTelemetryRecord.from_json_dict(original.to_json_dict())
+
+    assert restored.episode_id == 9
+    assert original.to_json_dict()["episode_id"] == 9
+
+
+def test_legacy_record_without_episode_id_remains_readable() -> None:
+    payload = _record(1).to_json_dict()
+    payload.pop("episode_id", None)
+
+    restored = TrainingTelemetryRecord.from_json_dict(payload)
+
+    assert restored.episode_id is None
+
+
+@pytest.mark.parametrize("episode_id", (-1, True))
+def test_invalid_episode_id_fails_closed(episode_id: object) -> None:
+    payload = _record(1).to_json_dict()
+    payload["episode_id"] = episode_id
+
+    with pytest.raises(ValueError, match="episode_id"):
+        TrainingTelemetryRecord.from_json_dict(payload)

--- a/tests/telemetry/test_indexed_process_concurrency.py
+++ b/tests/telemetry/test_indexed_process_concurrency.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import json
+import multiprocessing
+import os
+import time
+from pathlib import Path
+from queue import Empty
+from typing import Any
+
+import pytest
+
+from trade_rl.telemetry import (
+    TrainingTelemetryRecord,
+    TrainingTelemetryWriter,
+    read_training_telemetry,
+    training_telemetry_status,
+)
+
+
+def _record(sequence: int) -> TrainingTelemetryRecord:
+    return TrainingTelemetryRecord(
+        sequence=sequence,
+        recorded_at="2026-07-22T09:00:00+00:00",
+        global_step=sequence * 32,
+        environment_step=sequence,
+        seed=7,
+        environment_id=0,
+        event_type="rollout",
+        market_index=100 + sequence,
+        market_time="2026-07-22T08:55:00.000000000",
+        symbol="BTCUSDT",
+        open=67_500.0,
+        high=67_900.0,
+        low=67_400.0,
+        close=67_842.3,
+        action=(0.4,),
+        executed_target=(0.4,),
+        weights_before=(0.2,),
+        weights_after=(0.4,),
+        portfolio_value=101_342.85,
+        baseline_portfolio_value=100_400.0,
+        reward=0.214,
+        drawdown=0.0086,
+        interval_cost=4.25,
+        interval_return=0.0012,
+        risk_reasons=(),
+        emergency_deleverage=False,
+        terminated=False,
+        truncated=False,
+    )
+
+
+def _duplicate_writer_worker(
+    path_value: str,
+    ready: Any,
+    start: Any,
+    results: Any,
+) -> None:
+    writer: TrainingTelemetryWriter | None = None
+    try:
+        writer = TrainingTelemetryWriter(Path(path_value), flush_every=1)
+        ready.put(("ready", os.getpid()))
+        if not start.wait(timeout=20.0):
+            results.put(("error", "TimeoutError", "start event was not released"))
+            return
+        writer.append(_record(1))
+        writer.flush()
+        results.put(("ok", os.getpid(), ""))
+    except BaseException as error:  # pragma: no cover - asserted in parent process
+        results.put(("error", type(error).__name__, str(error)))
+    finally:
+        if writer is not None:
+            writer.close()
+
+
+def _ordered_writer_worker(
+    path_value: str,
+    start: Any,
+    results: Any,
+    count: int,
+) -> None:
+    try:
+        if not start.wait(timeout=20.0):
+            raise TimeoutError("start event was not released")
+        with TrainingTelemetryWriter(Path(path_value), flush_every=1) as writer:
+            for sequence in range(1, count + 1):
+                writer.append(_record(sequence))
+                if sequence % 4 == 0:
+                    time.sleep(0.001)
+        results.put(("writer", "ok", count))
+    except BaseException as error:  # pragma: no cover - asserted in parent process
+        results.put(("writer", type(error).__name__, str(error)))
+
+
+def _reader_worker(
+    path_value: str,
+    start: Any,
+    results: Any,
+    iterations: int,
+) -> None:
+    path = Path(path_value)
+    try:
+        if not start.wait(timeout=20.0):
+            raise TimeoutError("start event was not released")
+        last_seen = 0
+        for _ in range(iterations):
+            status = training_telemetry_status(path)
+            page = read_training_telemetry(path, after_sequence=0, limit=2_000)
+            sequences = [record.sequence for record in page.items]
+            if sequences != sorted(set(sequences)):
+                raise AssertionError("reader observed duplicate or unordered sequences")
+            if status.available and status.last_sequence < last_seen:
+                raise AssertionError("status last_sequence regressed")
+            last_seen = max(last_seen, status.last_sequence)
+            time.sleep(0.001)
+        results.put(("reader", "ok", last_seen))
+    except BaseException as error:  # pragma: no cover - asserted in parent process
+        results.put(("reader", type(error).__name__, str(error)))
+
+
+def _context() -> multiprocessing.context.SpawnContext:
+    return multiprocessing.get_context("spawn")
+
+
+def _join(processes: list[multiprocessing.Process], *, timeout: float = 30.0) -> None:
+    deadline = time.monotonic() + timeout
+    for process in processes:
+        process.join(timeout=max(0.0, deadline - time.monotonic()))
+    for process in processes:
+        if process.is_alive():
+            process.terminate()
+            process.join(timeout=5.0)
+            pytest.fail(f"process {process.pid} did not terminate")
+        assert process.exitcode == 0
+
+
+def _queue_items(queue: Any, expected: int) -> list[tuple[object, ...]]:
+    items: list[tuple[object, ...]] = []
+    for _ in range(expected):
+        try:
+            items.append(tuple(queue.get(timeout=10.0)))
+        except Empty:
+            pytest.fail(f"expected {expected} process results, received {len(items)}")
+    return items
+
+
+def test_duplicate_sequence_race_allows_exactly_one_process_append(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    context = _context()
+    ready = context.Queue()
+    start = context.Event()
+    results = context.Queue()
+    processes = [
+        context.Process(
+            target=_duplicate_writer_worker,
+            args=(str(path), ready, start, results),
+        )
+        for _ in range(2)
+    ]
+
+    for process in processes:
+        process.start()
+    ready_items = _queue_items(ready, 2)
+    assert all(item[0] == "ready" for item in ready_items)
+    start.set()
+    _join(processes)
+    outcomes = _queue_items(results, 2)
+
+    successful = [item for item in outcomes if item[0] == "ok"]
+    rejected = [item for item in outcomes if item[0] == "error"]
+    assert len(successful) == 1
+    assert len(rejected) == 1
+    assert rejected[0][1] == "ValueError"
+    assert "strictly increase" in str(rejected[0][2])
+
+    page = read_training_telemetry(path, after_sequence=0, limit=10)
+    status = training_telemetry_status(path)
+    assert [item.sequence for item in page.items] == [1]
+    assert status.record_count == 1
+    assert status.last_sequence == 1
+
+
+def test_append_fails_closed_when_stream_has_incomplete_tail(tmp_path: Path) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    path.write_bytes(
+        (json.dumps(_record(1).to_json_dict(), sort_keys=True) + "\n").encode("utf-8")
+        + b'{"schema_version":"training_telemetry_v1"'
+    )
+
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        with pytest.raises(RuntimeError, match="incomplete trailing record"):
+            writer.append(_record(2))
+
+    page = read_training_telemetry(path, after_sequence=0, limit=10)
+    assert [item.sequence for item in page.items] == [1]
+
+
+def test_concurrent_readers_observe_consistent_index_snapshots(tmp_path: Path) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    context = _context()
+    start = context.Event()
+    results = context.Queue()
+    count = 96
+    readers = 4
+    processes = [
+        context.Process(
+            target=_ordered_writer_worker,
+            args=(str(path), start, results, count),
+        ),
+        *[
+            context.Process(
+                target=_reader_worker,
+                args=(str(path), start, results, 80),
+            )
+            for _ in range(readers)
+        ],
+    ]
+
+    for process in processes:
+        process.start()
+    start.set()
+    _join(processes, timeout=60.0)
+    outcomes = _queue_items(results, readers + 1)
+
+    assert all(item[1] == "ok" for item in outcomes), outcomes
+    status = training_telemetry_status(path)
+    page = read_training_telemetry(path, after_sequence=0, limit=2_000)
+    index_path = path.with_name(f"{path.name}.index.json")
+    index_payload = json.loads(index_path.read_text(encoding="utf-8"))
+
+    assert status.record_count == count
+    assert status.last_sequence == count
+    assert [item.sequence for item in page.items] == list(range(1, count + 1))
+    assert index_payload["record_count"] == count
+    assert index_payload["last_sequence"] == count
+    assert index_payload["indexed_size"] == path.stat().st_size
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows prevents replacing an open file")
+def test_append_fails_closed_when_stream_identity_is_replaced(tmp_path: Path) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    replacement = tmp_path / "replacement.jsonl"
+    writer = TrainingTelemetryWriter(path, flush_every=1)
+    try:
+        writer.append(_record(1))
+        replacement.write_text(
+            json.dumps(_record(1).to_json_dict(), sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        os.replace(replacement, path)
+
+        with pytest.raises(RuntimeError, match="stream identity changed"):
+            writer.append(_record(2))
+    finally:
+        writer.close()
+
+    page = read_training_telemetry(path, after_sequence=0, limit=10)
+    assert [item.sequence for item in page.items] == [1]

--- a/tests/telemetry/test_training.py
+++ b/tests/telemetry/test_training.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import os
+import threading
 from pathlib import Path
 
 import pytest
@@ -11,6 +13,7 @@ from trade_rl.telemetry import (
     read_training_telemetry,
     training_telemetry_status,
 )
+from trade_rl.telemetry import indexed_training as indexed
 
 
 def record(sequence: int, *, event_type: str = "rollout") -> TrainingTelemetryRecord:
@@ -173,4 +176,195 @@ def test_index_rebuilds_after_stream_replacement(tmp_path: Path) -> None:
     assert status.last_sequence == 1
     assert rebuilt_payload["last_scan_start"] == 0
     assert [item.sequence for item in page.items] == [1]
-    assert next_payload["last_scan_start"] == path.stat().st_size
+    assert next_payload == rebuilt_payload
+
+
+def _required_generation(value: str | None) -> str:
+    assert value is not None
+    return value
+
+
+def test_generation_remains_stable_across_normal_append(tmp_path: Path) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        writer.append(record(1))
+    first = training_telemetry_status(path)
+
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        writer.append(record(2))
+    second = training_telemetry_status(path)
+
+    assert _required_generation(first.stream_generation) == second.stream_generation
+
+
+def test_old_generation_requests_reset_after_stream_replacement(tmp_path: Path) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        writer.append(record(1))
+        writer.append(record(2))
+    old_generation = _required_generation(
+        training_telemetry_status(path).stream_generation
+    )
+
+    replacement = tmp_path / "replacement.jsonl"
+    replacement.write_text(
+        json.dumps(record(1).to_json_dict(), sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(replacement, path)
+
+    page = read_training_telemetry(
+        path,
+        after_sequence=2,
+        limit=10,
+        expected_generation=old_generation,
+    )
+
+    assert page.items == ()
+    assert page.next_sequence == 0
+    assert page.reset_required is True
+    assert page.stream_generation not in (None, old_generation)
+
+
+def test_index_loss_rotates_generation_and_invalidates_cursor(tmp_path: Path) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        writer.append(record(1))
+    first = training_telemetry_status(path)
+    old_generation = _required_generation(first.stream_generation)
+    path.with_name(f"{path.name}.index.json").unlink()
+
+    page = read_training_telemetry(
+        path,
+        after_sequence=1,
+        limit=10,
+        expected_generation=old_generation,
+    )
+
+    assert page.items == ()
+    assert page.reset_required is True
+    assert page.stream_generation not in (None, old_generation)
+
+
+def test_expected_generation_requires_canonical_uuid(tmp_path: Path) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        writer.append(record(1))
+
+    with pytest.raises(ValueError, match="expected_generation"):
+        read_training_telemetry(
+            path,
+            after_sequence=0,
+            limit=10,
+            expected_generation="not-a-generation",
+        )
+
+
+def test_no_growth_polls_do_not_rewrite_index(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        for sequence in range(1, 70):
+            writer.append(record(sequence))
+    assert training_telemetry_status(path).last_sequence == 69
+
+    writes: list[int] = []
+
+    def fail_on_write(_path: Path, _index: object) -> None:
+        writes.append(1)
+
+    monkeypatch.setattr(indexed, "_write_index", fail_on_write)
+
+    status = training_telemetry_status(path)
+    page = read_training_telemetry(path, after_sequence=64, limit=10)
+
+    assert status.last_sequence == 69
+    assert [item.sequence for item in page.items] == [65, 66, 67, 68, 69]
+    assert writes == []
+
+
+def test_page_parsing_does_not_hold_append_process_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    with TrainingTelemetryWriter(path, flush_every=1) as writer:
+        for sequence in range(1, 131):
+            writer.append(record(sequence))
+    assert training_telemetry_status(path).last_sequence == 130
+
+    original_parse = indexed._parse_record
+    parse_started = threading.Event()
+    release_parse = threading.Event()
+    reader_done = threading.Event()
+    writer_done = threading.Event()
+    errors: list[BaseException] = []
+
+    def blocking_parse(raw_line: bytes) -> TrainingTelemetryRecord:
+        if not parse_started.is_set():
+            parse_started.set()
+            if not release_parse.wait(timeout=10.0):
+                raise TimeoutError("page parse was not released")
+        return original_parse(raw_line)
+
+    monkeypatch.setattr(indexed, "_parse_record", blocking_parse)
+
+    def read_page() -> None:
+        try:
+            read_training_telemetry(path, after_sequence=64, limit=20)
+        except BaseException as error:  # pragma: no cover - asserted below
+            errors.append(error)
+        finally:
+            reader_done.set()
+
+    def append_record() -> None:
+        try:
+            with TrainingTelemetryWriter(path, flush_every=1) as writer:
+                writer.append(record(131))
+        except BaseException as error:  # pragma: no cover - asserted below
+            errors.append(error)
+        finally:
+            writer_done.set()
+
+    reader = threading.Thread(target=read_page)
+    reader.start()
+    assert parse_started.wait(timeout=10.0)
+
+    writer = threading.Thread(target=append_record)
+    writer.start()
+    assert writer_done.wait(timeout=2.0), "writer remained blocked by page parsing"
+
+    release_parse.set()
+    reader.join(timeout=10.0)
+    writer.join(timeout=10.0)
+
+    assert reader_done.is_set()
+    assert errors == []
+    assert training_telemetry_status(path).last_sequence == 131
+
+
+def test_near_tail_page_parses_at_most_one_checkpoint_stride(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    with TrainingTelemetryWriter(path, flush_every=256) as writer:
+        for sequence in range(1, 4_097):
+            writer.append(record(sequence))
+    assert training_telemetry_status(path).last_sequence == 4_096
+
+    original_parse = indexed._parse_record
+    parsed = 0
+
+    def counted_parse(raw_line: bytes) -> TrainingTelemetryRecord:
+        nonlocal parsed
+        parsed += 1
+        return original_parse(raw_line)
+
+    monkeypatch.setattr(indexed, "_parse_record", counted_parse)
+    page = read_training_telemetry(path, after_sequence=4_080, limit=20)
+
+    assert [item.sequence for item in page.items] == list(range(4_081, 4_097))
+    assert parsed <= 80

--- a/trade_rl/rl/environment.py
+++ b/trade_rl/rl/environment.py
@@ -14,8 +14,6 @@ from gymnasium import spaces
 from trade_rl.artifacts.hashing import content_digest
 from trade_rl.data.market import MarketCalendarKind, MarketDataset
 from trade_rl.domain.common import require_sha256
-from trade_rl.evaluation.metrics import PerformanceMetrics, evaluate_performance
-from trade_rl.evaluation.series import ReturnKind, ReturnSeries
 from trade_rl.risk.emergency import CausalEmergencyRiskMonitor
 from trade_rl.risk.inputs import (
     PortfolioRiskInputsProvider,
@@ -41,14 +39,31 @@ from trade_rl.rl.environment_config import (
 from trade_rl.rl.environment_config import (
     ResidualMarketEnvConfig,
 )
+from trade_rl.rl.environment_decision import (
+    EnvironmentDecisionPlanner,
+    EnvironmentDecisionRequest,
+)
 from trade_rl.rl.environment_episode import EpisodeContractSampler
 from trade_rl.rl.environment_execution import (
     EnvironmentExecutionCoordinator,
     TargetExecutionRequest,
 )
+from trade_rl.rl.environment_info import (
+    EnvironmentInfoBuilder,
+    EnvironmentStepInfoRequest,
+    EnvironmentTerminalInfoRequest,
+)
 from trade_rl.rl.environment_observation import (
     EnvironmentObservationAssembler,
     EnvironmentObservationRuntime,
+)
+from trade_rl.rl.environment_reward import (
+    EnvironmentRewardCoordinator,
+    EnvironmentRewardRequest,
+)
+from trade_rl.rl.environment_risk import (
+    EnvironmentRiskProjector,
+    EnvironmentRiskRequest,
 )
 from trade_rl.rl.environment_transition import EnvironmentTerminationCoordinator
 from trade_rl.rl.episode import (
@@ -554,6 +569,32 @@ class ResidualMarketEnv(gym.Env[np.ndarray | dict[str, np.ndarray], np.ndarray])
             action_size=self.action_spec.size,
             n_factors=self.action_spec.n_factors,
             finite_horizon=self.config.finite_horizon_observation,
+        )
+        self._decision_planner = EnvironmentDecisionPlanner(
+            dataset,
+            action_spec=self.action_spec,
+            composer=self.composer,
+            max_gross=self.pre_trade_risk.config.max_gross,
+            alpha_enabled=self.alpha_enabled,
+            accept_legacy_actions=self.config.accept_legacy_actions,
+            signal_delay_decisions=self.config.signal_delay_decisions,
+            decision_every=self.config.decision_every,
+            decision_hours=self.config.decision_hours,
+        )
+        self._risk_projector = EnvironmentRiskProjector(
+            dataset,
+            emergency_risk_monitor=self.emergency_risk_monitor,
+            pre_trade_risk=self.pre_trade_risk,
+            portfolio_risk=self.portfolio_risk,
+            portfolio_risk_inputs_provider=(self.portfolio_risk_inputs_provider),
+        )
+        self._reward_coordinator = EnvironmentRewardCoordinator(
+            self.reward_tracker,
+            initial_capital=self.config.initial_capital,
+        )
+        self._info_builder = EnvironmentInfoBuilder(
+            dataset,
+            self.reward_tracker,
         )
         self._termination_coordinator = EnvironmentTerminationCoordinator(
             config=self.config,
@@ -1184,75 +1225,19 @@ class ResidualMarketEnv(gym.Env[np.ndarray | dict[str, np.ndarray], np.ndarray])
         }
 
     def _market_notional(self, index: int) -> np.ndarray:
-        prices = self.dataset.close[index]
-        volume = self.dataset.volume[index]
-        return np.asarray(
-            [
-                float(value)
-                if str(getattr(unit, "value", unit)) == "quote_notional"
-                else float(price * value)
-                for price, value, unit in zip(
-                    prices, volume, self.dataset.volume_units, strict=True
-                )
-            ],
-            dtype=np.float64,
-        )
+        return self._risk_projector.market_notional(index)
 
     def _constrain_target(
         self,
         proposal: np.ndarray,
         book: BookState,
     ) -> RiskConstrainedTarget:
-        target = np.asarray(proposal, dtype=np.float64).reshape(-1).copy()
-        if target.shape != (self.dataset.n_symbols,) or not np.isfinite(target).all():
-            raise ValueError("proposal does not match dataset symbols")
-        assessment = self.emergency_risk_monitor.assess(
-            self.dataset,
-            index=self.current_index,
-            weights=book.weights,
-        )
-        pretrade = self.pre_trade_risk.constrain(
-            target,
-            current=book.weights,
-            drawdown=self._drawdown(book),
-            emergency_flatten_mask=assessment.flatten_mask,
-        )
-        risk_inputs = None
-        if self.portfolio_risk.requires_advanced_inputs:
-            provider = self.portfolio_risk_inputs_provider
-            if provider is None:
-                raise RuntimeError(
-                    "advanced portfolio risk requires a causal input provider"
-                )
-            risk_inputs = provider.inputs(self.dataset, index=self.current_index)
-        portfolio = self.portfolio_risk.constrain(
-            pretrade.weights,
-            portfolio_value=max(book.portfolio_value, 1e-12),
-            market_notional=self._market_notional(self.current_index),
-            covariance=None if risk_inputs is None else risk_inputs.covariance,
-            beta=None if risk_inputs is None else risk_inputs.beta,
-            stress_losses=None if risk_inputs is None else risk_inputs.stress_losses,
-        )
-        final_weights = np.asarray(portfolio.weights, dtype=np.float64)
-        constrained_turnover = float(np.abs(final_weights - book.weights).sum())
-        reasons = tuple(
-            dict.fromkeys(
-                (
-                    *pretrade.reasons,
-                    *assessment.reasons,
-                    *(f"portfolio:{item}" for item in portfolio.reasons),
-                )
+        return self._risk_projector.project(
+            EnvironmentRiskRequest(
+                proposal=proposal,
+                book=book,
+                current_index=self.current_index,
             )
-        )
-        return RiskConstrainedTarget(
-            weights=final_weights,
-            requested_turnover=pretrade.requested_turnover,
-            constrained_turnover=constrained_turnover,
-            was_constrained=bool(reasons),
-            reasons=reasons,
-            risk_scale=pretrade.risk_scale,
-            projection_l1=float(np.abs(target - final_weights).sum()),
-            turnover_overridden=pretrade.turnover_overridden,
         )
 
     def _parse_action(
@@ -1264,58 +1249,12 @@ class ResidualMarketEnv(gym.Env[np.ndarray | dict[str, np.ndarray], np.ndarray])
         int,
         float,
     ]:
-        vector = np.asarray(value, dtype=np.float64).reshape(-1)
-        if (
-            self.action_spec.mode is ActionMode.RESIDUAL
-            and vector.shape == (2,)
-            and self.config.accept_legacy_actions
-        ):
-            legacy = ResidualAction.from_array(vector)
-            migrated = np.zeros(self.action_spec.size, dtype=np.float32)
-            if legacy.trend_mix >= 0.0:
-                migrated[0] = legacy.trend_mix
-            else:
-                migrated[1] = -legacy.trend_mix
-            if self.alpha_enabled:
-                migrated[self.action_spec.names.index("alpha_scale")] = (
-                    legacy.alpha_budget
-                )
-            saturated = int(np.count_nonzero(np.abs(vector) > 1.0))
-            return (
-                legacy,
-                migrated,
-                saturated,
-                float(np.max(np.abs(vector), initial=0.0)),
-            )
-        parsed = self.action_spec.parse(value)
-        if isinstance(parsed, TargetWeightAction):
-            maintained = parsed.as_array()
-        else:
-            maintained = parsed.as_array(
-                alpha_enabled=self.alpha_enabled,
-                risk_tilt_enabled=self.action_spec.risk_tilt_enabled,
-            )
-        return (
-            parsed,
-            maintained,
-            parsed.saturated_count,
-            parsed.raw_max_abs,
-        )
+        return self._decision_planner.parse_action(value)
 
     def _decision_bar_count(self) -> int:
-        remaining = self.end_index - self.current_index
-        if remaining <= 0:
-            raise RuntimeError("step called after the episode ended")
-        if self.config.decision_every is not None:
-            return min(self.config.decision_every, remaining)
-        if self.dataset.regular_cadence:
-            return min(
-                self.dataset.bars_for_hours(self.config.decision_hours), remaining
-            )
-        return self.dataset.bars_until(
-            self.current_index,
-            self.config.decision_hours,
-            maximum_index=self.end_index,
+        return self._decision_planner.decision_bar_count(
+            current_index=self.current_index,
+            end_index=self.end_index,
         )
 
     @staticmethod
@@ -1372,49 +1311,43 @@ class ResidualMarketEnv(gym.Env[np.ndarray | dict[str, np.ndarray], np.ndarray])
         if self.current_index >= self.end_index:
             raise RuntimeError("step called after the episode ended")
         trends, alpha, factor_basis = self._market_inputs()
-        parsed_action, maintained_action, saturated_count, raw_max_abs = (
-            self._parse_action(action)
-        )
-        composition = self.composer.compose(
-            parsed_action,
-            trends,
-            alpha,
-            alpha_enabled=self.alpha_enabled,
-            factor_basis=factor_basis,
-            max_gross=self.pre_trade_risk.config.max_gross,
-        )
-        submitted_hybrid_target = np.asarray(
-            composition.proposal, dtype=np.float64
-        ).copy()
-        submitted_shadow_target = np.asarray(trends.base, dtype=np.float64).copy()
-        execution_delay_warmup = False
-        if self.config.signal_delay_decisions == 0:
-            executed_hybrid_target = submitted_hybrid_target
-            executed_shadow_target = submitted_shadow_target
-        else:
-            execution_delay_warmup = self._pending_hybrid_target is None
-            executed_hybrid_target = (
-                self.hybrid.weights.copy()
-                if self._pending_hybrid_target is None
-                else self._pending_hybrid_target.copy()
+        decision = self._decision_planner.plan(
+            EnvironmentDecisionRequest(
+                action=action,
+                trends=trends,
+                alpha=alpha,
+                factor_basis=factor_basis,
+                hybrid_weights=self.hybrid.weights,
+                shadow_weights=self.shadow.weights,
+                pending_hybrid_target=self._pending_hybrid_target,
+                pending_shadow_target=self._pending_shadow_target,
+                current_index=self.current_index,
+                end_index=self.end_index,
             )
-            executed_shadow_target = (
-                self.shadow.weights.copy()
-                if self._pending_shadow_target is None
-                else self._pending_shadow_target.copy()
+        )
+        self._pending_hybrid_target = decision.next_pending_hybrid_target
+        self._pending_shadow_target = decision.next_pending_shadow_target
+        hybrid_risk = self._risk_projector.project(
+            EnvironmentRiskRequest(
+                proposal=decision.executed_hybrid_target,
+                book=self.hybrid,
+                current_index=self.current_index,
             )
-            self._pending_hybrid_target = submitted_hybrid_target
-            self._pending_shadow_target = submitted_shadow_target
-        hybrid_risk = self._constrain_target(executed_hybrid_target, self.hybrid)
-        shadow_risk = self._constrain_target(executed_shadow_target, self.shadow)
-        bars = self._decision_bar_count()
+        )
+        shadow_risk = self._risk_projector.project(
+            EnvironmentRiskRequest(
+                proposal=decision.executed_shadow_target,
+                book=self.shadow,
+                current_index=self.current_index,
+            )
+        )
         previous_hybrid_weights = self.hybrid.weights.copy()
         hybrid_execution = self._execute_stateful_target(
             executor=self.hybrid_executor,
             book=self.hybrid,
             order_book=self._hybrid_order_book,
             target=hybrid_risk.weights,
-            bars=bars,
+            bars=decision.bars,
             book_kind="hybrid",
         )
         shadow_execution = self._execute_stateful_target(
@@ -1422,7 +1355,7 @@ class ResidualMarketEnv(gym.Env[np.ndarray | dict[str, np.ndarray], np.ndarray])
             book=self.shadow,
             order_book=self._shadow_order_book,
             target=shadow_risk.weights,
-            bars=bars,
+            bars=decision.bars,
             book_kind="shadow",
         )
         if hybrid_execution.bars_advanced != shadow_execution.bars_advanced:
@@ -1471,33 +1404,30 @@ class ResidualMarketEnv(gym.Env[np.ndarray | dict[str, np.ndarray], np.ndarray])
         economic_transition = transition.economic_transition
         terminated = economic_transition.terminated
         truncated = economic_transition.truncated
-        action_delta_l1 = float(np.abs(maintained_action - self._previous_action).sum())
+        action_delta_l1 = float(
+            np.abs(decision.maintained_action - self._previous_action).sum()
+        )
         projection_distance = hybrid_risk.projection_l1
-        reward_breakdown = self.reward_tracker.step(
-            hybrid_log_return=hybrid_log_return,
-            shadow_log_return=shadow_log_return,
-            hybrid_drawdown=self._drawdown(self.hybrid),
-            shadow_drawdown=self._drawdown(self.shadow),
-            projection_distance=projection_distance,
-            hybrid_margin_deficit_fraction=(
-                self.hybrid.margin_deficit / self.config.initial_capital
-            ),
-            hybrid_equity_fraction=max(self.hybrid.portfolio_value, 0.0)
-            / self.config.initial_capital,
-            shadow_equity_fraction=max(self.shadow.portfolio_value, 0.0)
-            / self.config.initial_capital,
-            hybrid_terminated=hybrid_terminated,
-            shadow_terminated=shadow_terminated,
+        reward_breakdown = self._reward_coordinator.step(
+            EnvironmentRewardRequest(
+                hybrid_log_return=hybrid_log_return,
+                shadow_log_return=shadow_log_return,
+                hybrid=self.hybrid,
+                shadow=self.shadow,
+                projection_distance=projection_distance,
+                hybrid_terminated=hybrid_terminated,
+                shadow_terminated=shadow_terminated,
+            )
         )
         self._execution_state = self._execution_observation_state(
             requested_weights=hybrid_risk.weights,
             result=hybrid_execution,
             previous_weights=previous_hybrid_weights,
         )
-        self._previous_action = maintained_action.copy()
+        self._previous_action = decision.maintained_action.copy()
         self._action_diagnostics.update(
-            action=maintained_action,
-            saturated_count=saturated_count,
+            action=decision.maintained_action,
+            saturated_count=decision.saturated_count,
             action_delta_l1=action_delta_l1,
             projection_l1=projection_distance,
             constrained=hybrid_risk.was_constrained,
@@ -1516,69 +1446,38 @@ class ResidualMarketEnv(gym.Env[np.ndarray | dict[str, np.ndarray], np.ndarray])
             if liquidation_terminal and hybrid_liquidation is not None
             else 0.0
         )
-        info: dict[str, object] = {
-            "action_delta_l1": action_delta_l1,
-            "action_raw_max_abs": raw_max_abs,
-            "action_saturated_count": saturated_count,
-            "bars_advanced": hybrid_execution.bars_advanced,
-            "composition": composition,
-            "decision_step_index": self._decision_step_index,
-            "excess_log_return": hybrid_log_return - shadow_log_return,
-            "emergency_deleverage": emergency_deleverage,
-            "execution_delay_warmup": execution_delay_warmup,
-            "submitted_target": submitted_hybrid_target.copy(),
-            "executed_target": executed_hybrid_target.copy(),
-            "drawdown_after": self._drawdown(self.hybrid),
-            "portfolio_value_after": self.hybrid.portfolio_value,
-            "reward_growth_raw": reward_breakdown.absolute_log_growth,
-            "reward_baseline_penalty_delta": (
-                0.0
-                if self.reward_tracker.config.baseline_underperformance_weight == 0.0
-                else reward_breakdown.baseline_penalty
-                / self.reward_tracker.config.baseline_underperformance_weight
-            ),
-            "reward_baseline_penalty_weighted": reward_breakdown.baseline_penalty,
-            "reward_drawdown_penalty_delta": reward_breakdown.incremental_drawdown,
-            "reward_drawdown_penalty_weighted": reward_breakdown.drawdown_penalty,
-            "reward_total_raw": reward_breakdown.unscaled_total,
-            "reward_total_scaled": reward_breakdown.scaled_total,
-            "reward_context_before": self.reward_tracker.last_context_before,
-            "reward_context_after": self.reward_tracker.last_context_after,
-            "rolling_hybrid_log_growth": (
-                self.reward_tracker.last_context_after.rolling_hybrid_log_growth
-            ),
-            "rolling_baseline_log_growth": (
-                self.reward_tracker.last_context_after.rolling_shadow_log_growth
-            ),
-            "rolling_growth_gap": (
-                self.reward_tracker.last_context_after.rolling_growth_gap
-            ),
-            "hybrid_execution": hybrid_execution,
-            "hybrid_risk": hybrid_risk,
-            "hybrid_terminated": hybrid_terminated,
-            "interval_cost": hybrid_execution.interval_cost,
-            "interval_funding": hybrid_execution.interval_funding,
-            "interval_gross_return": hybrid_execution.interval_gross_return,
-            "interval_net_return": hybrid_execution.interval_net_return,
-            "liquidation_complete": liquidation_complete,
-            "liquidation_terminal": liquidation_terminal,
-            "projection_distance_l1": projection_distance,
-            "reward_breakdown": reward_breakdown,
-            "shadow_execution": shadow_execution,
-            "shadow_interval_net_return": shadow_execution.interval_net_return,
-            "shadow_risk": shadow_risk,
-            "shadow_terminated": shadow_terminated,
-            "termination_reason": termination_reason,
-            "terminal_accounting_mode": terminal_accounting_mode,
-            "terminal_liquidation_cost": terminal_liquidation_cost,
-            "pending_target_discarded": pending_target_discarded,
-        }
-        if discarded_pending_target is not None:
-            info["discarded_pending_target"] = discarded_pending_target
-        if hybrid_liquidation is not None:
-            info["hybrid_liquidation"] = hybrid_liquidation
-        if shadow_liquidation is not None:
-            info["shadow_liquidation"] = shadow_liquidation
+        info = self._info_builder.step_info(
+            EnvironmentStepInfoRequest(
+                action_delta_l1=action_delta_l1,
+                raw_max_abs=decision.raw_max_abs,
+                saturated_count=decision.saturated_count,
+                composition=decision.composition,
+                decision_step_index=self._decision_step_index,
+                hybrid_log_return=hybrid_log_return,
+                shadow_log_return=shadow_log_return,
+                emergency_deleverage=emergency_deleverage,
+                execution_delay_warmup=decision.execution_delay_warmup,
+                submitted_target=decision.submitted_hybrid_target,
+                executed_target=decision.executed_hybrid_target,
+                hybrid=self.hybrid,
+                reward_breakdown=reward_breakdown,
+                hybrid_execution=hybrid_execution,
+                hybrid_risk=hybrid_risk,
+                hybrid_terminated=hybrid_terminated,
+                shadow_execution=shadow_execution,
+                shadow_risk=shadow_risk,
+                shadow_terminated=shadow_terminated,
+                liquidation_complete=liquidation_complete,
+                liquidation_terminal=liquidation_terminal,
+                termination_reason=termination_reason,
+                terminal_accounting_mode=terminal_accounting_mode,
+                terminal_liquidation_cost=terminal_liquidation_cost,
+                pending_target_discarded=pending_target_discarded,
+                discarded_pending_target=discarded_pending_target,
+                hybrid_liquidation=hybrid_liquidation,
+                shadow_liquidation=shadow_liquidation,
+            )
+        )
         if terminated or truncated:
             info.update(self._terminal_info())
         return (
@@ -1589,32 +1488,14 @@ class ResidualMarketEnv(gym.Env[np.ndarray | dict[str, np.ndarray], np.ndarray])
             info,
         )
 
-    def _book_metrics(self, book: BookState) -> PerformanceMetrics:
-        return evaluate_performance(
-            ReturnSeries(
-                values=tuple(book.returns_history),
-                kind=ReturnKind.BASE_BAR,
-                periods_per_year=self.dataset.periods_per_year,
-            ),
-            turnover_total=book.turnover_total,
-            total_cost=book.total_cost,
-            funding_pnl=book.funding_pnl - book.borrow_cost,
-            n_trades=book.fill_count,
-        )
-
     def _terminal_info(self) -> dict[str, object]:
-        hybrid_metrics = self._book_metrics(self.hybrid)
-        shadow_metrics = self._book_metrics(self.shadow)
-        return {
-            "episode_hours": self._episode_hours,
-            "episode_seed": self._episode_seed,
-            "action_diagnostics": self._action_diagnostics.snapshot(),
-            "hybrid_metrics": hybrid_metrics,
-            "hybrid_rebalance_events": self.hybrid.rebalance_events,
-            "initial_state_mode": self._initial_state_mode,
-            "shadow_metrics": shadow_metrics,
-            "shadow_rebalance_events": self.shadow.rebalance_events,
-            "excess_total_return": (
-                hybrid_metrics.total_return - shadow_metrics.total_return
-            ),
-        }
+        return self._info_builder.terminal_info(
+            EnvironmentTerminalInfoRequest(
+                episode_hours=self._episode_hours,
+                episode_seed=self._episode_seed,
+                action_diagnostics=self._action_diagnostics.snapshot(),
+                hybrid=self.hybrid,
+                shadow=self.shadow,
+                initial_state_mode=self._initial_state_mode,
+            )
+        )

--- a/trade_rl/rl/environment_decision.py
+++ b/trade_rl/rl/environment_decision.py
@@ -1,0 +1,228 @@
+"""Immutable action and execution-delay planning for one environment decision."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import numpy as np
+
+from trade_rl.rl.actions import (
+    ActionMode,
+    ActionSpec,
+    BaselineResidualComposer,
+    ResidualAction,
+    ResidualActionV2,
+    ResidualComposition,
+    TargetWeightAction,
+)
+from trade_rl.strategies.trend import TrendTargets
+
+
+class DecisionCalendar(Protocol):
+    @property
+    def regular_cadence(self) -> bool: ...
+
+    def bars_for_hours(self, hours: float) -> int: ...
+
+    def bars_until(
+        self,
+        start: int,
+        hours: float,
+        *,
+        maximum_index: int,
+    ) -> int: ...
+
+
+@dataclass(frozen=True, slots=True)
+class EnvironmentDecisionRequest:
+    action: np.ndarray
+    trends: TrendTargets
+    alpha: np.ndarray
+    factor_basis: np.ndarray
+    hybrid_weights: np.ndarray
+    shadow_weights: np.ndarray
+    pending_hybrid_target: np.ndarray | None
+    pending_shadow_target: np.ndarray | None
+    current_index: int
+    end_index: int
+
+
+@dataclass(frozen=True, slots=True)
+class EnvironmentDecisionPlan:
+    parsed_action: ResidualAction | ResidualActionV2 | TargetWeightAction
+    maintained_action: np.ndarray
+    saturated_count: int
+    raw_max_abs: float
+    composition: ResidualComposition
+    submitted_hybrid_target: np.ndarray
+    submitted_shadow_target: np.ndarray
+    executed_hybrid_target: np.ndarray
+    executed_shadow_target: np.ndarray
+    next_pending_hybrid_target: np.ndarray | None
+    next_pending_shadow_target: np.ndarray | None
+    execution_delay_warmup: bool
+    bars: int
+
+
+class EnvironmentDecisionPlanner:
+    """Parse actions and resolve causal targets without mutating environment state."""
+
+    def __init__(
+        self,
+        dataset: DecisionCalendar,
+        *,
+        action_spec: ActionSpec,
+        composer: BaselineResidualComposer,
+        max_gross: float,
+        alpha_enabled: bool,
+        accept_legacy_actions: bool,
+        signal_delay_decisions: int,
+        decision_every: int | None,
+        decision_hours: float,
+    ) -> None:
+        if not np.isfinite(max_gross) or max_gross <= 0.0:
+            raise ValueError("max_gross must be finite and positive")
+        if signal_delay_decisions not in (0, 1):
+            raise ValueError("signal_delay_decisions must be zero or one")
+        if decision_every is not None and decision_every <= 0:
+            raise ValueError("decision_every must be positive")
+        if not np.isfinite(decision_hours) or decision_hours <= 0.0:
+            raise ValueError("decision_hours must be finite and positive")
+        self.dataset = dataset
+        self.action_spec = action_spec
+        self.composer = composer
+        self.max_gross = float(max_gross)
+        self.alpha_enabled = bool(alpha_enabled)
+        self.accept_legacy_actions = bool(accept_legacy_actions)
+        self.signal_delay_decisions = signal_delay_decisions
+        self.decision_every = decision_every
+        self.decision_hours = float(decision_hours)
+
+    def parse_action(
+        self,
+        value: np.ndarray,
+    ) -> tuple[
+        ResidualAction | ResidualActionV2 | TargetWeightAction,
+        np.ndarray,
+        int,
+        float,
+    ]:
+        vector = np.asarray(value, dtype=np.float64).reshape(-1)
+        if (
+            self.action_spec.mode is ActionMode.RESIDUAL
+            and vector.shape == (2,)
+            and self.accept_legacy_actions
+        ):
+            legacy = ResidualAction.from_array(vector)
+            migrated = np.zeros(self.action_spec.size, dtype=np.float32)
+            if legacy.trend_mix >= 0.0:
+                migrated[0] = legacy.trend_mix
+            else:
+                migrated[1] = -legacy.trend_mix
+            if self.alpha_enabled:
+                migrated[self.action_spec.names.index("alpha_scale")] = (
+                    legacy.alpha_budget
+                )
+            return (
+                legacy,
+                migrated,
+                int(np.count_nonzero(np.abs(vector) > 1.0)),
+                float(np.max(np.abs(vector), initial=0.0)),
+            )
+        parsed = self.action_spec.parse(value)
+        if isinstance(parsed, TargetWeightAction):
+            maintained = parsed.as_array()
+        else:
+            maintained = parsed.as_array(
+                alpha_enabled=self.alpha_enabled,
+                risk_tilt_enabled=self.action_spec.risk_tilt_enabled,
+            )
+        return (
+            parsed,
+            maintained,
+            parsed.saturated_count,
+            parsed.raw_max_abs,
+        )
+
+    def decision_bar_count(self, *, current_index: int, end_index: int) -> int:
+        remaining = end_index - current_index
+        if remaining <= 0:
+            raise RuntimeError("step called after the episode ended")
+        if self.decision_every is not None:
+            return min(self.decision_every, remaining)
+        if self.dataset.regular_cadence:
+            return min(self.dataset.bars_for_hours(self.decision_hours), remaining)
+        return self.dataset.bars_until(
+            current_index,
+            self.decision_hours,
+            maximum_index=end_index,
+        )
+
+    def plan(self, request: EnvironmentDecisionRequest) -> EnvironmentDecisionPlan:
+        parsed, maintained, saturated_count, raw_max_abs = self.parse_action(
+            request.action
+        )
+        composition = self.composer.compose(
+            parsed,
+            request.trends,
+            request.alpha,
+            alpha_enabled=self.alpha_enabled,
+            factor_basis=request.factor_basis,
+            max_gross=self.max_gross,
+        )
+        submitted_hybrid = (
+            np.asarray(composition.proposal, dtype=np.float64).reshape(-1).copy()
+        )
+        submitted_shadow = (
+            np.asarray(request.trends.base, dtype=np.float64).reshape(-1).copy()
+        )
+        execution_delay_warmup = False
+        next_pending_hybrid: np.ndarray | None = None
+        next_pending_shadow: np.ndarray | None = None
+        if self.signal_delay_decisions == 0:
+            executed_hybrid = submitted_hybrid.copy()
+            executed_shadow = submitted_shadow.copy()
+        else:
+            execution_delay_warmup = request.pending_hybrid_target is None
+            executed_hybrid = (
+                np.asarray(request.hybrid_weights, dtype=np.float64).reshape(-1).copy()
+                if request.pending_hybrid_target is None
+                else np.asarray(request.pending_hybrid_target, dtype=np.float64)
+                .reshape(-1)
+                .copy()
+            )
+            executed_shadow = (
+                np.asarray(request.shadow_weights, dtype=np.float64).reshape(-1).copy()
+                if request.pending_shadow_target is None
+                else np.asarray(request.pending_shadow_target, dtype=np.float64)
+                .reshape(-1)
+                .copy()
+            )
+            next_pending_hybrid = submitted_hybrid.copy()
+            next_pending_shadow = submitted_shadow.copy()
+        return EnvironmentDecisionPlan(
+            parsed_action=parsed,
+            maintained_action=np.asarray(maintained, dtype=np.float32).copy(),
+            saturated_count=saturated_count,
+            raw_max_abs=raw_max_abs,
+            composition=composition,
+            submitted_hybrid_target=submitted_hybrid,
+            submitted_shadow_target=submitted_shadow,
+            executed_hybrid_target=executed_hybrid,
+            executed_shadow_target=executed_shadow,
+            next_pending_hybrid_target=next_pending_hybrid,
+            next_pending_shadow_target=next_pending_shadow,
+            execution_delay_warmup=execution_delay_warmup,
+            bars=self.decision_bar_count(
+                current_index=request.current_index,
+                end_index=request.end_index,
+            ),
+        )
+
+
+__all__ = [
+    "EnvironmentDecisionPlan",
+    "EnvironmentDecisionPlanner",
+    "EnvironmentDecisionRequest",
+]

--- a/trade_rl/rl/environment_info.py
+++ b/trade_rl/rl/environment_info.py
@@ -1,0 +1,224 @@
+"""Stable step and terminal information construction for the market environment."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import numpy as np
+
+from trade_rl.evaluation.metrics import PerformanceMetrics, evaluate_performance
+from trade_rl.evaluation.series import ReturnKind, ReturnSeries
+from trade_rl.rl.rewards import RewardBreakdown, RewardConfig, RewardContext
+from trade_rl.simulation.accounting import BookState
+
+
+class InfoDataset(Protocol):
+    @property
+    def periods_per_year(self) -> int: ...
+
+
+class RewardInfoSource(Protocol):
+    @property
+    def config(self) -> RewardConfig: ...
+
+    @property
+    def last_context_before(self) -> RewardContext: ...
+
+    @property
+    def last_context_after(self) -> RewardContext: ...
+
+
+class ExecutionInfo(Protocol):
+    @property
+    def bars_advanced(self) -> int: ...
+
+    @property
+    def interval_cost(self) -> float: ...
+
+    @property
+    def interval_funding(self) -> float: ...
+
+    @property
+    def interval_gross_return(self) -> float: ...
+
+    @property
+    def interval_net_return(self) -> float: ...
+
+
+class RiskInfo(Protocol):
+    @property
+    def projection_l1(self) -> float: ...
+
+
+@dataclass(frozen=True, slots=True)
+class EnvironmentStepInfoRequest:
+    action_delta_l1: float
+    raw_max_abs: float
+    saturated_count: int
+    composition: object
+    decision_step_index: int
+    hybrid_log_return: float
+    shadow_log_return: float
+    emergency_deleverage: bool
+    execution_delay_warmup: bool
+    submitted_target: np.ndarray
+    executed_target: np.ndarray
+    hybrid: BookState
+    reward_breakdown: RewardBreakdown
+    hybrid_execution: ExecutionInfo
+    hybrid_risk: RiskInfo
+    hybrid_terminated: bool
+    shadow_execution: ExecutionInfo
+    shadow_risk: RiskInfo
+    shadow_terminated: bool
+    liquidation_complete: bool
+    liquidation_terminal: bool
+    termination_reason: object | None
+    terminal_accounting_mode: str
+    terminal_liquidation_cost: float
+    pending_target_discarded: bool
+    discarded_pending_target: np.ndarray | None
+    hybrid_liquidation: object | None
+    shadow_liquidation: object | None
+
+
+@dataclass(frozen=True, slots=True)
+class EnvironmentTerminalInfoRequest:
+    episode_hours: float
+    episode_seed: int
+    action_diagnostics: object
+    hybrid: BookState
+    shadow: BookState
+    initial_state_mode: str
+
+
+class EnvironmentInfoBuilder:
+    """Build fresh audit dictionaries while preserving the stable key contract."""
+
+    def __init__(
+        self,
+        dataset: InfoDataset,
+        reward_tracker: RewardInfoSource,
+    ) -> None:
+        self.dataset = dataset
+        self.reward_tracker = reward_tracker
+
+    @staticmethod
+    def drawdown(book: BookState) -> float:
+        value = max(book.portfolio_value, 0.0)
+        return min(
+            1.0,
+            max(0.0, 1.0 - value / max(book.peak_value, value, 1e-12)),
+        )
+
+    def step_info(self, request: EnvironmentStepInfoRequest) -> dict[str, object]:
+        reward = request.reward_breakdown
+        before = self.reward_tracker.last_context_before
+        after = self.reward_tracker.last_context_after
+        baseline_weight = self.reward_tracker.config.baseline_underperformance_weight
+        info: dict[str, object] = {
+            "action_delta_l1": request.action_delta_l1,
+            "action_raw_max_abs": request.raw_max_abs,
+            "action_saturated_count": request.saturated_count,
+            "bars_advanced": request.hybrid_execution.bars_advanced,
+            "composition": request.composition,
+            "decision_step_index": request.decision_step_index,
+            "excess_log_return": (
+                request.hybrid_log_return - request.shadow_log_return
+            ),
+            "emergency_deleverage": request.emergency_deleverage,
+            "execution_delay_warmup": request.execution_delay_warmup,
+            "submitted_target": np.asarray(
+                request.submitted_target, dtype=np.float64
+            ).copy(),
+            "executed_target": np.asarray(
+                request.executed_target, dtype=np.float64
+            ).copy(),
+            "drawdown_after": self.drawdown(request.hybrid),
+            "portfolio_value_after": request.hybrid.portfolio_value,
+            "reward_growth_raw": reward.absolute_log_growth,
+            "reward_baseline_penalty_delta": (
+                0.0
+                if baseline_weight == 0.0
+                else reward.baseline_penalty / baseline_weight
+            ),
+            "reward_baseline_penalty_weighted": reward.baseline_penalty,
+            "reward_drawdown_penalty_delta": reward.incremental_drawdown,
+            "reward_drawdown_penalty_weighted": reward.drawdown_penalty,
+            "reward_total_raw": reward.unscaled_total,
+            "reward_total_scaled": reward.scaled_total,
+            "reward_context_before": before,
+            "reward_context_after": after,
+            "rolling_hybrid_log_growth": after.rolling_hybrid_log_growth,
+            "rolling_baseline_log_growth": after.rolling_shadow_log_growth,
+            "rolling_growth_gap": after.rolling_growth_gap,
+            "hybrid_execution": request.hybrid_execution,
+            "hybrid_risk": request.hybrid_risk,
+            "hybrid_terminated": request.hybrid_terminated,
+            "interval_cost": request.hybrid_execution.interval_cost,
+            "interval_funding": request.hybrid_execution.interval_funding,
+            "interval_gross_return": request.hybrid_execution.interval_gross_return,
+            "interval_net_return": request.hybrid_execution.interval_net_return,
+            "liquidation_complete": request.liquidation_complete,
+            "liquidation_terminal": request.liquidation_terminal,
+            "projection_distance_l1": request.hybrid_risk.projection_l1,
+            "reward_breakdown": reward,
+            "shadow_execution": request.shadow_execution,
+            "shadow_interval_net_return": request.shadow_execution.interval_net_return,
+            "shadow_risk": request.shadow_risk,
+            "shadow_terminated": request.shadow_terminated,
+            "termination_reason": request.termination_reason,
+            "terminal_accounting_mode": request.terminal_accounting_mode,
+            "terminal_liquidation_cost": request.terminal_liquidation_cost,
+            "pending_target_discarded": request.pending_target_discarded,
+        }
+        if request.discarded_pending_target is not None:
+            info["discarded_pending_target"] = np.asarray(
+                request.discarded_pending_target, dtype=np.float64
+            ).copy()
+        if request.hybrid_liquidation is not None:
+            info["hybrid_liquidation"] = request.hybrid_liquidation
+        if request.shadow_liquidation is not None:
+            info["shadow_liquidation"] = request.shadow_liquidation
+        return info
+
+    def book_metrics(self, book: BookState) -> PerformanceMetrics:
+        return evaluate_performance(
+            ReturnSeries(
+                values=tuple(book.returns_history),
+                kind=ReturnKind.BASE_BAR,
+                periods_per_year=self.dataset.periods_per_year,
+            ),
+            turnover_total=book.turnover_total,
+            total_cost=book.total_cost,
+            funding_pnl=book.funding_pnl - book.borrow_cost,
+            n_trades=book.fill_count,
+        )
+
+    def terminal_info(
+        self,
+        request: EnvironmentTerminalInfoRequest,
+    ) -> dict[str, object]:
+        hybrid_metrics = self.book_metrics(request.hybrid)
+        shadow_metrics = self.book_metrics(request.shadow)
+        return {
+            "episode_hours": request.episode_hours,
+            "episode_seed": request.episode_seed,
+            "action_diagnostics": request.action_diagnostics,
+            "hybrid_metrics": hybrid_metrics,
+            "hybrid_rebalance_events": request.hybrid.rebalance_events,
+            "initial_state_mode": request.initial_state_mode,
+            "shadow_metrics": shadow_metrics,
+            "shadow_rebalance_events": request.shadow.rebalance_events,
+            "excess_total_return": (
+                hybrid_metrics.total_return - shadow_metrics.total_return
+            ),
+        }
+
+
+__all__ = [
+    "EnvironmentInfoBuilder",
+    "EnvironmentStepInfoRequest",
+    "EnvironmentTerminalInfoRequest",
+]

--- a/trade_rl/rl/environment_reward.py
+++ b/trade_rl/rl/environment_reward.py
@@ -1,0 +1,88 @@
+"""Reward transition coordination for one environment decision."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import numpy as np
+
+from trade_rl.rl.rewards import RewardBreakdown
+from trade_rl.simulation.accounting import BookState
+
+
+class RewardTrackerLike(Protocol):
+    def step(
+        self,
+        *,
+        hybrid_log_return: float,
+        shadow_log_return: float,
+        hybrid_drawdown: float,
+        shadow_drawdown: float,
+        projection_distance: float = 0.0,
+        hybrid_margin_deficit_fraction: float = 0.0,
+        hybrid_equity_fraction: float = 1.0,
+        shadow_equity_fraction: float = 1.0,
+        hybrid_terminated: bool = False,
+        shadow_terminated: bool = False,
+    ) -> RewardBreakdown: ...
+
+
+@dataclass(frozen=True, slots=True)
+class EnvironmentRewardRequest:
+    hybrid_log_return: float
+    shadow_log_return: float
+    hybrid: BookState
+    shadow: BookState
+    projection_distance: float
+    hybrid_terminated: bool
+    shadow_terminated: bool
+
+
+class EnvironmentRewardCoordinator:
+    """Map environment account state into the stable reward-tracker contract."""
+
+    def __init__(
+        self,
+        reward_tracker: RewardTrackerLike,
+        *,
+        initial_capital: float,
+    ) -> None:
+        if not np.isfinite(initial_capital) or initial_capital <= 0.0:
+            raise ValueError("initial_capital must be positive")
+        self.reward_tracker = reward_tracker
+        self.initial_capital = float(initial_capital)
+
+    @staticmethod
+    def drawdown(book: BookState) -> float:
+        value = max(book.portfolio_value, 0.0)
+        return min(
+            1.0,
+            max(0.0, 1.0 - value / max(book.peak_value, value, 1e-12)),
+        )
+
+    def step(self, request: EnvironmentRewardRequest) -> RewardBreakdown:
+        return self.reward_tracker.step(
+            hybrid_log_return=request.hybrid_log_return,
+            shadow_log_return=request.shadow_log_return,
+            hybrid_drawdown=self.drawdown(request.hybrid),
+            shadow_drawdown=self.drawdown(request.shadow),
+            projection_distance=request.projection_distance,
+            hybrid_margin_deficit_fraction=(
+                request.hybrid.margin_deficit / self.initial_capital
+            ),
+            hybrid_equity_fraction=(
+                max(request.hybrid.portfolio_value, 0.0) / self.initial_capital
+            ),
+            shadow_equity_fraction=(
+                max(request.shadow.portfolio_value, 0.0) / self.initial_capital
+            ),
+            hybrid_terminated=request.hybrid_terminated,
+            shadow_terminated=request.shadow_terminated,
+        )
+
+
+__all__ = [
+    "EnvironmentRewardCoordinator",
+    "EnvironmentRewardRequest",
+]

--- a/trade_rl/rl/environment_risk.py
+++ b/trade_rl/rl/environment_risk.py
@@ -1,0 +1,128 @@
+"""Causal emergency, pre-trade, and portfolio risk projection services."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from trade_rl.data.market import MarketDataset
+from trade_rl.risk.emergency import CausalEmergencyRiskMonitor
+from trade_rl.risk.inputs import PortfolioRiskInputsProvider
+from trade_rl.risk.portfolio import PortfolioRiskModel
+from trade_rl.risk.pretrade import PreTradeRisk, RiskConstrainedTarget
+from trade_rl.simulation.accounting import BookState
+
+
+@dataclass(frozen=True, slots=True)
+class EnvironmentRiskRequest:
+    proposal: np.ndarray
+    book: BookState
+    current_index: int
+
+
+class EnvironmentRiskProjector:
+    """Apply risk controls in the maintained emergency-to-portfolio order."""
+
+    def __init__(
+        self,
+        dataset: MarketDataset,
+        *,
+        emergency_risk_monitor: CausalEmergencyRiskMonitor,
+        pre_trade_risk: PreTradeRisk,
+        portfolio_risk: PortfolioRiskModel,
+        portfolio_risk_inputs_provider: PortfolioRiskInputsProvider | None,
+    ) -> None:
+        self.dataset = dataset
+        self.emergency_risk_monitor = emergency_risk_monitor
+        self.pre_trade_risk = pre_trade_risk
+        self.portfolio_risk = portfolio_risk
+        self.portfolio_risk_inputs_provider = portfolio_risk_inputs_provider
+
+    @staticmethod
+    def drawdown(book: BookState) -> float:
+        value = max(book.portfolio_value, 0.0)
+        return min(
+            1.0,
+            max(0.0, 1.0 - value / max(book.peak_value, value, 1e-12)),
+        )
+
+    def market_notional(self, index: int) -> np.ndarray:
+        prices = self.dataset.close[index]
+        volume = self.dataset.volume[index]
+        return np.asarray(
+            [
+                float(value)
+                if str(getattr(unit, "value", unit)) == "quote_notional"
+                else float(price * value)
+                for price, value, unit in zip(
+                    prices,
+                    volume,
+                    self.dataset.volume_units,
+                    strict=True,
+                )
+            ],
+            dtype=np.float64,
+        )
+
+    def project(self, request: EnvironmentRiskRequest) -> RiskConstrainedTarget:
+        target = np.asarray(request.proposal, dtype=np.float64).reshape(-1).copy()
+        if target.shape != (self.dataset.n_symbols,) or not np.isfinite(target).all():
+            raise ValueError("proposal does not match dataset symbols")
+        assessment = self.emergency_risk_monitor.assess(
+            self.dataset,
+            index=request.current_index,
+            weights=request.book.weights,
+        )
+        pretrade = self.pre_trade_risk.constrain(
+            target,
+            current=request.book.weights,
+            drawdown=self.drawdown(request.book),
+            emergency_flatten_mask=assessment.flatten_mask,
+        )
+        risk_inputs = None
+        if self.portfolio_risk.requires_advanced_inputs:
+            provider = self.portfolio_risk_inputs_provider
+            if provider is None:
+                raise RuntimeError(
+                    "advanced portfolio risk requires a causal input provider"
+                )
+            risk_inputs = provider.inputs(
+                self.dataset,
+                index=request.current_index,
+            )
+        portfolio = self.portfolio_risk.constrain(
+            pretrade.weights,
+            portfolio_value=max(request.book.portfolio_value, 1e-12),
+            market_notional=self.market_notional(request.current_index),
+            covariance=None if risk_inputs is None else risk_inputs.covariance,
+            beta=None if risk_inputs is None else risk_inputs.beta,
+            stress_losses=None if risk_inputs is None else risk_inputs.stress_losses,
+        )
+        final_weights = np.asarray(portfolio.weights, dtype=np.float64)
+        constrained_turnover = float(np.abs(final_weights - request.book.weights).sum())
+        reasons = tuple(
+            dict.fromkeys(
+                (
+                    *pretrade.reasons,
+                    *assessment.reasons,
+                    *(f"portfolio:{item}" for item in portfolio.reasons),
+                )
+            )
+        )
+        return RiskConstrainedTarget(
+            weights=final_weights,
+            requested_turnover=pretrade.requested_turnover,
+            constrained_turnover=constrained_turnover,
+            was_constrained=bool(reasons),
+            reasons=reasons,
+            risk_scale=pretrade.risk_scale,
+            projection_l1=float(np.abs(target - final_weights).sum()),
+            turnover_overridden=pretrade.turnover_overridden,
+        )
+
+
+__all__ = [
+    "EnvironmentRiskProjector",
+    "EnvironmentRiskRequest",
+]

--- a/trade_rl/rl/training_telemetry.py
+++ b/trade_rl/rl/training_telemetry.py
@@ -204,6 +204,22 @@ class TrainingTelemetrySampler:
         self.disabled = False
         self._previous_weights: dict[int, tuple[float, ...]] = {}
         self._previous_close: dict[int, float] = {}
+        self._episode_ids: dict[int, int] = {}
+        self._next_episode_id = self.sequence + 1
+
+    def _episode_id(self, environment_id: int) -> int:
+        current = self._episode_ids.get(environment_id)
+        if current is not None:
+            return current
+        assigned = self._next_episode_id
+        self._next_episode_id += 1
+        self._episode_ids[environment_id] = assigned
+        return assigned
+
+    def _finish_episode(self, environment_id: int) -> None:
+        self._episode_ids.pop(environment_id, None)
+        self._previous_weights.pop(environment_id, None)
+        self._previous_close.pop(environment_id, None)
 
     def _weights(
         self,
@@ -363,6 +379,7 @@ class TrainingTelemetrySampler:
                     if environment_id < reward_rows.size
                     else None
                 )
+                episode_id = self._episode_id(environment_id)
                 self.writer.append(
                     TrainingTelemetryRecord(
                         sequence=self.sequence,
@@ -399,9 +416,16 @@ class TrainingTelemetrySampler:
                         emergency_deleverage=bool(info.get("emergency_deleverage")),
                         terminated=bool(info.get("hybrid_terminated")) or done,
                         truncated=bool(info.get("TimeLimit.truncated")),
+                        episode_id=episode_id,
                     )
                 )
                 emitted += 1
+                if (
+                    done
+                    or bool(info.get("hybrid_terminated"))
+                    or bool(info.get("TimeLimit.truncated"))
+                ):
+                    self._finish_episode(environment_id)
             return emitted
         except Exception:
             self.close()

--- a/trade_rl/studio/api.py
+++ b/trade_rl/studio/api.py
@@ -185,12 +185,20 @@ def create_app(
         seed: int | None = Query(default=None, ge=0),
         after_sequence: int = Query(default=0, ge=0),
         limit: int = Query(default=512, ge=1, le=2_000),
+        stream_generation: str | None = Query(
+            default=None,
+            pattern=(
+                r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-"
+                r"[0-9a-f]{4}-[0-9a-f]{12}$"
+            ),
+        ),
     ) -> TelemetryEventsResponse:
         return telemetry_reader.events(
             resolved_supervisor.get_job(job_id),
             seed=seed,
             after_sequence=after_sequence,
             limit=limit,
+            stream_generation=stream_generation,
         )
 
     @app.get(

--- a/trade_rl/studio/telemetry.py
+++ b/trade_rl/studio/telemetry.py
@@ -33,6 +33,7 @@ class TelemetryRecordResponse(StudioModel):
     environment_step: int = Field(ge=0)
     seed: int = Field(ge=0)
     environment_id: int = Field(ge=0)
+    episode_id: int | None = Field(default=None, ge=0)
     event_type: Literal[
         "rollout",
         "position",

--- a/trade_rl/studio/telemetry.py
+++ b/trade_rl/studio/telemetry.py
@@ -73,6 +73,7 @@ class TelemetryStatusResponse(StudioModel):
     malformed_lines: int = Field(ge=0)
     size_bytes: int = Field(ge=0)
     source: str | None = None
+    stream_generation: str | None = None
 
 
 class TelemetryEventsResponse(StudioModel):
@@ -82,6 +83,8 @@ class TelemetryEventsResponse(StudioModel):
     truncated: bool
     malformed_lines: int = Field(ge=0)
     sequence_gaps: tuple[tuple[int, int], ...]
+    stream_generation: str | None = None
+    reset_required: bool = False
 
 
 def _response(record: TelemetryRecordInput) -> TelemetryRecordResponse:
@@ -194,6 +197,7 @@ class StudioTelemetryReader:
             malformed_lines=status.malformed_lines,
             size_bytes=status.size_bytes,
             source=self._source(path),
+            stream_generation=status.stream_generation,
         )
 
     def events(
@@ -203,6 +207,7 @@ class StudioTelemetryReader:
         seed: int | None = None,
         after_sequence: int,
         limit: int,
+        stream_generation: str | None = None,
     ) -> TelemetryEventsResponse:
         _, selected_seed, path = self._selection(job, seed)
         if path is None:
@@ -218,6 +223,7 @@ class StudioTelemetryReader:
             path,
             after_sequence=after_sequence,
             limit=limit,
+            expected_generation=stream_generation,
         )
         if selected_seed is None or any(
             item.seed != selected_seed for item in page.items
@@ -232,6 +238,8 @@ class StudioTelemetryReader:
             truncated=page.truncated,
             malformed_lines=page.malformed_lines,
             sequence_gaps=page.sequence_gaps,
+            stream_generation=page.stream_generation,
+            reset_required=page.reset_required,
         )
 
 

--- a/trade_rl/telemetry/indexed_training.py
+++ b/trade_rl/telemetry/indexed_training.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from types import TracebackType
 from typing import Any, BinaryIO, Self, cast
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from trade_rl.telemetry import training as _training
 
@@ -23,7 +23,7 @@ if sys.platform == "win32":
 else:
     import fcntl
 
-_INDEX_SCHEMA = "training_telemetry_index_v1"
+_INDEX_SCHEMA = "training_telemetry_index_v2"
 _INDEX_STRIDE = 64
 _LOCK_RETRY_SECONDS = 0.01
 _BaseRecord = _training.TrainingTelemetryRecord
@@ -54,6 +54,7 @@ class StrictTrainingTelemetryRecord(_BaseRecord):
 class _TelemetryIndex:
     device: int
     inode: int
+    generation: str
     indexed_size: int = 0
     last_scan_start: int = 0
     record_count: int = 0
@@ -67,6 +68,7 @@ class _TelemetryIndex:
             "schema_version": _INDEX_SCHEMA,
             "device": self.device,
             "inode": self.inode,
+            "generation": self.generation,
             "indexed_size": self.indexed_size,
             "last_scan_start": self.last_scan_start,
             "record_count": self.record_count,
@@ -75,6 +77,22 @@ class _TelemetryIndex:
             "sequence_gaps": self.sequence_gaps,
             "checkpoints": self.checkpoints,
         }
+
+
+@dataclass(frozen=True, slots=True)
+class _IndexRefresh:
+    index: _TelemetryIndex | None
+    changed: bool
+
+
+@dataclass(slots=True)
+class _TelemetrySnapshot:
+    handle: BinaryIO
+    size: int
+    index: _TelemetryIndex
+
+    def close(self) -> None:
+        self.handle.close()
 
 
 def _index_path(path: Path) -> Path:
@@ -89,6 +107,27 @@ def _non_negative_int(value: object, *, field_name: str) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value < 0:
         raise ValueError(f"telemetry index {field_name} is invalid")
     return value
+
+
+def _canonical_generation(value: object, *, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"telemetry index {field_name} is invalid")
+    try:
+        resolved = str(UUID(value))
+    except (AttributeError, ValueError) as error:
+        raise ValueError(f"telemetry index {field_name} is invalid") from error
+    if resolved != value:
+        raise ValueError(f"telemetry index {field_name} is invalid")
+    return resolved
+
+
+def _expected_generation(value: str | None) -> str | None:
+    if value is None:
+        return None
+    try:
+        return _canonical_generation(value, field_name="expected_generation")
+    except ValueError as error:
+        raise ValueError("expected_generation must be a canonical UUID") from error
 
 
 def _pairs(value: object, *, field_name: str) -> list[Pair]:
@@ -118,6 +157,9 @@ def _load_index(path: Path) -> _TelemetryIndex | None:
         return _TelemetryIndex(
             device=_non_negative_int(raw.get("device"), field_name="device"),
             inode=_non_negative_int(raw.get("inode"), field_name="inode"),
+            generation=_canonical_generation(
+                raw.get("generation"), field_name="generation"
+            ),
             indexed_size=_non_negative_int(
                 raw.get("indexed_size"), field_name="indexed_size"
             ),
@@ -199,7 +241,11 @@ def _acquire_process_lock(handle: BinaryIO) -> None:
                 msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
                 return
             except OSError as error:
-                if error.errno not in (errno.EACCES, errno.EAGAIN, errno.EDEADLK):
+                if error.errno not in (
+                    errno.EACCES,
+                    errno.EAGAIN,
+                    errno.EDEADLK,
+                ):
                     raise
                 time.sleep(_LOCK_RETRY_SECONDS)
     else:
@@ -234,29 +280,43 @@ def _parse_record(raw_line: bytes) -> StrictTrainingTelemetryRecord:
     )
 
 
-def _refresh_index_unlocked(path: Path) -> _TelemetryIndex | None:
+def _new_index(stat: os.stat_result) -> _TelemetryIndex:
+    return _TelemetryIndex(
+        device=int(stat.st_dev),
+        inode=int(stat.st_ino),
+        generation=str(uuid4()),
+    )
+
+
+def _refresh_index_unlocked(path: Path) -> _IndexRefresh:
     resolved = Path(path)
     if not resolved.is_file() or resolved.is_symlink():
-        return None
+        return _IndexRefresh(None, False)
     stat = resolved.stat()
     existing = _load_index(resolved)
-    if (
+    rebuilt = (
         existing is None
         or existing.device != int(stat.st_dev)
         or existing.inode != int(stat.st_ino)
         or stat.st_size < existing.indexed_size
-    ):
-        index = _TelemetryIndex(device=int(stat.st_dev), inode=int(stat.st_ino))
-    else:
-        index = existing
-    index.last_scan_start = index.indexed_size
+    )
+    index = _new_index(stat) if rebuilt else existing
+    if index is None:
+        raise RuntimeError("telemetry index refresh failed")
+    changed = rebuilt
+    scan_start = index.indexed_size
+    advanced = False
 
     with resolved.open("rb") as handle:
-        handle.seek(index.indexed_size)
+        handle.seek(scan_start)
         while True:
             raw_line = handle.readline()
             if not raw_line or not raw_line.endswith(b"\n"):
                 break
+            if not advanced:
+                index.last_scan_start = scan_start
+                advanced = True
+            changed = True
             end_offset = handle.tell()
             index.indexed_size = end_offset
             line = raw_line.strip()
@@ -264,7 +324,12 @@ def _refresh_index_unlocked(path: Path) -> _TelemetryIndex | None:
                 continue
             try:
                 record = _parse_record(line)
-            except (UnicodeError, json.JSONDecodeError, TypeError, ValueError):
+            except (
+                UnicodeError,
+                json.JSONDecodeError,
+                TypeError,
+                ValueError,
+            ):
                 index.malformed_lines += 1
                 continue
             if record.sequence <= index.last_sequence:
@@ -278,8 +343,33 @@ def _refresh_index_unlocked(path: Path) -> _TelemetryIndex | None:
             index.last_sequence = record.sequence
             if index.record_count == 1 or index.record_count % _INDEX_STRIDE == 0:
                 index.checkpoints.append((record.sequence, end_offset))
-    _write_index(resolved, index)
-    return index
+    if changed:
+        _write_index(resolved, index)
+    return _IndexRefresh(index, changed)
+
+
+def _open_snapshot_unlocked(
+    path: Path,
+    index: _TelemetryIndex,
+) -> _TelemetrySnapshot:
+    handle = path.open("rb")
+    try:
+        stat = os.fstat(handle.fileno())
+        if (int(stat.st_dev), int(stat.st_ino)) != (
+            index.device,
+            index.inode,
+        ):
+            raise RuntimeError("telemetry stream identity changed")
+        if stat.st_size < index.indexed_size:
+            raise RuntimeError("telemetry stream size regressed")
+        return _TelemetrySnapshot(
+            handle=handle,
+            size=index.indexed_size,
+            index=index,
+        )
+    except BaseException:
+        handle.close()
+        raise
 
 
 def _seek_offset(index: _TelemetryIndex, after_sequence: int) -> Pair:
@@ -296,56 +386,75 @@ def read_indexed_training_telemetry(
     *,
     after_sequence: int = 0,
     limit: int = 512,
+    expected_generation: str | None = None,
 ) -> _training.TrainingTelemetryPage:
     if isinstance(after_sequence, bool) or after_sequence < 0:
         raise ValueError("after_sequence must be non-negative")
     if isinstance(limit, bool) or limit <= 0 or limit > 2_000:
         raise ValueError("limit must be between 1 and 2000")
+    expected = _expected_generation(expected_generation)
     resolved = Path(path)
     with _telemetry_process_lock(resolved):
-        index = _refresh_index_unlocked(resolved)
+        refresh = _refresh_index_unlocked(resolved)
+        index = refresh.index
         if index is None:
             return _training.TrainingTelemetryPage((), after_sequence, False, 0, ())
-
+        if expected is not None and expected != index.generation:
+            return _training.TrainingTelemetryPage(
+                items=(),
+                next_sequence=0,
+                truncated=False,
+                malformed_lines=index.malformed_lines,
+                sequence_gaps=tuple(index.sequence_gaps),
+                stream_generation=index.generation,
+                reset_required=True,
+            )
         checkpoint_sequence, offset = _seek_offset(index, after_sequence)
-        previous_sequence = checkpoint_sequence or None
-        items: list[StrictTrainingTelemetryRecord] = []
-        truncated = False
-        snapshot_size = index.indexed_size
-        with resolved.open("rb") as handle:
-            handle.seek(offset)
-            while handle.tell() < snapshot_size:
-                remaining = snapshot_size - handle.tell()
-                raw_line = handle.readline(remaining)
-                if not raw_line or not raw_line.endswith(b"\n"):
-                    break
-                line = raw_line.strip()
-                if not line:
-                    continue
-                try:
-                    record = _parse_record(line)
-                except (UnicodeError, json.JSONDecodeError, TypeError, ValueError):
-                    continue
-                if (
-                    previous_sequence is not None
-                    and record.sequence <= previous_sequence
-                ):
-                    continue
-                previous_sequence = record.sequence
-                if record.sequence <= after_sequence:
-                    continue
-                if len(items) >= limit:
-                    truncated = True
-                    break
-                items.append(record)
-        next_sequence = items[-1].sequence if items else after_sequence
-        return _training.TrainingTelemetryPage(
-            items=tuple(items),
-            next_sequence=next_sequence,
-            truncated=truncated,
-            malformed_lines=index.malformed_lines,
-            sequence_gaps=tuple(index.sequence_gaps),
-        )
+        snapshot = _open_snapshot_unlocked(resolved, index)
+
+    previous_sequence = checkpoint_sequence or None
+    items: list[StrictTrainingTelemetryRecord] = []
+    truncated = False
+    try:
+        snapshot.handle.seek(offset)
+        while snapshot.handle.tell() < snapshot.size:
+            remaining = snapshot.size - snapshot.handle.tell()
+            raw_line = snapshot.handle.readline(remaining)
+            if not raw_line or not raw_line.endswith(b"\n"):
+                break
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                record = _parse_record(line)
+            except (
+                UnicodeError,
+                json.JSONDecodeError,
+                TypeError,
+                ValueError,
+            ):
+                continue
+            if previous_sequence is not None and record.sequence <= previous_sequence:
+                continue
+            previous_sequence = record.sequence
+            if record.sequence <= after_sequence:
+                continue
+            if len(items) >= limit:
+                truncated = True
+                break
+            items.append(record)
+    finally:
+        snapshot.close()
+    next_sequence = items[-1].sequence if items else after_sequence
+    return _training.TrainingTelemetryPage(
+        items=tuple(items),
+        next_sequence=next_sequence,
+        truncated=truncated,
+        malformed_lines=snapshot.index.malformed_lines,
+        sequence_gaps=tuple(snapshot.index.sequence_gaps),
+        stream_generation=snapshot.index.generation,
+        reset_required=False,
+    )
 
 
 def indexed_training_telemetry_status(
@@ -353,15 +462,22 @@ def indexed_training_telemetry_status(
 ) -> _training.TrainingTelemetryStatus:
     resolved = Path(path)
     with _telemetry_process_lock(resolved):
-        index = _refresh_index_unlocked(resolved)
+        refresh = _refresh_index_unlocked(resolved)
+        index = refresh.index
         if index is None:
             return _training.TrainingTelemetryStatus(False, 0, 0, 0, 0)
+        snapshot = _open_snapshot_unlocked(resolved, index)
+        try:
+            size_bytes = int(os.fstat(snapshot.handle.fileno()).st_size)
+        finally:
+            snapshot.close()
         return _training.TrainingTelemetryStatus(
             available=True,
             record_count=index.record_count,
             last_sequence=index.last_sequence,
             malformed_lines=index.malformed_lines,
-            size_bytes=resolved.stat().st_size,
+            size_bytes=size_bytes,
+            stream_generation=index.generation,
         )
 
 
@@ -392,7 +508,7 @@ class IndexedTrainingTelemetryWriter(_BaseWriter):
         self._fd: int | None = descriptor
         try:
             with _telemetry_process_lock(self.path):
-                index = _refresh_index_unlocked(self.path)
+                index = _refresh_index_unlocked(self.path).index
                 self._last_sequence = 0 if index is None else index.last_sequence
         except BaseException:
             os.close(descriptor)
@@ -415,7 +531,7 @@ class IndexedTrainingTelemetryWriter(_BaseWriter):
             if descriptor is None:
                 raise RuntimeError("telemetry writer is closed")
             with _telemetry_process_lock(self.path):
-                index = _refresh_index_unlocked(self.path)
+                index = _refresh_index_unlocked(self.path).index
                 if index is None:
                     raise RuntimeError("telemetry stream is unavailable")
                 path_stat = self.path.stat()

--- a/trade_rl/telemetry/indexed_training.py
+++ b/trade_rl/telemetry/indexed_training.py
@@ -2,15 +2,30 @@
 
 from __future__ import annotations
 
+import errno
 import json
+import os
+import sys
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Self, cast
+from types import TracebackType
+from typing import Any, BinaryIO, Self, cast
+from uuid import uuid4
 
 from trade_rl.telemetry import training as _training
 
+if sys.platform == "win32":
+    import msvcrt
+else:
+    import fcntl
+
 _INDEX_SCHEMA = "training_telemetry_index_v1"
 _INDEX_STRIDE = 64
+_LOCK_RETRY_SECONDS = 0.01
 _BaseRecord = _training.TrainingTelemetryRecord
 _BaseWriter = _training.TrainingTelemetryWriter
 Pair = tuple[int, int]
@@ -64,6 +79,10 @@ class _TelemetryIndex:
 
 def _index_path(path: Path) -> Path:
     return path.with_name(f"{path.name}.index.json")
+
+
+def _lock_path(path: Path) -> Path:
+    return path.with_name(f"{path.name}.lock")
 
 
 def _non_negative_int(value: object, *, field_name: str) -> int:
@@ -121,18 +140,92 @@ def _load_index(path: Path) -> _TelemetryIndex | None:
         return None
 
 
+def _sync_parent_directory(path: Path) -> None:
+    if sys.platform == "win32":
+        return
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError:
+        return
+    try:
+        os.fsync(descriptor)
+    except OSError:
+        pass
+    finally:
+        os.close(descriptor)
+
+
 def _write_index(path: Path, index: _TelemetryIndex) -> None:
     destination = _index_path(path)
-    temporary = destination.with_name(f".{destination.name}.tmp")
-    payload = json.dumps(
-        index.to_json_dict(),
-        ensure_ascii=False,
-        allow_nan=False,
-        sort_keys=True,
-        separators=(",", ":"),
+    temporary = destination.with_name(
+        f".{destination.name}.{os.getpid()}.{uuid4().hex}.tmp"
     )
-    temporary.write_text(payload + "\n", encoding="utf-8")
-    temporary.replace(destination)
+    payload = (
+        json.dumps(
+            index.to_json_dict(),
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        + b"\n"
+    )
+    try:
+        with temporary.open("xb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, destination)
+        _sync_parent_directory(destination.parent)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _prepare_windows_lock(handle: BinaryIO) -> None:
+    handle.seek(0, os.SEEK_END)
+    if handle.tell() == 0:
+        handle.write(b"\0")
+        handle.flush()
+    handle.seek(0)
+
+
+def _acquire_process_lock(handle: BinaryIO) -> None:
+    if sys.platform == "win32":
+        _prepare_windows_lock(handle)
+        while True:
+            try:
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                return
+            except OSError as error:
+                if error.errno not in (errno.EACCES, errno.EAGAIN, errno.EDEADLK):
+                    raise
+                time.sleep(_LOCK_RETRY_SECONDS)
+    else:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+
+
+def _release_process_lock(handle: BinaryIO) -> None:
+    if sys.platform == "win32":
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+    else:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+@contextmanager
+def _telemetry_process_lock(path: Path) -> Iterator[None]:
+    lock_path = _lock_path(Path(path))
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    if lock_path.is_symlink():
+        raise RuntimeError("telemetry lock path must not be a symbolic link")
+    with lock_path.open("a+b", buffering=0) as handle:
+        _acquire_process_lock(handle)
+        try:
+            yield
+        finally:
+            _release_process_lock(handle)
 
 
 def _parse_record(raw_line: bytes) -> StrictTrainingTelemetryRecord:
@@ -141,7 +234,7 @@ def _parse_record(raw_line: bytes) -> StrictTrainingTelemetryRecord:
     )
 
 
-def _refresh_index(path: Path) -> _TelemetryIndex | None:
+def _refresh_index_unlocked(path: Path) -> _TelemetryIndex | None:
     resolved = Path(path)
     if not resolved.is_file() or resolved.is_symlink():
         return None
@@ -209,64 +302,170 @@ def read_indexed_training_telemetry(
     if isinstance(limit, bool) or limit <= 0 or limit > 2_000:
         raise ValueError("limit must be between 1 and 2000")
     resolved = Path(path)
-    index = _refresh_index(resolved)
-    if index is None:
-        return _training.TrainingTelemetryPage((), after_sequence, False, 0, ())
+    with _telemetry_process_lock(resolved):
+        index = _refresh_index_unlocked(resolved)
+        if index is None:
+            return _training.TrainingTelemetryPage((), after_sequence, False, 0, ())
 
-    checkpoint_sequence, offset = _seek_offset(index, after_sequence)
-    previous_sequence = checkpoint_sequence or None
-    items: list[StrictTrainingTelemetryRecord] = []
-    truncated = False
-    with resolved.open("rb") as handle:
-        handle.seek(offset)
-        while True:
-            raw_line = handle.readline()
-            if not raw_line or not raw_line.endswith(b"\n"):
-                break
-            line = raw_line.strip()
-            if not line:
-                continue
-            try:
-                record = _parse_record(line)
-            except (UnicodeError, json.JSONDecodeError, TypeError, ValueError):
-                continue
-            if previous_sequence is not None and record.sequence <= previous_sequence:
-                continue
-            previous_sequence = record.sequence
-            if record.sequence <= after_sequence:
-                continue
-            if len(items) >= limit:
-                truncated = True
-                break
-            items.append(record)
-    next_sequence = items[-1].sequence if items else after_sequence
-    return _training.TrainingTelemetryPage(
-        items=tuple(items),
-        next_sequence=next_sequence,
-        truncated=truncated,
-        malformed_lines=index.malformed_lines,
-        sequence_gaps=tuple(index.sequence_gaps),
-    )
+        checkpoint_sequence, offset = _seek_offset(index, after_sequence)
+        previous_sequence = checkpoint_sequence or None
+        items: list[StrictTrainingTelemetryRecord] = []
+        truncated = False
+        snapshot_size = index.indexed_size
+        with resolved.open("rb") as handle:
+            handle.seek(offset)
+            while handle.tell() < snapshot_size:
+                remaining = snapshot_size - handle.tell()
+                raw_line = handle.readline(remaining)
+                if not raw_line or not raw_line.endswith(b"\n"):
+                    break
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    record = _parse_record(line)
+                except (UnicodeError, json.JSONDecodeError, TypeError, ValueError):
+                    continue
+                if (
+                    previous_sequence is not None
+                    and record.sequence <= previous_sequence
+                ):
+                    continue
+                previous_sequence = record.sequence
+                if record.sequence <= after_sequence:
+                    continue
+                if len(items) >= limit:
+                    truncated = True
+                    break
+                items.append(record)
+        next_sequence = items[-1].sequence if items else after_sequence
+        return _training.TrainingTelemetryPage(
+            items=tuple(items),
+            next_sequence=next_sequence,
+            truncated=truncated,
+            malformed_lines=index.malformed_lines,
+            sequence_gaps=tuple(index.sequence_gaps),
+        )
 
 
 def indexed_training_telemetry_status(
     path: Path,
 ) -> _training.TrainingTelemetryStatus:
     resolved = Path(path)
-    index = _refresh_index(resolved)
-    if index is None:
-        return _training.TrainingTelemetryStatus(False, 0, 0, 0, 0)
-    return _training.TrainingTelemetryStatus(
-        available=True,
-        record_count=index.record_count,
-        last_sequence=index.last_sequence,
-        malformed_lines=index.malformed_lines,
-        size_bytes=resolved.stat().st_size,
-    )
+    with _telemetry_process_lock(resolved):
+        index = _refresh_index_unlocked(resolved)
+        if index is None:
+            return _training.TrainingTelemetryStatus(False, 0, 0, 0, 0)
+        return _training.TrainingTelemetryStatus(
+            available=True,
+            record_count=index.record_count,
+            last_sequence=index.last_sequence,
+            malformed_lines=index.malformed_lines,
+            size_bytes=resolved.stat().st_size,
+        )
+
+
+def _write_all(descriptor: int, payload: bytes) -> None:
+    view = memoryview(payload)
+    while view:
+        written = os.write(descriptor, view)
+        if written <= 0:
+            raise OSError("telemetry append made no progress")
+        view = view[written:]
 
 
 class IndexedTrainingTelemetryWriter(_BaseWriter):
-    """Existing append writer paired with the indexed status implementation."""
+    """Append telemetry with thread and cross-process sequence serialization."""
+
+    def __init__(self, path: Path, *, flush_every: int = 32) -> None:
+        if isinstance(flush_every, bool) or flush_every <= 0:
+            raise ValueError("flush_every must be positive")
+        self.path = Path(path)
+        self.flush_every = int(flush_every)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if self.path.is_symlink():
+            raise RuntimeError("telemetry path must not be a symbolic link")
+        self._lock = threading.Lock()
+        self._pending = 0
+        flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND | getattr(os, "O_BINARY", 0)
+        descriptor = os.open(self.path, flags, 0o600)
+        self._fd: int | None = descriptor
+        try:
+            with _telemetry_process_lock(self.path):
+                index = _refresh_index_unlocked(self.path)
+                self._last_sequence = 0 if index is None else index.last_sequence
+        except BaseException:
+            os.close(descriptor)
+            self._fd = None
+            raise
+
+    def append(self, record: _BaseRecord) -> None:
+        payload = (
+            json.dumps(
+                record.to_json_dict(),
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+                allow_nan=False,
+            ).encode("utf-8")
+            + b"\n"
+        )
+        with self._lock:
+            descriptor = self._fd
+            if descriptor is None:
+                raise RuntimeError("telemetry writer is closed")
+            with _telemetry_process_lock(self.path):
+                index = _refresh_index_unlocked(self.path)
+                if index is None:
+                    raise RuntimeError("telemetry stream is unavailable")
+                path_stat = self.path.stat()
+                descriptor_stat = os.fstat(descriptor)
+                if (
+                    int(descriptor_stat.st_dev),
+                    int(descriptor_stat.st_ino),
+                ) != (int(path_stat.st_dev), int(path_stat.st_ino)):
+                    raise RuntimeError("telemetry stream identity changed")
+                if path_stat.st_size != index.indexed_size:
+                    raise RuntimeError(
+                        "telemetry file has an incomplete trailing record"
+                    )
+                if record.sequence <= index.last_sequence:
+                    raise ValueError("telemetry sequence must strictly increase")
+                _write_all(descriptor, payload)
+                self._last_sequence = record.sequence
+                self._pending += 1
+                if self._pending >= self.flush_every:
+                    os.fsync(descriptor)
+                    self._pending = 0
+
+    def flush(self) -> None:
+        with self._lock:
+            if self._fd is not None:
+                os.fsync(self._fd)
+                self._pending = 0
+
+    def close(self) -> None:
+        with self._lock:
+            descriptor = self._fd
+            if descriptor is None:
+                return
+            try:
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+                self._fd = None
+                self._pending = 0
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc_value: BaseException | None,
+        _traceback: TracebackType | None,
+    ) -> None:
+        self.close()
 
 
 __all__ = [

--- a/trade_rl/telemetry/training.py
+++ b/trade_rl/telemetry/training.py
@@ -278,6 +278,8 @@ class TrainingTelemetryPage:
     truncated: bool
     malformed_lines: int
     sequence_gaps: tuple[tuple[int, int], ...]
+    stream_generation: str | None = None
+    reset_required: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -287,6 +289,7 @@ class TrainingTelemetryStatus:
     last_sequence: int
     malformed_lines: int
     size_bytes: int
+    stream_generation: str | None = None
 
 
 class TrainingTelemetryWriter:

--- a/trade_rl/telemetry/training.py
+++ b/trade_rl/telemetry/training.py
@@ -137,6 +137,7 @@ class TrainingTelemetryRecord:
     emergency_deleverage: bool
     terminated: bool
     truncated: bool
+    episode_id: int | None = None
     schema_version: str = TELEMETRY_SCHEMA_VERSION
 
     def __post_init__(self) -> None:
@@ -161,6 +162,12 @@ class TrainingTelemetryRecord:
             or self.market_index < 0
         ):
             raise ValueError("market_index is invalid")
+        if self.episode_id is not None and (
+            isinstance(self.episode_id, bool)
+            or not isinstance(self.episode_id, int)
+            or self.episode_id < 0
+        ):
+            raise ValueError("episode_id is invalid")
         try:
             recorded = datetime.fromisoformat(self.recorded_at.replace("Z", "+00:00"))
         except ValueError as error:
@@ -205,6 +212,7 @@ class TrainingTelemetryRecord:
             "environment_step": self.environment_step,
             "seed": self.seed,
             "environment_id": self.environment_id,
+            "episode_id": self.episode_id,
             "event_type": self.event_type,
             "market_index": self.market_index,
             "market_time": self.market_time,
@@ -246,6 +254,7 @@ class TrainingTelemetryRecord:
             environment_step=_required_int(raw, "environment_step"),
             seed=_required_int(raw, "seed"),
             environment_id=_required_int(raw, "environment_id"),
+            episode_id=_optional_int(raw, "episode_id"),
             event_type=cast(TelemetryEventType, event_type),
             market_index=_optional_int(raw, "market_index"),
             market_time=_optional_string(raw, "market_time"),


### PR DESCRIPTION
Synchronize current `main`, including producer telemetry episode identity PR #103, into `ci/guard-sequence-projection-stability-20260723` before final exact-head verification of PR #94.

This changes only the feature branch and does not merge PR #94 into `main`.