### PR TITLE
feat: add paper reconciliation CLI

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -106,6 +106,35 @@ uv run trade-rl train run \
   --run-id quickstart-001
 ```
 
+## Paper reconciliationとOffline証拠
+
+`paper_reconciliation_request_v1`には、外部Paper環境で正規化した注文・約定・会計照合の測定値を入れます。CLIはfield closure、型、Identity、時刻、件数、差分、許容値を検証し、`passed`を再計算します。ただし、入力値が本当に特定Paper環境から取得されたこと自体をCLIが証明するわけではありません。
+
+作成された照合artifactのdigestをFresh confirmation requestへ入れ、その後Ed25519署名します。Serving packageでは照合artifactの明示パスが必須です。
+
+```bash
+uv run trade-rl reconciliation create \
+  --request /secure/paper-reconciliation-request.json \
+  --output /secure/paper-reconciliation.json
+
+uv run trade-rl confirmation create \
+  --request /secure/fresh-confirmation-request.json \
+  --private-key /secure/confirmation-key.json \
+  --output /secure/fresh-confirmation.json
+
+uv run trade-rl serving package \
+  --training-run var/research/selected-final \
+  --confirmation /secure/fresh-confirmation.json \
+  --paper-reconciliation /secure/paper-reconciliation.json \
+  --confirmation-public-keys /secure/confirmation-public-keys.json \
+  --output var/serving/candidate \
+  --signal-digest <signal-sha256> \
+  --selection-digest <selection-sha256> \
+  --trusted-now 2026-08-18T03:00:00Z
+```
+
+照合artifactを作れることは、実際のPaper runがGateを通過したことを意味しません。Production statusは実証証拠が揃うまで`NO-GO`です。
+
 ## PostgreSQL artifact catalog
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -137,11 +137,13 @@ uv run trade-rl data binance \
 
 Spot and USDⓈ-M are supported linear products. COIN-M inverse futures fail closed because the current accounting model is linear. See [docs/BINANCE.md](docs/BINANCE.md).
 
-Both execution commands print one machine-readable JSON result. Exploratory training cannot be packaged or released. A selected-final run requires an externally signed selection authorization before model construction, at least 30 days of Ed25519-signed post-training confirmation, deterministic bundle packaging, matching conservative execution evidence, and a separate offline release approval. Direct exchange connectivity is not implemented.
+Both execution commands print one machine-readable JSON result. Exploratory training cannot be packaged or released. A selected-final run requires an externally signed selection authorization before model construction, at least 30 days of Ed25519-signed post-training confirmation, deterministic bundle packaging, matching conservative execution evidence, a verified paper-reconciliation artifact, and a separate offline release approval. Direct exchange connectivity is not implemented.
 
 ### Offline evidence and release commands
 
 Private Ed25519 key files use schema `ed25519_private_key_v1`, must be purpose-bound, and on POSIX must have mode `0600`. They are used only on an offline approval host.
+
+The reconciliation request contains externally normalized paper-order, fill, and accounting measurements. `reconciliation create` validates the strict request and derives the artifact's pass state, but it does not independently prove the source of those measurements. The resulting digest must be referenced by the fresh-confirmation request and is then covered by the confirmation signature.
 
 ```bash
 uv run trade-rl selection authorize \
@@ -152,10 +154,24 @@ uv run trade-rl selection authorize \
   --expires-at 2026-07-25T03:00:00Z \
   --output /secure/selection-authorization.json
 
+uv run trade-rl reconciliation create \
+  --request /secure/paper-reconciliation-request.json \
+  --output /secure/paper-reconciliation.json
+
 uv run trade-rl confirmation create \
   --request /secure/fresh-confirmation-request.json \
   --private-key /secure/confirmation-key.json \
   --output /secure/fresh-confirmation.json
+
+uv run trade-rl serving package \
+  --training-run var/research/selected-final \
+  --confirmation /secure/fresh-confirmation.json \
+  --paper-reconciliation /secure/paper-reconciliation.json \
+  --confirmation-public-keys /secure/confirmation-public-keys.json \
+  --output var/serving/candidate \
+  --signal-digest <signal-sha256> \
+  --selection-digest <selection-sha256> \
+  --trusted-now 2026-08-18T03:00:00Z
 
 uv run trade-rl release approve \
   --bundle var/serving/candidate \
@@ -167,7 +183,7 @@ uv run trade-rl release approve \
   --expires-at 2026-09-18T03:00:00Z
 ```
 
-The authorization, confirmation, and release files are immutable and remain external to the candidate bundle until verification.
+The authorization, reconciliation, confirmation, and release files are immutable and remain external to the candidate bundle until verification and packaging.
 
 ## Docker GPU full research run
 

--- a/docs/superpowers/plans/2026-07-23-paper-reconciliation-cli.md
+++ b/docs/superpowers/plans/2026-07-23-paper-reconciliation-cli.md
@@ -1,0 +1,57 @@
+# Paper Reconciliation CLI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development and superpowers:verification-before-completion task by task.
+
+**Goal:** Produce immutable paper reconciliation evidence from a strict normalized request and require an explicit reconciliation path in the public Serving package CLI.
+
+**Architecture:** `trade_rl.cli.extended` owns request parsing and machine-readable command results. `trade_rl.evaluation.paper_reconciliation` remains the sole authority for validation, derived pass state, hashing, and immutable artifact writing. The Serving package Python API remains backward compatible while the CLI requires an explicit path.
+
+**Tech Stack:** Python 3.12, argparse, JSON, pytest, Ruff, MyPy, GitHub Actions.
+
+## Constraints
+
+- Production remains `NO-GO`.
+- Direct exchange routing remains `NOT_IMPLEMENTED`.
+- The reconciliation command accepts normalized measurements only; no venue adapter or network access.
+- No signing key is accepted by the reconciliation command.
+- `passed` is derived, not accepted from the request.
+- A valid failed report is written as evidence; promotion still rejects it.
+
+### Task 1: Define the reconciliation-create CLI contract
+
+**Files:**
+- Modify: `tests/cli/test_offline_approval_cli.py`
+- Modify: `trade_rl/cli/extended.py`
+
+- [ ] Add a failing test for `trade-rl reconciliation create` using a complete `paper_reconciliation_request_v1` request.
+- [ ] Assert immutable artifact loading, derived `passed`, exact result JSON, and `production_status: NO-GO`.
+- [ ] Add a failing test proving that an extra caller-supplied `passed` field is rejected and no artifact is written.
+- [ ] Confirm RED because the command is unsupported.
+- [ ] Add the parser, strict request-field closure, type helpers, command handler, and dispatcher entry.
+- [ ] Confirm focused GREEN.
+
+### Task 2: Require the explicit artifact path in Serving CLI
+
+**Files:**
+- Modify: `tests/cli/test_artifact_commands.py` or the nearest existing Serving package CLI tests
+- Modify: `trade_rl/cli/extended.py`
+
+- [ ] Add a failing parser/forwarding test for required `--paper-reconciliation`.
+- [ ] Assert the exact `Path` reaches `package_selected_training_run(paper_reconciliation_path=...)`.
+- [ ] Add the required parser option and forwarding argument.
+- [ ] Retain the Python package API sibling fallback for direct callers.
+- [ ] Confirm focused GREEN.
+
+### Task 3: Document, verify, and publish
+
+**Files:**
+- Modify: `README.md`
+- Modify: `README.ja.md`
+- Modify: `docs/ARCHITECTURE.md`
+- Modify: `docs/RESEARCH_STATUS.md` only if the operational status wording changes materially.
+
+- [ ] Add the reconciliation-create command before confirmation creation in the documented offline evidence flow.
+- [ ] State that input measurements are externally normalized and are not independently proven by the CLI.
+- [ ] Run Ruff, formatter, MyPy, Import Linter, complete pytest with branch coverage, Studio checks, Ubuntu/Windows compatibility, training image, and PostgreSQL Catalog at the exact PR head.
+- [ ] Record RED/GREEN SHAs, run IDs, test count, coverage, and artifact digests.
+- [ ] Mark ready and squash merge only after every required check succeeds.

--- a/docs/superpowers/specs/2026-07-23-paper-reconciliation-cli-design.md
+++ b/docs/superpowers/specs/2026-07-23-paper-reconciliation-cli-design.md
@@ -1,0 +1,85 @@
+# Paper Reconciliation CLI Design
+
+## Purpose
+
+Make the verified `paper_reconciliation_evidence_v1` contract operationally producible from normalized external paper-run measurements and make its path explicit at the Serving packaging boundary.
+
+Production remains `NO-GO`. This work does not add a paper broker, exchange connectivity, credentials, order routing, or a claim that supplied measurements came from a real maintained paper run.
+
+## Alternatives considered
+
+### Raw order/fill log ingestion and reconciliation
+
+The CLI could ingest venue-specific raw logs and compute all matches itself. This is premature because no maintained paper venue or canonical raw-log schema is selected. It would couple the repository to an invented adapter contract.
+
+### Serving path argument only
+
+The CLI could expose `--paper-reconciliation` without creating the artifact. This makes packaging clearer but leaves operators without a maintained way to produce the required artifact.
+
+### Strict normalized request plus explicit package path — selected
+
+Add a strict JSON request whose fields exactly cover `PaperReconciliationEvidence.create(...)`. The command validates field closure and types, derives pass/fail through the existing domain contract, writes the immutable artifact, and returns one machine-readable result. A separate explicit Serving option passes the artifact path to the already fail-closed package boundary.
+
+## Command contract
+
+```text
+trade-rl reconciliation create \
+  --request /secure/paper-reconciliation-request.json \
+  --output /secure/paper-reconciliation.json
+```
+
+The request schema is `paper_reconciliation_request_v1`. It contains:
+
+- dataset, environment, policy, and training-run digests;
+- start, end, and creation timestamps;
+- order and fill log digests;
+- submitted/terminal order counts;
+- observed/matched fill counts;
+- unknown-order fill, duplicate-fill, and open-order counts;
+- maximum position-notional, cash, and equity difference fractions;
+- the three declared tolerance fractions.
+
+The request does not contain `passed`, `sealed`, `schema_version` for the artifact, or an evidence digest. Those values are derived by the artifact implementation.
+
+The command writes immutable `paper_reconciliation_evidence_v1` and returns:
+
+```json
+{
+  "artifact_path": "...",
+  "evidence_digest": "...",
+  "passed": true,
+  "production_status": "NO-GO",
+  "schema": "paper_reconciliation_creation_result_v1",
+  "status": "sealed_for_fresh_confirmation_review"
+}
+```
+
+A failed reconciliation report is still valid evidence and may be written with `passed=false`; later promotion rejects it. Malformed requests fail before artifact publication.
+
+## Serving package contract
+
+`trade-rl serving package` gains required `--paper-reconciliation`. The CLI passes this explicit path into `package_selected_training_run()` rather than relying on sibling-file discovery. The Python API retains its sibling fallback for compatibility and direct library callers.
+
+## Security and trust boundary
+
+The reconciliation artifact is content-addressed but unsigned. Its digest must subsequently be included in Ed25519-signed fresh confirmation. Therefore the required operational order is:
+
+```text
+normalized external measurements
+  -> reconciliation create
+  -> confirmation request references reconciliation digest
+  -> confirmation create signs the complete evidence identity
+  -> serving package verifies both artifacts and their chronology
+```
+
+Private signing keys remain used only by the existing confirmation command. The reconciliation command loads no private keys.
+
+## Error handling
+
+- Reject non-object JSON, missing/extra fields, unsupported request schema, booleans in numeric fields, invalid datetimes, invalid digests, negative counts, invalid fractions, and immutable-output conflicts.
+- Emit the standard machine-readable `production_status: NO-GO` error payload.
+- Do not write partial artifacts on validation failure.
+
+## Testing
+
+Use TDD to cover a valid passing report, a valid failed report, malformed field closure, immutable output, machine-readable error output, and explicit Serving path forwarding. Then run the complete exact-head CI and PostgreSQL workflows before squash merge.

--- a/tests/cli/test_offline_approval_cli.py
+++ b/tests/cli/test_offline_approval_cli.py
@@ -5,6 +5,9 @@ import json
 from datetime import UTC, datetime, timedelta
 from io import StringIO
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 from trade_rl.workflows.selection_authorization import (
     SelectionProposal,
@@ -29,6 +32,34 @@ def _write_private_key(path: Path, *, purpose: str, raw: bytes) -> None:
         encoding="utf-8",
     )
     path.chmod(0o600)
+
+
+def _reconciliation_request() -> dict[str, object]:
+    return {
+        "cash_tolerance_fraction": 1e-8,
+        "created_at": (NOW + timedelta(days=30)).isoformat(),
+        "dataset_id": "1" * 64,
+        "duplicate_fill_count": 0,
+        "end_time": (NOW + timedelta(days=30)).isoformat(),
+        "environment_digest": "2" * 64,
+        "equity_tolerance_fraction": 1e-8,
+        "fill_log_digest": "3" * 64,
+        "matched_fill_count": 80,
+        "maximum_cash_difference_fraction": 0.0,
+        "maximum_equity_difference_fraction": 0.0,
+        "maximum_position_notional_difference_fraction": 0.0,
+        "observed_fill_count": 80,
+        "open_order_count": 0,
+        "order_log_digest": "4" * 64,
+        "policy_digest": "5" * 64,
+        "position_notional_tolerance_fraction": 1e-8,
+        "schema_version": "paper_reconciliation_request_v1",
+        "start_time": NOW.isoformat(),
+        "submitted_order_count": 100,
+        "terminal_order_count": 100,
+        "training_run_digest": "6" * 64,
+        "unknown_order_fill_count": 0,
+    }
 
 
 def test_selection_authorize_cli_writes_immutable_signed_authorization(
@@ -226,3 +257,157 @@ def test_confirmation_create_cli_signs_exact_external_measurements(
         "schema": "confirmation_creation_result_v1",
         "status": "sealed_for_fresh_confirmation_review",
     }
+
+
+def test_reconciliation_create_cli_writes_derived_evidence(tmp_path: Path) -> None:
+    from trade_rl.cli import extended
+    from trade_rl.evaluation.paper_reconciliation import (
+        load_paper_reconciliation_evidence,
+    )
+
+    request_path = tmp_path / "reconciliation-request.json"
+    request_path.write_text(json.dumps(_reconciliation_request()), encoding="utf-8")
+    output = tmp_path / "paper-reconciliation.json"
+    stdout = StringIO()
+    stderr = StringIO()
+
+    exit_code = extended.main(
+        [
+            "reconciliation",
+            "create",
+            "--request",
+            str(request_path),
+            "--output",
+            str(output),
+        ],
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+    evidence = load_paper_reconciliation_evidence(output)
+    assert exit_code == 0
+    assert stderr.getvalue() == ""
+    assert evidence.passed is True
+    assert json.loads(stdout.getvalue()) == {
+        "artifact_path": str(output),
+        "evidence_digest": evidence.evidence_digest,
+        "passed": True,
+        "production_status": "NO-GO",
+        "schema": "paper_reconciliation_creation_result_v1",
+        "status": "sealed_for_fresh_confirmation_review",
+    }
+
+
+def test_reconciliation_create_cli_rejects_caller_passed_field(
+    tmp_path: Path,
+) -> None:
+    from trade_rl.cli import extended
+
+    request = _reconciliation_request()
+    request["passed"] = True
+    request_path = tmp_path / "reconciliation-request.json"
+    request_path.write_text(json.dumps(request), encoding="utf-8")
+    output = tmp_path / "paper-reconciliation.json"
+    stdout = StringIO()
+    stderr = StringIO()
+
+    exit_code = extended.main(
+        [
+            "reconciliation",
+            "create",
+            "--request",
+            str(request_path),
+            "--output",
+            str(output),
+        ],
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+    assert exit_code == 1
+    assert stdout.getvalue() == ""
+    assert not output.exists()
+    assert json.loads(stderr.getvalue()) == {
+        "error": "paper reconciliation request fields are invalid",
+        "error_type": "ValueError",
+        "production_status": "NO-GO",
+        "schema": "paper_reconciliation_creation_error_v1",
+        "status": "failed",
+    }
+
+
+def test_serving_package_cli_forwards_explicit_reconciliation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trade_rl.cli import extended
+
+    captured: dict[str, object] = {}
+
+    def fake_package(**kwargs: object) -> SimpleNamespace:
+        captured.update(kwargs)
+        return SimpleNamespace(
+            bundle_digest="1" * 64,
+            confirmation_evidence_digest="2" * 64,
+            run_kind="research_selected_final",
+            training_run_digest="3" * 64,
+        )
+
+    monkeypatch.setattr(extended, "package_selected_training_run", fake_package)
+    monkeypatch.setattr(extended, "load_public_verification_keys", lambda _: {})
+    reconciliation = tmp_path / "paper-reconciliation.json"
+    stdout = StringIO()
+    stderr = StringIO()
+
+    exit_code = extended.main(
+        [
+            "serving",
+            "package",
+            "--training-run",
+            str(tmp_path / "training"),
+            "--confirmation",
+            str(tmp_path / "confirmation.json"),
+            "--paper-reconciliation",
+            str(reconciliation),
+            "--confirmation-public-keys",
+            str(tmp_path / "keys.json"),
+            "--output",
+            str(tmp_path / "bundle"),
+            "--signal-digest",
+            "4" * 64,
+            "--selection-digest",
+            "5" * 64,
+            "--trusted-now",
+            NOW.isoformat(),
+        ],
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+    assert exit_code == 0
+    assert stderr.getvalue() == ""
+    assert captured["paper_reconciliation_path"] == reconciliation
+
+
+def test_serving_package_parser_requires_explicit_reconciliation() -> None:
+    from trade_rl.cli import extended
+
+    with pytest.raises(SystemExit):
+        extended._serving_package_parser().parse_args(
+            [
+                "--training-run",
+                "training",
+                "--confirmation",
+                "confirmation.json",
+                "--confirmation-public-keys",
+                "keys.json",
+                "--output",
+                "bundle",
+                "--signal-digest",
+                "1" * 64,
+                "--selection-digest",
+                "2" * 64,
+                "--trusted-now",
+                NOW.isoformat(),
+            ]
+        )

--- a/tests/cli/test_offline_approval_cli.py
+++ b/tests/cli/test_offline_approval_cli.py
@@ -298,6 +298,41 @@ def test_reconciliation_create_cli_writes_derived_evidence(tmp_path: Path) -> No
     }
 
 
+def test_reconciliation_create_cli_preserves_failed_evidence(tmp_path: Path) -> None:
+    from trade_rl.cli import extended
+    from trade_rl.evaluation.paper_reconciliation import (
+        load_paper_reconciliation_evidence,
+    )
+
+    request = _reconciliation_request()
+    request["matched_fill_count"] = 79
+    request["unknown_order_fill_count"] = 1
+    request_path = tmp_path / "reconciliation-request.json"
+    request_path.write_text(json.dumps(request), encoding="utf-8")
+    output = tmp_path / "paper-reconciliation.json"
+    stdout = StringIO()
+    stderr = StringIO()
+
+    exit_code = extended.main(
+        [
+            "reconciliation",
+            "create",
+            "--request",
+            str(request_path),
+            "--output",
+            str(output),
+        ],
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+    evidence = load_paper_reconciliation_evidence(output)
+    assert exit_code == 0
+    assert stderr.getvalue() == ""
+    assert evidence.passed is False
+    assert json.loads(stdout.getvalue())["passed"] is False
+
+
 def test_reconciliation_create_cli_rejects_caller_passed_field(
     tmp_path: Path,
 ) -> None:

--- a/trade_rl/cli/extended.py
+++ b/trade_rl/cli/extended.py
@@ -469,9 +469,7 @@ def _run_reconciliation_create(
             ),
             order_log_digest=_reconciliation_string(raw, "order_log_digest"),
             fill_log_digest=_reconciliation_string(raw, "fill_log_digest"),
-            submitted_order_count=_reconciliation_integer(
-                raw, "submitted_order_count"
-            ),
+            submitted_order_count=_reconciliation_integer(raw, "submitted_order_count"),
             terminal_order_count=_reconciliation_integer(raw, "terminal_order_count"),
             observed_fill_count=_reconciliation_integer(raw, "observed_fill_count"),
             matched_fill_count=_reconciliation_integer(raw, "matched_fill_count"),

--- a/trade_rl/cli/extended.py
+++ b/trade_rl/cli/extended.py
@@ -31,6 +31,32 @@ _CONFIRMATION_REQUEST_FIELDS = {
     "start_time",
     "training_run_digest",
 }
+_PAPER_RECONCILIATION_REQUEST_SCHEMA = "paper_reconciliation_request_v1"
+_PAPER_RECONCILIATION_REQUEST_FIELDS = {
+    "cash_tolerance_fraction",
+    "created_at",
+    "dataset_id",
+    "duplicate_fill_count",
+    "end_time",
+    "environment_digest",
+    "equity_tolerance_fraction",
+    "fill_log_digest",
+    "matched_fill_count",
+    "maximum_cash_difference_fraction",
+    "maximum_equity_difference_fraction",
+    "maximum_position_notional_difference_fraction",
+    "observed_fill_count",
+    "open_order_count",
+    "order_log_digest",
+    "policy_digest",
+    "position_notional_tolerance_fraction",
+    "schema_version",
+    "start_time",
+    "submitted_order_count",
+    "terminal_order_count",
+    "training_run_digest",
+    "unknown_order_fill_count",
+}
 
 
 def execute_training_run(**kwargs: Any) -> Any:
@@ -87,6 +113,7 @@ def _serving_package_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="trade-rl serving package")
     parser.add_argument("--training-run", type=Path, required=True)
     parser.add_argument("--confirmation", type=Path, required=True)
+    parser.add_argument("--paper-reconciliation", type=Path, required=True)
     parser.add_argument("--confirmation-public-keys", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--signal-digest", required=True)
@@ -123,6 +150,13 @@ def _confirmation_create_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="trade-rl confirmation create")
     parser.add_argument("--request", type=Path, required=True)
     parser.add_argument("--private-key", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser
+
+
+def _reconciliation_create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="trade-rl reconciliation create")
+    parser.add_argument("--request", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
     return parser
 
@@ -304,6 +338,40 @@ def _request_number(raw: Mapping[str, object], field: str) -> float:
     return float(value)
 
 
+def _strict_reconciliation_request(path: Path) -> Mapping[str, object]:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError("paper reconciliation request must be an object")
+    if set(raw) != _PAPER_RECONCILIATION_REQUEST_FIELDS:
+        raise ValueError("paper reconciliation request fields are invalid")
+    if raw.get("schema_version") != _PAPER_RECONCILIATION_REQUEST_SCHEMA:
+        raise ValueError("paper reconciliation request schema is unsupported")
+    return raw
+
+
+def _reconciliation_string(raw: Mapping[str, object], field: str) -> str:
+    value = raw.get(field)
+    if not isinstance(value, str) or not value:
+        raise ValueError(
+            f"paper reconciliation request {field} must be a non-empty string"
+        )
+    return value
+
+
+def _reconciliation_integer(raw: Mapping[str, object], field: str) -> int:
+    value = raw.get(field)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"paper reconciliation request {field} must be an integer")
+    return value
+
+
+def _reconciliation_number(raw: Mapping[str, object], field: str) -> float:
+    value = raw.get(field)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"paper reconciliation request {field} must be numeric")
+    return float(value)
+
+
 def _run_confirmation_create(
     argv: Sequence[str],
     *,
@@ -371,6 +439,87 @@ def _run_confirmation_create(
     return 0
 
 
+def _run_reconciliation_create(
+    argv: Sequence[str],
+    *,
+    stdout: TextIO,
+    stderr: TextIO,
+) -> int:
+    args = _reconciliation_create_parser().parse_args(list(argv))
+    try:
+        from trade_rl.evaluation.paper_reconciliation import (
+            PaperReconciliationEvidence,
+            write_paper_reconciliation_evidence,
+        )
+
+        raw = _strict_reconciliation_request(args.request)
+        evidence = PaperReconciliationEvidence.create(
+            dataset_id=_reconciliation_string(raw, "dataset_id"),
+            environment_digest=_reconciliation_string(raw, "environment_digest"),
+            policy_digest=_reconciliation_string(raw, "policy_digest"),
+            training_run_digest=_reconciliation_string(raw, "training_run_digest"),
+            start_time=_parse_datetime(
+                _reconciliation_string(raw, "start_time"), field="start-time"
+            ),
+            end_time=_parse_datetime(
+                _reconciliation_string(raw, "end_time"), field="end-time"
+            ),
+            created_at=_parse_datetime(
+                _reconciliation_string(raw, "created_at"), field="created-at"
+            ),
+            order_log_digest=_reconciliation_string(raw, "order_log_digest"),
+            fill_log_digest=_reconciliation_string(raw, "fill_log_digest"),
+            submitted_order_count=_reconciliation_integer(
+                raw, "submitted_order_count"
+            ),
+            terminal_order_count=_reconciliation_integer(raw, "terminal_order_count"),
+            observed_fill_count=_reconciliation_integer(raw, "observed_fill_count"),
+            matched_fill_count=_reconciliation_integer(raw, "matched_fill_count"),
+            unknown_order_fill_count=_reconciliation_integer(
+                raw, "unknown_order_fill_count"
+            ),
+            duplicate_fill_count=_reconciliation_integer(raw, "duplicate_fill_count"),
+            open_order_count=_reconciliation_integer(raw, "open_order_count"),
+            maximum_position_notional_difference_fraction=_reconciliation_number(
+                raw, "maximum_position_notional_difference_fraction"
+            ),
+            maximum_cash_difference_fraction=_reconciliation_number(
+                raw, "maximum_cash_difference_fraction"
+            ),
+            maximum_equity_difference_fraction=_reconciliation_number(
+                raw, "maximum_equity_difference_fraction"
+            ),
+            position_notional_tolerance_fraction=_reconciliation_number(
+                raw, "position_notional_tolerance_fraction"
+            ),
+            cash_tolerance_fraction=_reconciliation_number(
+                raw, "cash_tolerance_fraction"
+            ),
+            equity_tolerance_fraction=_reconciliation_number(
+                raw, "equity_tolerance_fraction"
+            ),
+        )
+        path = write_paper_reconciliation_evidence(args.output, evidence)
+    except Exception as error:
+        return _error(
+            stderr,
+            error,
+            schema="paper_reconciliation_creation_error_v1",
+        )
+    _write_json(
+        stdout,
+        {
+            "artifact_path": str(path),
+            "evidence_digest": evidence.evidence_digest,
+            "passed": evidence.passed,
+            "production_status": "NO-GO",
+            "schema": "paper_reconciliation_creation_result_v1",
+            "status": "sealed_for_fresh_confirmation_review",
+        },
+    )
+    return 0
+
+
 def _run_serving_package(
     argv: Sequence[str],
     *,
@@ -382,6 +531,7 @@ def _run_serving_package(
         manifest = package_selected_training_run(
             training_root=args.training_run,
             confirmation_path=args.confirmation,
+            paper_reconciliation_path=args.paper_reconciliation,
             output_root=args.output,
             signal_digest=args.signal_digest,
             selection_digest=args.selection_digest,
@@ -503,6 +653,8 @@ def main(
         return _run_release_approve(arguments[2:], stdout=output, stderr=errors)
     if arguments[:2] == ["confirmation", "create"]:
         return _run_confirmation_create(arguments[2:], stdout=output, stderr=errors)
+    if arguments[:2] == ["reconciliation", "create"]:
+        return _run_reconciliation_create(arguments[2:], stdout=output, stderr=errors)
     raise ValueError("unsupported artifact-producing CLI command")
 
 


### PR DESCRIPTION
## Summary

Add an offline `trade-rl reconciliation create` command for strict normalized paper-run measurements and require explicit `--paper-reconciliation` at the public Serving package CLI.

This adds no paper broker, exchange connectivity, credentials, order routing, production authorization, or profitability claim.

## What changed

- add strict `paper_reconciliation_request_v1` field closure
- derive `passed` through the existing `PaperReconciliationEvidence` contract
- write immutable content-addressed reconciliation artifacts
- preserve valid failed reports as `passed=false` evidence rather than discarding or relabeling them
- reject caller-supplied `passed` and malformed/extra fields
- require `--paper-reconciliation` for `trade-rl serving package`
- forward the explicit path to the already fail-closed Python packaging boundary
- document the operational order in English and Japanese:
  normalized measurements → reconciliation create → signed confirmation → Serving package
- retain the Python API sibling-file fallback for direct library compatibility

## TDD RED

Head: `e07e37b36ee7f6e64321156d5b3ab6c82eb9dc5c`

CI run `30006802342` failed exactly with:

- unsupported `reconciliation create` command in two tests
- unrecognized `--paper-reconciliation` in Serving forwarding
- Serving parser not requiring the option

Exact RED result: `4 failed, 1326 passed, 2 skipped, 11 warnings`, coverage `84.20%`.

RED artifact:

- artifact `8563386102`
- digest `sha256:efba51b2b073dc6f1ca1bb473dd5e4e6379d8566d46d4415ee9ae16774003569`

## Exact-head verification

Head: `8dcafa28da617abc7cba80c722f0fa3691992a65`

- CI run `30008311160`: success
- PostgreSQL Catalog run `30008311125`: success
- Python: `1331 passed, 2 skipped, 11 warnings`
- branch coverage included: `84.21%` total coverage
- Ruff: success
- Ruff format: success
- MyPy: success
- Import Linter: success
- Studio tests, typecheck, production build, and fixed-layout check: success
- Ubuntu and Windows compatibility: success
- training image build and packaged non-root probe: success
- critical branch coverage and CLI smoke: success

Pytest evidence artifact:

- artifact `8564026994`
- digest `sha256:e8e83f766104e24d476cca03d927249f6c5e322008a1ec0bdbb810a248ebb5c3`

## Trust boundary

The request contains externally normalized measurements. The CLI validates and content-addresses them but does not independently prove their source. The reconciliation digest must subsequently be covered by Ed25519-signed fresh confirmation before packaging.

Production remains `NO-GO`. Direct exchange routing remains `NOT_IMPLEMENTED`. No real maintained paper run has yet cleared the empirical gate.