### PR TITLE
ci: synchronize PR165 finalizer

### DIFF
--- a/.github/pr165-finalizer-sync-marker
+++ b/.github/pr165-finalizer-sync-marker
@@ -1,0 +1,1 @@
+synchronize


### PR DESCRIPTION
Temporary one-file child PR targeting the PR #167 runner branch. Squash merge only to produce a normal synchronize event after the exact-head workflow exists. The runner removes this marker from the canonical PR because it checks out PR #165 RED head directly; this child PR must not be merged into `main`.