### PR TITLE
fix: correct PR C Lagrangian stability semantics

### DIFF
--- a/tests/integrations/test_lagrangian_actor_advantages.py
+++ b/tests/integrations/test_lagrangian_actor_advantages.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import numpy as np
+import torch
+
+from trade_rl.integrations.lagrangian_ppo import LagrangianPPO
+
+
+def _actor_stub(*, multipliers: np.ndarray, normalize: bool) -> Any:
+    model = cast(Any, object.__new__(LagrangianPPO))
+    snapshot = np.asarray(multipliers, dtype=np.float64).copy()
+    snapshot.flags.writeable = False
+    model.frozen_lagrange_multipliers = snapshot
+    model.normalize_advantage = normalize
+    return model
+
+
+def test_actor_normalizes_only_after_raw_lagrangian_composition() -> None:
+    model = _actor_stub(
+        multipliers=np.asarray([2.0, 0.5]),
+        normalize=True,
+    )
+    reward = torch.asarray([0.4, -0.2, 1.3, 0.1], dtype=torch.float32)
+    costs = np.asarray(
+        [[0.1, 3.0], [0.4, 2.0], [0.2, 1.0], [0.8, 4.0]],
+        dtype=np.float64,
+    )
+
+    actual = model._actor_advantages(
+        reward_advantages=reward,
+        cost_advantages=costs,
+    )
+
+    penalty = torch.as_tensor(costs @ np.asarray([2.0, 0.5]), dtype=reward.dtype)
+    raw = reward - penalty
+    expected = (raw - raw.mean()) / (raw.std() + 1e-8)
+    torch.testing.assert_close(actual, expected, rtol=0.0, atol=0.0)
+
+
+def test_actor_uses_raw_composition_when_normalization_is_disabled() -> None:
+    model = _actor_stub(
+        multipliers=np.asarray([1.5]),
+        normalize=False,
+    )
+    reward = torch.asarray([1.0, -2.0, 4.0], dtype=torch.float32)
+    costs = np.asarray([[0.2], [0.4], [0.1]], dtype=np.float64)
+
+    actual = model._actor_advantages(
+        reward_advantages=reward,
+        cost_advantages=costs,
+    )
+
+    expected = reward - torch.as_tensor(
+        costs[:, 0] * 1.5,
+        dtype=reward.dtype,
+    )
+    torch.testing.assert_close(actual, expected, rtol=0.0, atol=0.0)
+
+
+def test_actor_zero_multiplier_path_uses_pinned_ppo_normalization() -> None:
+    model = _actor_stub(
+        multipliers=np.asarray([0.0]),
+        normalize=True,
+    )
+    reward = torch.asarray([1.0, 3.0, 5.0], dtype=torch.float32)
+    costs = np.asarray([[10.0], [20.0], [30.0]], dtype=np.float64)
+
+    actual = model._actor_advantages(
+        reward_advantages=reward,
+        cost_advantages=costs,
+    )
+
+    expected = (reward - reward.mean()) / (reward.std() + 1e-8)
+    torch.testing.assert_close(actual, expected, rtol=0.0, atol=0.0)


### PR DESCRIPTION
Closed because the correction branch was forked before the latest PR #191 test commit, so the intended reversion was not represented in the PR diff. A replacement correction branch is created from the exact current PR #191 head.