### PR TITLE
ci: prune final verified branches

### DIFF
--- a/.github/workflows/prune-final-branches-20260723.yml
+++ b/.github/workflows/prune-final-branches-20260723.yml
@@ -98,7 +98,7 @@ jobs:
               if [ -z "$reason" ] && jq -e '
                 length > 0
                 and all(.[]; .state == "CLOSED")
-                and any(.[ ];
+                and any(.[];
                   (((.title // "") + " " + (.body // "")) | ascii_downcase)
                   | test("superseded|temporary|closed without merge|must not be merged|do not merge|not be merged|diagnostic|verification only|validation pr|cleanup pr|ci-only|audit-only|runner branch|trigger")
                 )

--- a/.github/workflows/prune-final-branches-20260723.yml
+++ b/.github/workflows/prune-final-branches-20260723.yml
@@ -1,0 +1,162 @@
+name: Prune final verified branches 2026-07-23
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/prune-final-branches-20260723.yml'
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: prune-final-branches-20260723
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    if: github.head_ref == 'ci/prune-final-branches-20260723'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout exact cleanup head
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Delete only proven integrated or temporary branches
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          CLEANUP_BRANCH: ci/prune-final-branches-20260723
+          TELEMETRY_CANONICAL_HEAD: 1c96d0c4e85f7bc84027e586db2bbae8bbff2849
+        run: |
+          set -euo pipefail
+          git fetch origin '+refs/heads/*:refs/remotes/origin/*' --prune
+          git fetch origin "$TELEMETRY_CANONICAL_HEAD" || true
+
+          report=/tmp/final-branch-prune-report.txt
+          : > "$report"
+          echo 'final_verified_branch_prune_v1' >> "$report"
+          echo "cleanup_head=${{ github.event.pull_request.head.sha }}" >> "$report"
+          echo "main_sha=$(git rev-parse origin/main)" >> "$report"
+          echo >> "$report"
+
+          mapfile -t branches < <(
+            git for-each-ref --format='%(refname:strip=3)' refs/remotes/origin \
+              | grep -v '^HEAD$' \
+              | grep -v '^main$' \
+              | grep -v "^${CLEANUP_BRANCH}$" \
+              | sort -u
+          )
+
+          deleted=0
+          kept=0
+          failed=0
+
+          for branch in "${branches[@]}"; do
+            open_count=$(gh pr list --repo "$REPO" --state open --head "$branch" \
+              --limit 100 --json number --jq 'length')
+            if [ "$open_count" -gt 0 ]; then
+              echo "KEEP open-pr $branch" | tee -a "$report"
+              kept=$((kept + 1))
+              continue
+            fi
+
+            reason=''
+            if git merge-base --is-ancestor "origin/$branch" origin/main; then
+              reason='ancestor-of-main'
+            elif [ "$(git rev-parse "origin/$branch^{tree}")" = "$(git rev-parse 'origin/main^{tree}')" ]; then
+              reason='identical-tree-to-main'
+            else
+              prs=$(gh pr list --repo "$REPO" --state all --head "$branch" \
+                --limit 100 --json number,state,mergedAt,baseRefName,title,body)
+
+              if jq -e 'any(.[]; .mergedAt != null and .baseRefName == "main")' \
+                >/dev/null <<<"$prs"; then
+                reason='merged-pr-to-main'
+              else
+                mapfile -t merged_bases < <(
+                  jq -r '.[] | select(.mergedAt != null and .baseRefName != "main") | .baseRefName' \
+                    <<<"$prs" | sort -u
+                )
+                for base in "${merged_bases[@]}"; do
+                  [ -n "$base" ] || continue
+                  canonical=$(gh pr list --repo "$REPO" --state merged --head "$base" \
+                    --base main --limit 100 --json number --jq 'length')
+                  if [ "$canonical" -gt 0 ]; then
+                    reason="merged-child-of-main-integrated-$base"
+                    break
+                  fi
+                done
+              fi
+
+              if [ -z "$reason" ] && jq -e '
+                length > 0
+                and all(.[]; .state == "CLOSED")
+                and any(.[ ];
+                  (((.title // "") + " " + (.body // "")) | ascii_downcase)
+                  | test("superseded|temporary|closed without merge|must not be merged|do not merge|not be merged|diagnostic|verification only|validation pr|cleanup pr|ci-only|audit-only|runner branch|trigger")
+                )
+              ' >/dev/null <<<"$prs"; then
+                reason='explicitly-temporary-or-superseded'
+              fi
+            fi
+
+            if [ -z "$reason" ] \
+              && [ "$branch" = 'fix/bind-telemetry-cursors-generation-main-20260723' ] \
+              && git cat-file -e "$TELEMETRY_CANONICAL_HEAD^{commit}" \
+              && git diff --quiet "$TELEMETRY_CANONICAL_HEAD" "origin/$branch"; then
+              reason='exact-match-to-merged-pr99-head'
+            fi
+
+            if [ -z "$reason" ]; then
+              summary=$(gh pr list --repo "$REPO" --state all --head "$branch" \
+                --limit 20 --json number,state,mergedAt,baseRefName,title \
+                --jq 'map("#\(.number):\(.state):base=\(.baseRefName):merged=\(.mergedAt != null):\(.title)") | join(";")')
+              echo "KEEP unique-or-unverified $branch prs=${summary:-none}" | tee -a "$report"
+              kept=$((kept + 1))
+              continue
+            fi
+
+            encoded=$(printf '%s' "$branch" | jq -sRr @uri)
+            if gh api --method DELETE "repos/$REPO/git/refs/heads/$encoded"; then
+              echo "DELETE $reason $branch" | tee -a "$report"
+              deleted=$((deleted + 1))
+            else
+              echo "KEEP delete-failed $branch" | tee -a "$report"
+              failed=$((failed + 1))
+            fi
+          done
+
+          echo >> "$report"
+          echo "deleted=$deleted" >> "$report"
+          echo "kept=$kept" >> "$report"
+          echo "delete_failed=$failed" >> "$report"
+          cat "$report" >> "$GITHUB_STEP_SUMMARY"
+          test "$failed" -eq 0
+
+      - name: Upload final branch inventory
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: final-branch-prune-report-20260723
+          path: /tmp/final-branch-prune-report.txt
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Delete cleanup branch
+        if: success()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          CLEANUP_BRANCH: ci/prune-final-branches-20260723
+        run: |
+          set -euo pipefail
+          encoded=$(printf '%s' "$CLEANUP_BRANCH" | jq -sRr @uri)
+          gh api --method DELETE "repos/$REPO/git/refs/heads/$encoded"


### PR DESCRIPTION
Closed without merge after successful final branch inventory. Workflow run `30017370883` deleted 16 proven integrated/temporary branches, preserved 3 branches fail-closed for individual review, reported zero deletion failures, uploaded artifact `8567720412` (`sha256:14404d9de3f24ca1275147abc1ce51d1618b9c9fe50b92ee5e32d3c19dedce60`), and deleted its own cleanup branch.