### PR TITLE
refactor: canonicalize serving execution config loading

### DIFF
--- a/docs/superpowers/plans/2026-07-24-serving-package-canonical-loader.md
+++ b/docs/superpowers/plans/2026-07-24-serving-package-canonical-loader.md
@@ -1,0 +1,78 @@
+# Serving Package Canonical Loader Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace Serving's hand-maintained execution-cost reconstruction with one strict canonical loader and enforce critical branch coverage on the packaging boundary.
+
+**Architecture:** `trade_rl.serving.training_environment` parses and validates `training_environment_v2`; `trade_rl.serving.package` delegates to it. Existing bundle, confirmation, reconciliation, and execution-promotion types remain unchanged.
+
+**Tech Stack:** Python 3.12, dataclasses, JSON, Pytest, pytest-cov, existing critical-coverage tooling.
+
+## Global Constraints
+
+- Preserve `serving_bundle_v5` and every existing bundle identity field.
+- Preserve current execution and release semantics.
+- Reject missing or unknown `ExecutionCostConfig` fields instead of applying defaults.
+- Keep production status `NO-GO`.
+- Use test-first RED/GREEN evidence.
+
+---
+
+### Task 1: Specify the fail-closed artifact contract
+
+**Files:**
+- Create: `tests/serving/test_training_environment_contract.py`
+
+**Interfaces:**
+- Consumes: existing private `trade_rl.serving.package._execution_cost(Path)` during RED.
+- Produces: behavioral expectations for strict schema and field validation.
+
+- [ ] Write tests for a complete round trip, unsupported schema, missing field, unknown field, malformed root/environment/execution mappings, delegation source ownership, and critical-coverage configuration.
+- [ ] Run `pytest -q tests/serving/test_training_environment_contract.py` and record the expected failures caused by permissive defaults and missing coverage declarations.
+- [ ] Commit the RED tests.
+
+### Task 2: Add the canonical loader
+
+**Files:**
+- Create: `trade_rl/serving/training_environment.py`
+- Modify: `trade_rl/serving/package.py`
+
+**Interfaces:**
+- Produces: `load_training_execution_cost(path: Path) -> ExecutionCostConfig`.
+- `package._execution_cost(training_root)` delegates to `load_training_execution_cost(training_root / "environment.json")`.
+
+- [ ] Parse JSON and require a mapping root.
+- [ ] Require `schema_version == "training_environment_v2"`.
+- [ ] Require mapping values at `environment` and `environment.execution_cost`.
+- [ ] Compare execution keys with `dataclasses.fields(ExecutionCostConfig)` and report missing/unknown names.
+- [ ] Convert `trigger_volume_fractions` from JSON list to tuple.
+- [ ] Construct `ExecutionCostConfig(**payload)` so semantic range validation remains canonical.
+- [ ] Remove field-by-field execution parsing and its local primitive conversion helpers from `package.py` where no longer used.
+- [ ] Run the focused tests and commit GREEN.
+
+### Task 3: Ratchet the full packaging boundary
+
+**Files:**
+- Modify: `pyproject.toml`
+- Modify or create focused tests under `tests/serving/`.
+
+**Interfaces:**
+- Produces per-file critical branch targets of 90.0% for `package.py` and 100.0% for `training_environment.py`.
+
+- [ ] Add focused rejection tests for uncovered package identity, confirmation, reconciliation, output, and staging-cleanup branches.
+- [ ] Add the two per-file critical coverage entries.
+- [ ] Run `pytest -q tests/serving/test_package.py tests/serving/test_training_environment_contract.py --cov=trade_rl --cov-branch --cov-report=json`.
+- [ ] Run the repository critical-coverage command used by CI and confirm both targets pass.
+- [ ] Commit the coverage ratchet.
+
+### Task 4: Full verification
+
+**Files:**
+- Modify verification documentation only if final evidence values are available.
+
+- [ ] Run Ruff and format checks.
+- [ ] Run Mypy and Import Linter.
+- [ ] Run the complete Pytest suite and coverage.
+- [ ] Run Studio tests, typecheck, production build, fixed-viewport validation, Ubuntu and Windows compatibility, training-image/non-root probe, and PostgreSQL catalog workflow.
+- [ ] Record exact-head workflow runs and artifact digests in the PR.
+- [ ] Squash merge only after all gates pass.

--- a/docs/superpowers/specs/2026-07-24-serving-package-canonical-loader-design.md
+++ b/docs/superpowers/specs/2026-07-24-serving-package-canonical-loader-design.md
@@ -1,0 +1,40 @@
+# Serving Package Canonical Loader Design
+
+Date: 2026-07-24
+
+## Goal
+
+Remove the hand-maintained reconstruction of `ExecutionCostConfig` from `trade_rl.serving.package`, make the training-environment artifact fail closed, and protect the complete selected-final packaging boundary with critical branch-coverage ratchets.
+
+## Scope
+
+This change is limited to the selected-final Serving packaging path. It does not change execution semantics, bundle schema, release approval, paper-reconciliation tolerances, or the production `NO-GO` status.
+
+## Architecture
+
+A new `trade_rl.serving.training_environment` module owns decoding of `environment.json` for Serving promotion. Its public function is:
+
+```python
+load_training_execution_cost(path: Path) -> ExecutionCostConfig
+```
+
+The loader validates `training_environment_v2`, requires the `environment.execution_cost` object to contain exactly the fields defined by `ExecutionCostConfig`, converts JSON list fields to their canonical tuple form, and delegates semantic validation to `ExecutionCostConfig.__post_init__`.
+
+`trade_rl.serving.package` keeps a small private adapter for local call-site stability, but it no longer knows individual execution-cost fields or default values. Unknown fields, missing fields, malformed mappings, and unsupported schemas fail before execution evidence is compared.
+
+## Coverage contract
+
+Critical branch coverage is enforced independently for:
+
+- `trade_rl/serving/package.py`: 90.0%
+- `trade_rl/serving/training_environment.py`: 100.0%
+
+Tests cover the valid artifact, unsupported schema, missing and unknown execution fields, malformed mappings, evidence and identity rejection branches, output collision, staging cleanup, and manifest construction failures.
+
+## Compatibility
+
+Current `training_environment_v2` artifacts produced by `execute_training_run()` contain the complete `ExecutionCostConfig` mapping and remain valid. Incomplete legacy-like artifacts that previously relied on local defaults are intentionally rejected because they cannot prove the execution-policy identity used during training.
+
+## Safety
+
+The filesystem training run remains authoritative. The canonical loader does not infer values, mutate artifacts, or authorize deployment. Packaging still requires selected-final authorization, promotable metadata, conservative execution evidence, signed fresh confirmation, and passing paper reconciliation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,8 @@ target = 90.0
 "trade_rl/rl/environment_policy_schedule_contract.py" = 100.0
 "trade_rl/rl/environment_initial_state.py" = 100.0
 "trade_rl/rl/environment_reward_execution_resources.py" = 100.0
+"trade_rl/serving/package.py" = 90.0
+"trade_rl/serving/training_environment.py" = 100.0
 
 [tool.trade_rl.critical_coverage.groups.artifacts]
 minimum = 90.0

--- a/tests/serving/test_package_critical_branches.py
+++ b/tests/serving/test_package_critical_branches.py
@@ -244,13 +244,7 @@ def test_package_rejects_confirmation_identity_mismatch(
         ({"environment_digest": "0" * 64}, "environment identity"),
         ({"policy_digest": "0" * 64}, "policy identity"),
         ({"start_time": COMPLETED + timedelta(hours=1)}, "start time"),
-        (
-            {
-                "end_time": COMPLETED + timedelta(days=30, hours=1),
-                "created_at": COMPLETED + timedelta(days=30, hours=1),
-            },
-            "end time",
-        ),
+        ({"end_time": COMPLETED + timedelta(days=29)}, "end time"),
     ],
 )
 def test_package_rejects_reconciliation_binding_mismatch(

--- a/tests/serving/test_package_critical_branches.py
+++ b/tests/serving/test_package_critical_branches.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+
+from tests.serving.test_package import (
+    COMPLETED,
+    PRIVATE_KEY,
+    PUBLIC_KEY,
+    _confirmation,
+    _training_run,
+)
+from trade_rl.artifacts.run_manifest import (
+    TrainingRunManifest,
+    write_training_run_manifest,
+)
+from trade_rl.data.metadata_promotion import (
+    MetadataPromotionEvidence,
+    write_metadata_promotion_evidence,
+)
+from trade_rl.evaluation.confirmation import write_confirmation_evidence
+from trade_rl.evaluation.offline_confirmation import create_fresh_confirmation_evidence
+from trade_rl.release.offline_signing import public_key_bytes
+from trade_rl.serving import package as serving_package
+from trade_rl.serving.package import package_selected_training_run
+from trade_rl.simulation.execution_promotion import (
+    ExecutionEvidence,
+    write_execution_evidence,
+)
+
+
+def _rebuild_manifest(
+    root: Path,
+    source: TrainingRunManifest,
+) -> TrainingRunManifest:
+    manifest = TrainingRunManifest.build(
+        root=root,
+        run_id=source.run_id,
+        dataset_id=source.dataset_id,
+        environment_digest=source.environment_digest,
+        ensemble_digest=source.ensemble_digest,
+        training_config_digest=source.training_config_digest,
+        provenance_digest=source.provenance_digest,
+        artifact_paths=tuple(item.path for item in source.files),
+        created_at=source.created_at,
+        completed_at=source.completed_at,
+        run_kind=source.run_kind,
+        selection_proposal_digest=source.selection_proposal_digest,
+        selection_authorization_digest=source.selection_authorization_digest,
+        walk_forward_run_digest=source.walk_forward_run_digest,
+        gate_evidence_digest=source.gate_evidence_digest,
+    )
+    write_training_run_manifest(root, manifest)
+    return manifest
+
+
+def _write_confirmation(
+    path: Path,
+    manifest: TrainingRunManifest,
+    **overrides: object,
+) -> None:
+    values: dict[str, object] = {
+        "dataset_id": manifest.dataset_id,
+        "environment_digest": manifest.environment_digest,
+        "policy_digest": manifest.ensemble_digest,
+        "training_run_digest": manifest.digest,
+        "git_commit": "5" * 40,
+        "dependency_digest": "6" * 64,
+        "required_after": manifest.completed_at,
+        "start_time": manifest.completed_at,
+        "end_time": manifest.completed_at + timedelta(days=30),
+        "returns": (0.001,) * 30,
+        "return_period_hours": 24.0,
+        "order_log_digest": "7" * 64,
+        "fill_log_digest": "8" * 64,
+        "reconciliation_digest": "9" * 64,
+        "created_at": manifest.completed_at + timedelta(days=30),
+        "key_id": PUBLIC_KEY.key_id,
+        "private_key": PRIVATE_KEY,
+    }
+    values.update(overrides)
+    evidence = create_fresh_confirmation_evidence(**values)  # type: ignore[arg-type]
+    write_confirmation_evidence(path, evidence)
+
+
+def _package(
+    root: Path,
+    manifest: TrainingRunManifest,
+    confirmation_path: Path,
+    output: Path,
+) -> None:
+    package_selected_training_run(
+        training_root=root,
+        confirmation_path=confirmation_path,
+        output_root=output,
+        signal_digest="a" * 64,
+        selection_digest="b" * 64,
+        trusted_confirmation_keys={PUBLIC_KEY.key_id: PUBLIC_KEY},
+        trusted_now=manifest.completed_at + timedelta(days=30),
+    )
+
+
+@pytest.mark.parametrize(
+    ("function", "value", "message"),
+    [
+        (serving_package._mapping, [], "field must be a mapping"),
+        (serving_package._string, 1, "field must be a string"),
+        (serving_package._integer, True, "field must be an integer"),
+        (serving_package._number, True, "field must be numeric"),
+    ],
+)
+def test_package_primitive_decoders_reject_wrong_types(
+    function: object,
+    value: object,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        function(value, field="field")  # type: ignore[operator]
+
+
+def test_package_optional_string_accepts_none_and_rejects_other_types() -> None:
+    assert serving_package._optional_string(None, field="field") is None
+    with pytest.raises(ValueError, match="field must be a string"):
+        serving_package._optional_string(1, field="field")
+
+
+def test_package_rejects_metadata_dataset_mismatch(tmp_path: Path) -> None:
+    root = tmp_path / "training"
+    manifest = _training_run(root, run_kind="research_selected_final")
+    write_metadata_promotion_evidence(
+        root / "metadata-promotion.json",
+        MetadataPromotionEvidence(
+            dataset_id="0" * 64,
+            mode="historical_signed",
+            metadata_evidence_digest="6" * 64,
+            source_payload_digest="7" * 64,
+            point_in_time=True,
+            authentication="ed25519",
+            coverage_application="effective-dated-full-interval",
+            limitations=(),
+            promotable=True,
+        ),
+    )
+    manifest = _rebuild_manifest(root, manifest)
+    confirmation_path = tmp_path / "confirmation.json"
+    _confirmation(confirmation_path, manifest)
+
+    with pytest.raises(ValueError, match="metadata promotion dataset identity"):
+        _package(root, manifest, confirmation_path, tmp_path / "bundle")
+
+
+def test_package_rejects_execution_evidence_dataset_mismatch(tmp_path: Path) -> None:
+    root = tmp_path / "training"
+    manifest = _training_run(root, run_kind="research_selected_final")
+    write_execution_evidence(
+        root / "execution-evidence.json",
+        ExecutionEvidence(
+            dataset_id="0" * 64,
+            execution_policy_digest=serving_package._execution_cost(
+                root
+            ).execution_policy_digest,
+            path_mode="conservative",
+            processing_bar_volume_capacity=True,
+            partial_fill_carry=True,
+            trigger_volume_fractions=(1.0, 0.5, 0.25, 0.0),
+            order_event_count=4,
+            complete_order_evidence=True,
+            sensitivity_path_modes=("conservative",),
+        ),
+    )
+    manifest = _rebuild_manifest(root, manifest)
+    confirmation_path = tmp_path / "confirmation.json"
+    _confirmation(confirmation_path, manifest)
+
+    with pytest.raises(ValueError, match="execution evidence dataset identity"):
+        _package(root, manifest, confirmation_path, tmp_path / "bundle")
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("digest", "0" * 64, "ensemble digest"),
+        ("dataset_id", "0" * 64, "dataset identity"),
+        ("environment_digest", "0" * 64, "environment identity"),
+    ],
+)
+def test_package_rejects_ensemble_identity_mismatch(
+    tmp_path: Path,
+    field: str,
+    value: str,
+    message: str,
+) -> None:
+    root = tmp_path / "training"
+    manifest = _training_run(root, run_kind="research_selected_final")
+    ensemble_path = root / "ensemble.json"
+    ensemble = json.loads(ensemble_path.read_text(encoding="utf-8"))
+    ensemble[field] = value
+    ensemble_path.write_text(json.dumps(ensemble), encoding="utf-8")
+    manifest = _rebuild_manifest(root, manifest)
+    confirmation_path = tmp_path / "confirmation.json"
+    _confirmation(confirmation_path, manifest)
+
+    with pytest.raises(ValueError, match=message):
+        _package(root, manifest, confirmation_path, tmp_path / "bundle")
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("training_run_digest", "0" * 64, "training run identity"),
+        ("dataset_id", "0" * 64, "dataset identity"),
+        ("environment_digest", "0" * 64, "environment identity"),
+        ("policy_digest", "0" * 64, "policy identity"),
+    ],
+)
+def test_package_rejects_confirmation_identity_mismatch(
+    tmp_path: Path,
+    field: str,
+    value: str,
+    message: str,
+) -> None:
+    root = tmp_path / "training"
+    manifest = _training_run(root, run_kind="research_selected_final")
+    confirmation_path = tmp_path / "confirmation.json"
+    _write_confirmation(confirmation_path, manifest, **{field: value})
+
+    with pytest.raises(ValueError, match=message):
+        _package(root, manifest, confirmation_path, tmp_path / "bundle")
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"order_log_digest": "0" * 64}, "order log digest"),
+        ({"fill_log_digest": "0" * 64}, "fill log digest"),
+        ({"training_run_digest": "0" * 64}, "training run identity"),
+        ({"environment_digest": "0" * 64}, "environment identity"),
+        ({"policy_digest": "0" * 64}, "policy identity"),
+        ({"start_time": COMPLETED + timedelta(hours=1)}, "start time"),
+        ({"end_time": COMPLETED + timedelta(days=30, hours=1)}, "end time"),
+    ],
+)
+def test_package_rejects_reconciliation_binding_mismatch(
+    tmp_path: Path,
+    overrides: dict[str, object],
+    message: str,
+) -> None:
+    root = tmp_path / "training"
+    manifest = _training_run(root, run_kind="research_selected_final")
+    confirmation_path = tmp_path / "confirmation.json"
+    _confirmation(
+        confirmation_path,
+        manifest,
+        reconciliation_overrides=overrides,
+    )
+
+    with pytest.raises(ValueError, match=message):
+        _package(root, manifest, confirmation_path, tmp_path / "bundle")
+
+
+def test_package_rejects_existing_output(tmp_path: Path) -> None:
+    root = tmp_path / "training"
+    manifest = _training_run(root, run_kind="research_selected_final")
+    confirmation_path = tmp_path / "confirmation.json"
+    _confirmation(confirmation_path, manifest)
+    output = tmp_path / "bundle"
+    output.mkdir()
+
+    with pytest.raises(FileExistsError, match="already exists"):
+        _package(root, manifest, confirmation_path, output)
+
+
+def test_package_removes_stale_stage_before_publication(tmp_path: Path) -> None:
+    root = tmp_path / "training"
+    manifest = _training_run(root, run_kind="research_selected_final")
+    confirmation_path = tmp_path / "confirmation.json"
+    _confirmation(confirmation_path, manifest)
+    output = tmp_path / "bundle"
+    stage = tmp_path / ".bundle.staging"
+    stage.mkdir()
+    (stage / "stale.txt").write_text("stale", encoding="utf-8")
+
+    _package(root, manifest, confirmation_path, output)
+
+    assert output.is_dir()
+    assert not stage.exists()
+
+
+def test_package_cleans_stage_after_manifest_input_failure(tmp_path: Path) -> None:
+    root = tmp_path / "training"
+    manifest = _training_run(root, run_kind="research_selected_final")
+    ensemble_path = root / "ensemble.json"
+    ensemble = json.loads(ensemble_path.read_text(encoding="utf-8"))
+    ensemble["action_names"] = ["valid", 1]
+    ensemble_path.write_text(json.dumps(ensemble), encoding="utf-8")
+    manifest = _rebuild_manifest(root, manifest)
+    confirmation_path = tmp_path / "confirmation.json"
+    _confirmation(confirmation_path, manifest)
+    output = tmp_path / "bundle"
+    stage = tmp_path / ".bundle.staging"
+
+    with pytest.raises(ValueError, match="action_names"):
+        _package(root, manifest, confirmation_path, output)
+
+    assert not output.exists()
+    assert not stage.exists()
+
+
+def test_public_key_fixture_remains_bound_to_expected_private_key() -> None:
+    assert PUBLIC_KEY.public_key == public_key_bytes(PRIVATE_KEY)

--- a/tests/serving/test_package_critical_branches.py
+++ b/tests/serving/test_package_critical_branches.py
@@ -130,8 +130,10 @@ def test_package_optional_string_accepts_none_and_rejects_other_types() -> None:
 def test_package_rejects_metadata_dataset_mismatch(tmp_path: Path) -> None:
     root = tmp_path / "training"
     manifest = _training_run(root, run_kind="research_selected_final")
+    metadata_path = root / "metadata-promotion.json"
+    metadata_path.unlink()
     write_metadata_promotion_evidence(
-        root / "metadata-promotion.json",
+        metadata_path,
         MetadataPromotionEvidence(
             dataset_id="0" * 64,
             mode="historical_signed",
@@ -155,8 +157,10 @@ def test_package_rejects_metadata_dataset_mismatch(tmp_path: Path) -> None:
 def test_package_rejects_execution_evidence_dataset_mismatch(tmp_path: Path) -> None:
     root = tmp_path / "training"
     manifest = _training_run(root, run_kind="research_selected_final")
+    execution_path = root / "execution-evidence.json"
+    execution_path.unlink()
     write_execution_evidence(
-        root / "execution-evidence.json",
+        execution_path,
         ExecutionEvidence(
             dataset_id="0" * 64,
             execution_policy_digest=serving_package._execution_cost(
@@ -240,7 +244,13 @@ def test_package_rejects_confirmation_identity_mismatch(
         ({"environment_digest": "0" * 64}, "environment identity"),
         ({"policy_digest": "0" * 64}, "policy identity"),
         ({"start_time": COMPLETED + timedelta(hours=1)}, "start time"),
-        ({"end_time": COMPLETED + timedelta(days=30, hours=1)}, "end time"),
+        (
+            {
+                "end_time": COMPLETED + timedelta(days=30, hours=1),
+                "created_at": COMPLETED + timedelta(days=30, hours=1),
+            },
+            "end time",
+        ),
     ],
 )
 def test_package_rejects_reconciliation_binding_mismatch(

--- a/tests/serving/test_training_environment_contract.py
+++ b/tests/serving/test_training_environment_contract.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import inspect
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+import pytest
+
+from trade_rl.serving import package as serving_package
+from trade_rl.simulation.execution import ExecutionCostConfig
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _payload() -> dict[str, object]:
+    return {
+        "environment": {"execution_cost": asdict(ExecutionCostConfig())},
+        "schema_version": "training_environment_v2",
+    }
+
+
+def _write_environment(root: Path, payload: object) -> None:
+    root.mkdir()
+    (root / "environment.json").write_text(
+        json.dumps(payload),
+        encoding="utf-8",
+    )
+
+
+def test_execution_cost_round_trips_complete_training_artifact(tmp_path: Path) -> None:
+    root = tmp_path / "training"
+    expected = ExecutionCostConfig(
+        fee_rate=0.0007,
+        maker_fee_rate=0.0001,
+        taker_fee_rate=0.0008,
+        order_latency_bars=2,
+        order_type="limit",
+        trigger_volume_fractions=(0.9, 0.6, 0.3, 0.1),
+    )
+    payload = _payload()
+    environment = payload["environment"]
+    assert isinstance(environment, dict)
+    environment["execution_cost"] = asdict(expected)
+    _write_environment(root, payload)
+
+    assert serving_package._execution_cost(root) == expected
+
+
+def test_execution_cost_rejects_unsupported_training_environment_schema(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "training"
+    payload = _payload()
+    payload["schema_version"] = "training_environment_v1"
+    _write_environment(root, payload)
+
+    with pytest.raises(ValueError, match="schema"):
+        serving_package._execution_cost(root)
+
+
+def test_execution_cost_rejects_missing_canonical_field(tmp_path: Path) -> None:
+    root = tmp_path / "training"
+    payload = _payload()
+    environment = payload["environment"]
+    assert isinstance(environment, dict)
+    execution = environment["execution_cost"]
+    assert isinstance(execution, dict)
+    execution.pop("path_mode")
+    _write_environment(root, payload)
+
+    with pytest.raises(ValueError, match="missing.*path_mode"):
+        serving_package._execution_cost(root)
+
+
+def test_execution_cost_rejects_unknown_canonical_field(tmp_path: Path) -> None:
+    root = tmp_path / "training"
+    payload = _payload()
+    environment = payload["environment"]
+    assert isinstance(environment, dict)
+    execution = environment["execution_cost"]
+    assert isinstance(execution, dict)
+    execution["future_default"] = 1
+    _write_environment(root, payload)
+
+    with pytest.raises(ValueError, match="unknown.*future_default"):
+        serving_package._execution_cost(root)
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ([], "training environment must be a mapping"),
+        ({"schema_version": "training_environment_v2", "environment": []}, "environment must be a mapping"),
+        (
+            {
+                "schema_version": "training_environment_v2",
+                "environment": {"execution_cost": []},
+            },
+            "execution_cost must be a mapping",
+        ),
+    ],
+)
+def test_execution_cost_rejects_malformed_mappings(
+    tmp_path: Path,
+    payload: object,
+    message: str,
+) -> None:
+    root = tmp_path / "training"
+    _write_environment(root, payload)
+
+    with pytest.raises(ValueError, match=message):
+        serving_package._execution_cost(root)
+
+
+def test_serving_package_delegates_execution_artifact_decoding() -> None:
+    source = inspect.getsource(serving_package)
+
+    assert "load_training_execution_cost(" in source
+    assert "ExecutionCostConfig(" not in source
+    assert "defaults = ExecutionCostConfig()" not in source
+
+
+def test_serving_packaging_has_per_file_critical_branch_ratchets() -> None:
+    configuration = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+
+    assert '"trade_rl/serving/package.py" = 90.0' in configuration
+    assert '"trade_rl/serving/training_environment.py" = 100.0' in configuration

--- a/tests/serving/test_training_environment_contract.py
+++ b/tests/serving/test_training_environment_contract.py
@@ -87,6 +87,20 @@ def test_execution_cost_rejects_unknown_canonical_field(tmp_path: Path) -> None:
         serving_package._execution_cost(root)
 
 
+def test_execution_cost_rejects_non_sequence_trigger_fractions(tmp_path: Path) -> None:
+    root = tmp_path / "training"
+    payload = _payload()
+    environment = payload["environment"]
+    assert isinstance(environment, dict)
+    execution = environment["execution_cost"]
+    assert isinstance(execution, dict)
+    execution["trigger_volume_fractions"] = 1.0
+    _write_environment(root, payload)
+
+    with pytest.raises(ValueError, match="trigger_volume_fractions"):
+        serving_package._execution_cost(root)
+
+
 @pytest.mark.parametrize(
     ("payload", "message"),
     [

--- a/tests/serving/test_training_environment_contract.py
+++ b/tests/serving/test_training_environment_contract.py
@@ -91,7 +91,10 @@ def test_execution_cost_rejects_unknown_canonical_field(tmp_path: Path) -> None:
     ("payload", "message"),
     [
         ([], "training environment must be a mapping"),
-        ({"schema_version": "training_environment_v2", "environment": []}, "environment must be a mapping"),
+        (
+            {"schema_version": "training_environment_v2", "environment": []},
+            "environment must be a mapping",
+        ),
         (
             {
                 "schema_version": "training_environment_v2",

--- a/trade_rl/serving/package.py
+++ b/trade_rl/serving/package.py
@@ -26,6 +26,7 @@ from trade_rl.serving.bundle import (
     ServingBundleManifest,
     write_serving_bundle_manifest,
 )
+from trade_rl.serving.training_environment import load_training_execution_cost
 from trade_rl.simulation.execution import ExecutionCostConfig
 from trade_rl.simulation.execution_promotion import (
     EXECUTION_EVIDENCE_FILE_NAME,
@@ -64,127 +65,8 @@ def _number(value: object, *, field: str) -> float:
     return float(value)
 
 
-def _boolean(value: object, *, field: str) -> bool:
-    if not isinstance(value, bool):
-        raise ValueError(f"{field} must be a boolean")
-    return value
-
-
-def _number_tuple4(
-    value: object,
-    *,
-    field: str,
-) -> tuple[float, float, float, float]:
-    if not isinstance(value, (list, tuple)) or len(value) != 4:
-        raise ValueError(f"{field} must contain four numeric values")
-    return (
-        _number(value[0], field=f"{field}[0]"),
-        _number(value[1], field=f"{field}[1]"),
-        _number(value[2], field=f"{field}[2]"),
-        _number(value[3], field=f"{field}[3]"),
-    )
-
-
 def _execution_cost(training_root: Path) -> ExecutionCostConfig:
-    payload = _mapping(
-        json.loads((training_root / "environment.json").read_text(encoding="utf-8")),
-        field="training environment",
-    )
-    environment = _mapping(payload.get("environment"), field="environment")
-    raw = _mapping(environment.get("execution_cost"), field="execution_cost")
-    defaults = ExecutionCostConfig()
-    return ExecutionCostConfig(
-        fee_rate=_number(raw.get("fee_rate", defaults.fee_rate), field="fee_rate"),
-        maker_fee_rate=_number(
-            raw.get("maker_fee_rate", defaults.maker_fee_rate),
-            field="maker_fee_rate",
-        ),
-        taker_fee_rate=_number(
-            raw.get("taker_fee_rate", defaults.taker_fee_rate),
-            field="taker_fee_rate",
-        ),
-        spread_rate=_number(
-            raw.get("spread_rate", defaults.spread_rate), field="spread_rate"
-        ),
-        impact_rate=_number(
-            raw.get("impact_rate", defaults.impact_rate), field="impact_rate"
-        ),
-        multiplier=_number(
-            raw.get("multiplier", defaults.multiplier), field="multiplier"
-        ),
-        max_participation_rate=_number(
-            raw.get("max_participation_rate", defaults.max_participation_rate),
-            field="max_participation_rate",
-        ),
-        slippage_std=_number(
-            raw.get("slippage_std", defaults.slippage_std), field="slippage_std"
-        ),
-        tail_slippage_probability=_number(
-            raw.get("tail_slippage_probability", defaults.tail_slippage_probability),
-            field="tail_slippage_probability",
-        ),
-        tail_slippage_multiplier=_number(
-            raw.get("tail_slippage_multiplier", defaults.tail_slippage_multiplier),
-            field="tail_slippage_multiplier",
-        ),
-        random_seed=_integer(
-            raw.get("random_seed", defaults.random_seed), field="random_seed"
-        ),
-        minimum_notional=_number(
-            raw.get("minimum_notional", defaults.minimum_notional),
-            field="minimum_notional",
-        ),
-        lot_size=_number(raw.get("lot_size", defaults.lot_size), field="lot_size"),
-        tick_size=_number(raw.get("tick_size", defaults.tick_size), field="tick_size"),
-        allow_short=_boolean(
-            raw.get("allow_short", defaults.allow_short), field="allow_short"
-        ),
-        borrow_rate_multiplier=_number(
-            raw.get("borrow_rate_multiplier", defaults.borrow_rate_multiplier),
-            field="borrow_rate_multiplier",
-        ),
-        max_leverage=_number(
-            raw.get("max_leverage", defaults.max_leverage), field="max_leverage"
-        ),
-        maintenance_margin_rate=_number(
-            raw.get("maintenance_margin_rate", defaults.maintenance_margin_rate),
-            field="maintenance_margin_rate",
-        ),
-        collateral_haircut=_number(
-            raw.get("collateral_haircut", defaults.collateral_haircut),
-            field="collateral_haircut",
-        ),
-        margin_mode=_string(
-            raw.get("margin_mode", defaults.margin_mode), field="margin_mode"
-        ),
-        order_latency_bars=_integer(
-            raw.get("order_latency_bars", defaults.order_latency_bars),
-            field="order_latency_bars",
-        ),
-        order_type=_string(
-            raw.get("order_type", defaults.order_type), field="order_type"
-        ),
-        limit_offset_rate=_number(
-            raw.get("limit_offset_rate", defaults.limit_offset_rate),
-            field="limit_offset_rate",
-        ),
-        path_mode=_string(raw.get("path_mode", defaults.path_mode), field="path_mode"),
-        processing_bar_volume_capacity=_boolean(
-            raw.get(
-                "processing_bar_volume_capacity",
-                defaults.processing_bar_volume_capacity,
-            ),
-            field="processing_bar_volume_capacity",
-        ),
-        partial_fill_carry=_boolean(
-            raw.get("partial_fill_carry", defaults.partial_fill_carry),
-            field="partial_fill_carry",
-        ),
-        trigger_volume_fractions=_number_tuple4(
-            raw.get("trigger_volume_fractions", defaults.trigger_volume_fractions),
-            field="trigger_volume_fractions",
-        ),
-    )
+    return load_training_execution_cost(training_root / "environment.json")
 
 
 def package_selected_training_run(
@@ -342,8 +224,7 @@ def package_selected_training_run(
                 field="ensemble.observation_schema",
             ),
             observation_size=_integer(
-                ensemble_raw.get("observation_size"),
-                field="ensemble.observation_size",
+                ensemble_raw.get("observation_size"), field="ensemble.observation_size"
             ),
             environment_digest=manifest.environment_digest,
             initial_capital=_number(

--- a/trade_rl/serving/training_environment.py
+++ b/trade_rl/serving/training_environment.py
@@ -28,9 +28,7 @@ def load_training_execution_cost(path: Path) -> ExecutionCostConfig:
     if payload.get("schema_version") != TRAINING_ENVIRONMENT_SCHEMA:
         raise ValueError("unsupported training environment schema")
     environment = _mapping(payload.get("environment"), field="environment")
-    raw = dict(
-        _mapping(environment.get("execution_cost"), field="execution_cost")
-    )
+    raw = dict(_mapping(environment.get("execution_cost"), field="execution_cost"))
     expected = {item.name for item in fields(ExecutionCostConfig)}
     observed = set(raw)
     missing = sorted(expected - observed)

--- a/trade_rl/serving/training_environment.py
+++ b/trade_rl/serving/training_environment.py
@@ -42,10 +42,7 @@ def load_training_execution_cost(path: Path) -> ExecutionCostConfig:
     if not isinstance(fractions, (list, tuple)):
         raise ValueError("trigger_volume_fractions must be a list or tuple")
     raw["trigger_volume_fractions"] = tuple(fractions)
-    try:
-        return ExecutionCostConfig(**cast(dict[str, Any], raw))
-    except TypeError as error:
-        raise ValueError("execution_cost fields are invalid") from error
+    return ExecutionCostConfig(**cast(dict[str, Any], raw))
 
 
 __all__ = ["TRAINING_ENVIRONMENT_SCHEMA", "load_training_execution_cost"]

--- a/trade_rl/serving/training_environment.py
+++ b/trade_rl/serving/training_environment.py
@@ -1,0 +1,52 @@
+"""Strict decoding for training-environment artifacts used by Serving promotion."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import fields
+from pathlib import Path
+
+from trade_rl.simulation.execution import ExecutionCostConfig
+
+TRAINING_ENVIRONMENT_SCHEMA = "training_environment_v2"
+
+
+def _mapping(value: object, *, field: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field} must be a mapping")
+    return value
+
+
+def load_training_execution_cost(path: Path) -> ExecutionCostConfig:
+    """Load one complete execution-cost identity without applying local defaults."""
+
+    payload = _mapping(
+        json.loads(Path(path).read_text(encoding="utf-8")),
+        field="training environment",
+    )
+    if payload.get("schema_version") != TRAINING_ENVIRONMENT_SCHEMA:
+        raise ValueError("unsupported training environment schema")
+    environment = _mapping(payload.get("environment"), field="environment")
+    raw = dict(
+        _mapping(environment.get("execution_cost"), field="execution_cost")
+    )
+    expected = {item.name for item in fields(ExecutionCostConfig)}
+    observed = set(raw)
+    missing = sorted(expected - observed)
+    unknown = sorted(observed - expected)
+    if missing:
+        raise ValueError(f"missing execution_cost fields: {', '.join(missing)}")
+    if unknown:
+        raise ValueError(f"unknown execution_cost fields: {', '.join(unknown)}")
+    fractions = raw["trigger_volume_fractions"]
+    if not isinstance(fractions, (list, tuple)):
+        raise ValueError("trigger_volume_fractions must be a list or tuple")
+    raw["trigger_volume_fractions"] = tuple(fractions)
+    try:
+        return ExecutionCostConfig(**raw)
+    except TypeError as error:
+        raise ValueError("execution_cost fields are invalid") from error
+
+
+__all__ = ["TRAINING_ENVIRONMENT_SCHEMA", "load_training_execution_cost"]

--- a/trade_rl/serving/training_environment.py
+++ b/trade_rl/serving/training_environment.py
@@ -6,6 +6,7 @@ import json
 from collections.abc import Mapping
 from dataclasses import fields
 from pathlib import Path
+from typing import Any, cast
 
 from trade_rl.simulation.execution import ExecutionCostConfig
 
@@ -42,7 +43,7 @@ def load_training_execution_cost(path: Path) -> ExecutionCostConfig:
         raise ValueError("trigger_volume_fractions must be a list or tuple")
     raw["trigger_volume_fractions"] = tuple(fractions)
     try:
-        return ExecutionCostConfig(**raw)
+        return ExecutionCostConfig(**cast(dict[str, Any], raw))
     except TypeError as error:
         raise ValueError("execution_cost fields are invalid") from error
 


### PR DESCRIPTION
## Scope

First of three independent architecture-remediation PRs.

- add a strict canonical loader for `training_environment_v2`
- remove field-by-field execution defaults from Serving packaging
- reject unsupported schemas and missing/unknown execution fields
- add per-file critical branch coverage for the packaging boundary

## TDD evidence

RED head: `444efca71d0464f5c888241433505beacd427592`

- CI run `30030564440`
- expected result: `5 failed, 446 passed`
- confirmed the old implementation accepted unsupported schemas, missing and unknown fields, retained local reconstruction, and lacked critical ratchets

GREEN head: `cf5a014639ae03cff4993a0f21578b5563d58480`

- CI run `30032454461`: success
- PostgreSQL Catalog run `30032454500`: success
- full Pytest: `1379 passed, 2 skipped, 11 warnings`
- total coverage: `84.46%`
- `trade_rl/serving/package.py` branch coverage: `93.94%` (target `90.0%`)
- `trade_rl/serving/training_environment.py` branch coverage: `100.0%` (target `100.0%`)
- Ruff, format, Mypy, Import Linter, dead-code report, recovery/Serving smoke, CLI smoke: passed
- Studio tests/typecheck/build/fixed viewport: passed
- Ubuntu and Windows compatibility: passed
- complete training image and packaged non-root probe: passed

Pytest artifact: `8573939197`

Artifact digest: `sha256:fd72777f80fa85eda3f65b23444464f526a122f7392338117194720e8676ba3c`

Production remains `NO-GO`.