### PR TITLE
test: export PR126 source

### DIFF
--- a/.github/workflows/export-pr126-source.yml
+++ b/.github/workflows/export-pr126-source.yml
@@ -1,0 +1,34 @@
+name: Export PR126 source
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/export-pr126-source.yml'
+
+permissions:
+  contents: read
+
+env:
+  TARGET_SHA: 94ff547ffd54e8d06e23b77665d664820064d97c
+
+jobs:
+  export:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout exact target
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ env.TARGET_SHA }}
+          persist-credentials: false
+      - name: Verify exact target
+        run: test "$(git rev-parse HEAD)" = "$TARGET_SHA"
+      - name: Package source
+        run: tar --exclude=.git -czf /tmp/pr126-source.tar.gz .
+      - name: Upload source
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: pr126-source
+          path: /tmp/pr126-source.tar.gz
+          if-no-files-found: error


### PR DESCRIPTION
Closed without merge after source export. The same branch was upgraded to a verified implementation runner; a fresh temporary PR will be opened so its `pull_request.opened` event executes the workflow against exact PR #126 head `94ff547ffd54e8d06e23b77665d664820064d97c`.