### PR TITLE
ci: trigger PR152 architecture closeout

### DIFF
--- a/.github/pr152-architecture-closeout-trigger
+++ b/.github/pr152-architecture-closeout-trigger
@@ -1,0 +1,1 @@
+trigger


### PR DESCRIPTION
Temporary one-file child PR targeting canonical PR #152. Squash merge only to trigger the exact closeout updater already present on the feature branch. The updater modifies only the architecture closeout, removes itself and this trigger, checks the diff, and pushes the clean documentation commit. This child PR must not be merged into `main`.