### PR TITLE
docs: correct PR126 RED evidence

### DIFF
--- a/docs/verification/2026-07-23-environment-policy-schedule-contract-extraction.md
+++ b/docs/verification/2026-07-23-environment-policy-schedule-contract-extraction.md
@@ -23,13 +23,29 @@ The change does not alter action semantics, reward calculations, emergency-risk 
 
 Production remains `NO-GO`.
 
-## 2. Test-first evidence and limitation
+## 2. TDD RED evidence
 
-The architecture contract was committed at `dbd68a3161d947d84785d4ff37c8b4bb1afd5f8d` before `trade_rl/rl/environment_policy_schedule_contract.py` existed. That commit requires local ownership of the new contract, one facade delegation, the absence of the extracted inline policy, preserved validation order, and a 190-line constructor bound.
+The architecture and direct characterization contracts were committed before production implementation. The clean RED head was:
 
-The direct characterization test file was also committed before production implementation. It defines supplied-identity preservation, default action-spec construction, action names, bars and decision hours, exact validation messages and order, environment integration, and digest preservation.
+- commit: `4c52249de08230a4493658a1f23104e3513e1e34`;
+- CI run: `29989543655`;
+- pytest diagnostic artifact: `8556494515`;
+- artifact digest: `sha256:6d522d868f88eb24f88fd50f6047e701787622f0a4fbc68f2f71992ef2e286c8`.
 
-A clean RED GitHub Actions run is not claimed. Connector-authored branch commits did not reliably produce a preserved `pull_request` run during the initial RED phase, and temporary branch-local workflows were removed from the final diff. The test-before-production commit order is preserved, but the maintained verification evidence begins with the exact GREEN/ratchet head below.
+At this head:
+
+- Studio frontend and fixed-viewport verification passed;
+- workflow-security checks passed;
+- Ruff and Ruff formatting passed;
+- Mypy passed;
+- Import Linter passed;
+- dead-code reporting passed;
+- recovery and structured-serving smoke passed;
+- Ubuntu compatibility passed;
+- Windows compatibility passed;
+- the complete training image and packaged non-root runtime probe passed.
+
+Complete pytest collection then failed with exactly two collection errors because `trade_rl.rl.environment_policy_schedule_contract` did not exist. No production implementation for the boundary was present at the clean RED head.
 
 ## 3. Implemented contract
 
@@ -100,9 +116,15 @@ Architecture tests require:
 
 The measured constructor source span is 186 lines, reduced from 218 after PR #125. Across `trade_rl/rl/environment.py`, this extraction adds 20 lines and removes 50 lines, for a net reduction of 30 source lines.
 
-## 5. Exact-head verification
+## 5. Integration regression detected and repaired
 
-The exact implementation, stress regression, and coverage-ratchet head was:
+Implementation review detected one unrelated deletion in commit `9e01814d999cd2d0fc9cd0f5ecf25da2aa16f44e`: the denominator expression in the existing stress initial-state peak calculation had been removed. That change was outside the policy/schedule extraction and would have attempted division by an empty tuple during stress reset.
+
+Commit `05efa77a9d183663de7f786a6c27f35116f05347` restored `1.0 - self.config.stress_drawdown_fraction`. The maintained stress-reset test exercises this path. Temporary implementation workflows, triggers, and synchronization markers were removed before final verification.
+
+## 6. Exact-head verification
+
+The exact implementation, repaired stress regression, and coverage-ratchet head was:
 
 - commit: `08d8bdf6b39f00adaaca6d3f65e3183404083447`;
 - CI run: `29993016948`;
@@ -124,6 +146,15 @@ The complete test result was:
 - 100.0% branch coverage.
 
 A permanent 100.0% critical branch-coverage ratchet is recorded in `pyproject.toml`.
+
+Final CI evidence artifacts include:
+
+- pytest and coverage: `8557864354`, digest `sha256:ccac19935762ff2695400fddbd0fb359159daf79c25f442687d2c73ed64925c7`;
+- training image: `8557816573`, digest `sha256:fd8cb7d41ddca4dabe1c157fb723a90171051cf61a5be30790e31f02fde1de99`;
+- architecture diagnostics: `8557812721`, digest `sha256:6a2eeebf71094192b7c409f8894f02609003a7a34e8f1ef1a3835effbad30113`;
+- static diagnostics: `8557812197`, digest `sha256:8207d00790d0f996c775e8d4f061708a29a8ae697b88bfbb7b797325c7fd70e9`;
+- Windows compatibility: `8557793257`, digest `sha256:b14d31cf706e83b3ba3b9e916ab6960b44d354236bd255060c8385f444b9ca6e`;
+- Ubuntu compatibility: `8557786892`, digest `sha256:d26f78e9448a14afaea58565b20f168eae1763c80f41c3211550de1917ff4333`.
 
 CI run `29993016948` passed:
 
@@ -150,7 +181,7 @@ PostgreSQL Catalog run `29993016956` passed:
 - catalog unit and integration tests;
 - cleanup.
 
-## 6. Final architecture disposition
+## 7. Final architecture disposition
 
 `AUD-RL-001` remains a maintainability risk rather than a reproduced behavioral defect.
 


### PR DESCRIPTION
Corrects the merged PR #126 verification record to cite the preserved clean RED head, CI run, pytest artifact, and exact two collection failures. Also records the detected stress-reset integration regression, its repair commit, and final CI artifact identities. No production code changes. Production remains `NO-GO`.