### PR TITLE
test: inventory branches after PR165

### DIFF
--- a/.github/workflows/post-pr165-branch-inventory-20260724.yml
+++ b/.github/workflows/post-pr165-branch-inventory-20260724.yml
@@ -1,0 +1,58 @@
+name: Post PR165 branch inventory 2026-07-24
+
+on:
+  pull_request:
+    branches: [main]
+    paths: ['.github/workflows/post-pr165-branch-inventory-20260724.yml']
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  inventory:
+    if: github.head_ref == 'audit/post-pr165-branch-inventory-20260724'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout exact inventory head
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Record all remaining branches
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          INVENTORY_BRANCH: audit/post-pr165-branch-inventory-20260724
+        run: |
+          set -euo pipefail
+          git fetch origin '+refs/heads/*:refs/remotes/origin/*' --prune
+          report=/tmp/post-pr165-branch-inventory.txt
+          : > "$report"
+          echo 'post_pr165_branch_inventory_v1' >> "$report"
+          echo "main_sha=$(git rev-parse origin/main)" >> "$report"
+          mapfile -t extra < <(
+            git for-each-ref --format='%(refname:strip=3)' refs/remotes/origin \
+              | grep -v '^HEAD$' \
+              | grep -v '^main$' \
+              | grep -v "^${INVENTORY_BRANCH}$" \
+              | sort -u
+          )
+          echo "extra_branch_count=${#extra[@]}" >> "$report"
+          for branch in "${extra[@]}"; do
+            open_count=$(gh pr list --repo "$REPO" --state open --head "$branch" --limit 100 --json number --jq 'length')
+            all_prs=$(gh pr list --repo "$REPO" --state all --head "$branch" --limit 100 --json number,state,mergedAt,baseRefName,title --jq 'map("#\(.number):\(.state):base=\(.baseRefName):merged=\(.mergedAt != null):\(.title)") | join(";")')
+            echo "EXTRA branch=$branch open_prs=$open_count prs=${all_prs:-none}" >> "$report"
+          done
+          cat "$report" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload inventory report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: post-pr165-branch-inventory-20260724
+          path: /tmp/post-pr165-branch-inventory.txt
+          if-no-files-found: error
+          retention-days: 30


### PR DESCRIPTION
Closed without merge after successful read-only inventory. Run `30021277087` found exactly 12 remaining branches, all tied to closed validation/update PRs, merged synchronization PR #169, or merged canonical PR #165. Artifact `8569348233` (`sha256:1fd88b95642d50e1e432e2d6dfff95549da21ffe8ccb997b239f5079f82161b7`). These 12 branches plus this inventory branch will be deleted through an exact allowlist cleanup.