### PR TITLE
chore: synchronize H1 with merged market-data base

### DIFF
--- a/.github/workflows/launch-binance-frozen-226.yml
+++ b/.github/workflows/launch-binance-frozen-226.yml
@@ -109,6 +109,13 @@ jobs:
             "trade-rl-training:${TRADE_RL_GIT_COMMIT}" \
             -c 'import torch; assert torch.cuda.is_available(); print(torch.cuda.get_device_name(0))'
 
+      - name: Synchronize shared market archives
+        if: env.TRADE_RL_OPERATION == 'start'
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker compose -f compose.training.yaml run --rm market-data-sync
+
       - name: Start supervised research phase
         if: env.TRADE_RL_OPERATION == 'start'
         shell: bash

--- a/Dockerfile.training
+++ b/Dockerfile.training
@@ -21,6 +21,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     TRADE_RL_METADATA_MODE=frozen_snapshot \
     TRADE_RL_RESEARCH_PHASE=develop \
+    TRADE_RL_MARKET_DATA_CACHE_ROOT=/workspace/market-data/binance-vision \
     UV_LINK_MODE=copy \
     UV_PROJECT_ENVIRONMENT=/opt/trade-rl-venv \
     PATH="/opt/trade-rl-venv/bin:${PATH}"
@@ -32,8 +33,16 @@ RUN groupadd --system trainer \
 WORKDIR /workspace
 COPY pyproject.toml uv.lock README.md ./
 RUN uv sync --frozen --extra train-sb3 --no-dev --no-install-project \
-    && mkdir -p /workspace/var \
-    && chown trainer:trainer /workspace/var
+    && mkdir -p \
+        /workspace/var/runs \
+        /workspace/var/cache/teacher-artifacts \
+        /workspace/market-data/binance-vision \
+    && chown trainer:trainer /workspace/var \
+        /workspace/var/runs \
+        /workspace/var/cache \
+        /workspace/var/cache/teacher-artifacts \
+        /workspace/market-data \
+        /workspace/market-data/binance-vision
 
 COPY --chown=trainer:trainer trade_rl ./trade_rl
 COPY --chown=trainer:trainer examples ./examples
@@ -60,8 +69,11 @@ RUN test "$(sha256sum uv.lock | cut -d' ' -f1)" = "${TRADE_RL_LOCKFILE_DIGEST}" 
 USER trainer
 RUN test "$(id -u)" -ne 0 \
     && test -w /workspace/var \
+    && test -w /workspace/var/runs \
+    && test -w /workspace/var/cache/teacher-artifacts \
+    && test -w /workspace/market-data/binance-vision \
     && test -r /workspace/trade_rl/__init__.py \
-    && test -r /workspace/examples/binance-multitimeframe/full_run_entrypoint.py \
+    && test -r /workspace/examples/binance-multitimeframe/training_bootstrap.py \
     && test "$(cat /provenance.valid)" \
         = "${TRADE_RL_GIT_COMMIT}:${TRADE_RL_GIT_DIRTY}:${TRADE_RL_SOURCE_TREE_DIGEST}:${TRADE_RL_LOCKFILE_DIGEST}"
 

--- a/compose.training.yaml
+++ b/compose.training.yaml
@@ -1,14 +1,37 @@
+x-training-image: &training-image
+  image: trade-rl-training:${TRADE_RL_GIT_COMMIT:-invalid}
+  build:
+    context: .
+    dockerfile: Dockerfile.training
+    args:
+      TRADE_RL_GIT_COMMIT: ${TRADE_RL_GIT_COMMIT:-}
+      TRADE_RL_GIT_DIRTY: ${TRADE_RL_GIT_DIRTY:-}
+      TRADE_RL_SOURCE_TREE_DIGEST: ${TRADE_RL_SOURCE_TREE_DIGEST:-}
+      TRADE_RL_LOCKFILE_DIGEST: ${TRADE_RL_LOCKFILE_DIGEST:-}
+
 services:
+  market-data-sync:
+    <<: *training-image
+    command:
+      - python
+      - examples/binance-multitimeframe/sync_market_data.py
+      - --cache-root
+      - /workspace/market-data/binance-vision
+      - --legacy-cache-root
+      - /workspace/legacy-var/cache/binance-vision
+    environment:
+      TRADE_RL_MARKET_DATA_CACHE_ROOT: /workspace/market-data/binance-vision
+      TRADE_RL_LEGACY_MARKET_DATA_CACHE_ROOT: /workspace/legacy-var/cache/binance-vision
+    volumes:
+      - trade-rl-market-archives:/workspace/market-data/binance-vision
+      - trade-rl-training-data:/workspace/legacy-var:ro
+    restart: "no"
+
   trainer:
-    image: trade-rl-training:${TRADE_RL_GIT_COMMIT:-invalid}
-    build:
-      context: .
-      dockerfile: Dockerfile.training
-      args:
-        TRADE_RL_GIT_COMMIT: ${TRADE_RL_GIT_COMMIT:-}
-        TRADE_RL_GIT_DIRTY: ${TRADE_RL_GIT_DIRTY:-}
-        TRADE_RL_SOURCE_TREE_DIGEST: ${TRADE_RL_SOURCE_TREE_DIGEST:-}
-        TRADE_RL_LOCKFILE_DIGEST: ${TRADE_RL_LOCKFILE_DIGEST:-}
+    <<: *training-image
+    command:
+      - python
+      - examples/binance-multitimeframe/training_bootstrap.py
     gpus: all
     environment:
       TRADE_RL_RUN_GENERATION: ${TRADE_RL_RUN_GENERATION:-}
@@ -23,10 +46,12 @@ services:
       TRADE_RL_CONFIRMATION_PUBLIC_KEYS: ${TRADE_RL_CONFIRMATION_PUBLIC_KEYS:-}
       TRADE_RL_TRUSTED_NOW: ${TRADE_RL_TRUSTED_NOW:-}
       TRADE_RL_IMAGE_DIGEST: ${TRADE_RL_IMAGE_DIGEST:-}
+      TRADE_RL_MARKET_DATA_CACHE_ROOT: /workspace/market-data/binance-vision
       TRADE_RL_TEACHER_CACHE_ROOT: /workspace/var/cache/teacher-artifacts
       OMP_NUM_THREADS: "8"
       MKL_NUM_THREADS: "8"
     volumes:
+      - trade-rl-market-archives:/workspace/market-data/binance-vision:ro
       - trade-rl-training-data:/workspace/var
       - type: bind
         source: ${TRADE_RL_EVIDENCE_ROOT:-./var/evidence}
@@ -34,5 +59,7 @@ services:
         read_only: true
 
 volumes:
+  trade-rl-market-archives:
+    name: trade-rl-market-archives
   trade-rl-training-data:
     name: trade-rl-training-data

--- a/docs/operations/docker-gpu-full-training.md
+++ b/docs/operations/docker-gpu-full-training.md
@@ -20,6 +20,40 @@ The training image is tagged by the exact Git commit and binds:
 
 The image build and runtime both recompute source and lock identities. A caller-supplied commit string alone is never accepted as provenance. The process also records generation identity, phase, runtime/container identity, heartbeat, terminal state, and retained evidence paths before cleanup.
 
+## Shared market-data archives
+
+Binance Vision ZIP archives are stored in the independent Docker volume `trade-rl-market-archives`. They are not stored inside a training generation or PostgreSQL. The one-shot `market-data-sync` service mounts this volume read-write; `trainer` mounts it read-only.
+
+The existing `trade-rl-training-data` volume remains mounted at `/workspace/var`. Existing generation directories, checkpoints, logs and teacher artifacts therefore remain available. During synchronization the same legacy volume is mounted read-only at `/workspace/legacy-var`; valid nonempty files from `/workspace/legacy-var/cache/binance-vision` are copied into the new archive volume only when the destination file does not already exist. This avoids a one-time full redownload while preserving new-volume ownership.
+
+Use the canonical launcher for every local phase start:
+
+```bash
+python examples/binance-multitimeframe/run_docker_training.py
+```
+
+The launcher executes these operations in order:
+
+1. import reusable files from the former cache location;
+2. plan the exact archive URLs required by the maintained symbols, native timeframes and fixed research interval;
+3. inspect the shared cache and download only missing or empty archives;
+4. stop immediately if synchronization fails;
+5. start `trainer` with `--no-deps`.
+
+Manual synchronization is available when only the archive volume should be updated:
+
+```bash
+docker compose -f compose.training.yaml run --rm market-data-sync
+```
+
+A direct `docker compose ... run trainer` invocation does not perform synchronization. The training bootstrap still performs a read-only completeness check before CUDA preflight and forwards the same cache root to the full-research command. If the archive volume is incomplete, training fails closed and prints the synchronization command instead of downloading into the read-only mount.
+
+The protected **Control Binance frozen 226 full generation** workflow also runs `market-data-sync` explicitly before handing control to the durable trainer supervisor. This ensures every supervised phase start performs the same missing-only synchronization rather than relying on the lifecycle state of a previous Compose service container.
+
+The maintained research end time remains authoritative. Advancing it in the pipeline causes only newly required URL-addressed archives to be downloaded; unchanged archives are read from the shared cache. The trailing incomplete USDⓈ-M funding month remains a REST responsibility of the existing dataset path because Binance Vision publishes funding archives monthly.
+
+Removing `trade-rl-training-data` still removes run artifacts and teacher cache, as before. Removing `trade-rl-market-archives` removes only the reusable public archive cache and causes the next sync to re-import any surviving legacy cache files and download the remaining gaps.
+
 ## Evidence and public keys
 
 Set `TRADE_RL_EVIDENCE_ROOT` as a host path readable by the runner. Mount only public verification material into the trainer:
@@ -43,7 +77,7 @@ Use **Control Binance frozen 226 full generation** from `main`. Supply:
 - phase: `develop`, `train-selected`, or `finalize`
 - generation: one stable identifier reused across the three phases
 
-The workflow checks out `${{ github.sha }}`, verifies the source/lock labels of the commit-tagged image, requires a real CUDA device, then starts one supervised container. `develop` may finish in `awaiting_selection_authorization`; `train-selected` may finish in `awaiting_fresh_confirmation`. These are successful persisted states.
+The workflow checks out `${{ github.sha }}`, verifies the source/lock labels of the commit-tagged image, requires a real CUDA device, synchronizes the shared market archive volume, then starts one supervised container. `develop` may finish in `awaiting_selection_authorization`; `train-selected` may finish in `awaiting_fresh_confirmation`. These are successful persisted states.
 
 Every generation stores its own:
 
@@ -83,6 +117,6 @@ Do not reuse a failed generation as if it were clean. Preserve its artifact and 
 
 ## Studio 学習診断の確認
 
-`training-full.json` と `training-growth-optimal.json` は linear learning-rate decay と TensorBoard scalar 出力を有効にしています。linear decay は候補設定であり、最適値とみなさないでください。
+`training-full.json` と `training-growth-optimal.json` は linear learning-rate decay と TensorBoard scalar output を有効にしています。linear decay は候補設定であり、最適値とみなさないでください。
 
 GPU training の開始後、Studio の `Live Training` で Run と Seed を選択し、`学習診断` を開きます。event file が作成されるまでは `未出力` と表示されます。resume 後は同じ seed/run identity の event file を統合し、global step 軸を継続します。市場リプレイの JSONL telemetry は独立して継続します。

--- a/docs/superpowers/plans/2026-07-27-shared-market-data-cache.md
+++ b/docs/superpowers/plans/2026-07-27-shared-market-data-cache.md
@@ -1,0 +1,88 @@
+# Shared Market Data Cache Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a separate persistent Binance Vision archive volume, incremental missing-only synchronization, legacy-cache import, and a fail-closed training startup cache check.
+
+**Architecture:** A package-level cache planner owns deterministic URL planning, cache inspection, and synchronization. A one-shot sync container imports the old cache read-only, writes the new archive volume, and downloads only remaining gaps. The existing training-data volume remains mounted at `/workspace/var` so current runs and teacher artifacts are preserved. A maintained example launcher runs sync then trainer for every canonical local training invocation, while the protected GPU workflow performs the same explicit sequence.
+
+**Tech Stack:** Python 3.12, Docker Compose, pytest, existing Binance integration.
+
+## Global Constraints
+
+- Keep PostgreSQL metadata-only; do not store numerical market payloads in PostgreSQL.
+- Keep the maintained fixed research interval authoritative and reproducible.
+- Download only missing Binance Vision archives.
+- Preserve existing `trade-rl-training-data` runs and resumable phases.
+- Trainer mounts market archives read-only and must not repair missing data.
+- Fail before CUDA preflight when archive coverage is incomplete.
+
+---
+
+### Task 1: Deterministic Binance Vision cache planner
+
+**Files:**
+- Create: `trade_rl/integrations/binance_cache.py`
+- Test: `tests/integrations/test_binance_cache.py`
+
+**Interfaces:**
+- Produces: `BinanceVisionCachePlan`, `BinanceVisionCacheReport`, `plan_binance_vision_cache`, `inspect_binance_vision_cache`, `require_complete_binance_vision_cache`, `sync_binance_vision_cache`.
+
+- [ ] Write tests for deterministic kline/funding URL planning, completed funding-month selection, missing-only synchronization, and empty cached file rejection.
+- [ ] Run the focused tests and confirm they fail because the module does not exist.
+- [ ] Implement immutable plan/report dataclasses and cache operations using the existing Binance URL planners and `BinancePublicTransport` request/cache contract.
+- [ ] Run focused tests and confirm they pass.
+- [ ] Commit the planner and tests.
+
+### Task 2: Sync CLI, legacy import, and fail-closed training bootstrap
+
+**Files:**
+- Create: `examples/binance-multitimeframe/sync_market_data.py`
+- Create: `examples/binance-multitimeframe/training_bootstrap.py`
+- Test: `tests/examples/test_market_data_sync.py`
+- Test: `tests/examples/test_training_bootstrap.py`
+
+**Interfaces:**
+- Consumes: cache planner from Task 1 and maintained pipeline constants.
+- Produces: legacy-import-aware sync JSON report, `ensure_cache_root_argument`, and `run_bootstrap(cache_root, full_entrypoint)`.
+
+- [ ] Write tests proving sync uses maintained symbols/timeframes/range, imports only valid missing legacy payloads, and bootstrap checks cache before invoking the full entrypoint.
+- [ ] Run focused tests and confirm expected failures.
+- [ ] Implement the sync CLI, legacy import, report persistence, read-only bootstrap check, and shared cache-root forwarding with actionable failure text.
+- [ ] Run focused tests and confirm they pass.
+- [ ] Commit CLI/bootstrap and tests.
+
+### Task 3: Separate Docker market ownership and canonical launcher
+
+**Files:**
+- Modify: `compose.training.yaml`
+- Modify: `Dockerfile.training`
+- Create: `examples/binance-multitimeframe/run_docker_training.py`
+- Modify: `.github/workflows/launch-binance-frozen-226.yml`
+- Test: `tests/test_training_compose_contract.py`
+- Test: `tests/scripts/test_run_docker_training.py`
+- Test: `tests/test_training_workflow_market_sync.py`
+
+**Interfaces:**
+- Produces: `market-data-sync` service, RW new archive mount, RO trainer archive mount, RO legacy cache source for migration, preserved `/workspace/var`, sequential sync/trainer launcher, and explicit protected-workflow synchronization.
+
+- [ ] Write tests that parse the Compose and workflow contracts and assert RW sync versus RO trainer mounts, legacy training-volume preservation, and launcher command ordering.
+- [ ] Run focused tests and confirm expected failures.
+- [ ] Update Compose services/volumes, route the trainer service through bootstrap, and implement both local and protected-workflow sync-before-training paths.
+- [ ] Run focused tests and confirm they pass.
+- [ ] Commit Docker and launcher changes.
+
+### Task 4: Operations documentation and regression verification
+
+**Files:**
+- Modify: `docs/operations/docker-gpu-full-training.md`
+
+**Interfaces:**
+- Documents: canonical launcher, manual sync, automatic legacy-cache import, direct-trainer fail-closed behavior, volume backup/removal, and fixed-range incremental semantics.
+
+- [ ] Update operations documentation.
+- [ ] Run Ruff on changed Python files.
+- [ ] Run focused pytest suites for cache, bootstrap, launcher, Compose contract, existing Binance cache tests, and full-run entrypoint tests.
+- [ ] Run broader relevant integration/example tests when available.
+- [ ] Review the final diff for accidental market-cache writes from trainer and payload storage in PostgreSQL.
+- [ ] Commit documentation and verification adjustments.

--- a/docs/superpowers/specs/2026-07-27-shared-market-data-cache-design.md
+++ b/docs/superpowers/specs/2026-07-27-shared-market-data-cache-design.md
@@ -1,0 +1,49 @@
+# Shared Market Data Cache Design
+
+## Goal
+
+Keep Binance public market archives outside training-run storage, reuse them across containers and generations, and fail before GPU work when required archives are missing.
+
+## Architecture
+
+Docker owns two persistent named-volume boundaries:
+
+- `trade-rl-market-archives`: immutable-by-URL Binance Vision ZIP payload cache.
+- `trade-rl-training-data`: the existing generation artifacts, checkpoints, logs, summaries, and teacher cache.
+
+The existing training-data volume is retained to preserve current runs and resumable research phases. Only the raw public market archive cache moves to the new ownership boundary.
+
+A one-shot `market-data-sync` service mounts the market archive volume read-write. The `trainer` service mounts the same volume read-only. The canonical host-side training launcher always runs the sync service first and then starts the trainer without dependencies.
+
+The sync service mounts the legacy training-data volume read-only and imports valid, nonempty files from its former `cache/binance-vision` directory without overwriting files already present in the new archive volume. It then plans the exact Binance Vision URLs required by the maintained research interval, inspects the URL-addressed cache, and downloads only missing archives. Existing cache files are not requested again. The configured research end remains the source of truth; advancing that end causes only newly required URLs to be downloaded.
+
+## Training startup contract
+
+The training image starts through `training_bootstrap.py` rather than calling the full-research entrypoint directly. Bootstrap performs a read-only cache completeness check before CUDA preflight or training and forwards the shared cache root into the existing full-research command. If any required archive is absent or empty, startup fails with a command that runs the sync service.
+
+The trainer never repairs the archive cache. This preserves the ownership boundary and makes an accidental direct trainer invocation fail closed instead of silently writing into the read-only market volume.
+
+## URL coverage
+
+The cache plan includes:
+
+- Kline archives for every maintained symbol and native timeframe.
+- Completed monthly funding-rate archives for USDⓈ-M symbols.
+
+The trailing incomplete funding month is intentionally not required from Vision because the existing dataset path obtains that interval through the public REST funding endpoint. Exchange metadata remains governed by the selected metadata mode and is not treated as an immutable Vision archive.
+
+## Reports and evidence
+
+Each sync emits a deterministic JSON report containing the requested range, planned URL count, legacy-import count, already-cached count, downloaded count, and cache root. The report is written into the archive volume and printed to stdout. Training bootstrap reports the planned/cached counts during its read-only check.
+
+## Failure handling
+
+- Missing or empty cache payload: fail before CUDA preflight.
+- Failed download: sync exits non-zero; trainer is not started by the canonical launcher.
+- Invalid legacy cache path shape or empty legacy payload: ignore rather than import.
+- Non-Vision URL passed to the cache path resolver: reject.
+- Duplicate planned URLs: deduplicate while preserving deterministic ordering.
+
+## Testing
+
+Tests cover deterministic URL planning, completed funding-month selection, missing-only synchronization, legacy-cache import, empty-file rejection, bootstrap ordering and cache-root forwarding, launcher command ordering, and Compose volume access modes.

--- a/examples/binance-multitimeframe/run_docker_training.py
+++ b/examples/binance-multitimeframe/run_docker_training.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Run incremental market-data synchronization before Docker GPU training."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+
+CommandRunner = Callable[[tuple[str, ...]], int]
+
+
+def build_commands(compose_file: Path) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    prefix = ("docker", "compose", "-f", str(compose_file), "run", "--rm")
+    return (
+        (*prefix, "market-data-sync"),
+        (*prefix, "--no-deps", "trainer"),
+    )
+
+
+def _run_command(command: tuple[str, ...]) -> int:
+    return subprocess.run(command, check=False).returncode
+
+
+def run_training(
+    *,
+    compose_file: Path,
+    runner: CommandRunner = _run_command,
+) -> int:
+    sync_command, trainer_command = build_commands(compose_file)
+    sync_exit = runner(sync_command)
+    if sync_exit != 0:
+        return sync_exit
+    return runner(trainer_command)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--compose-file",
+        type=Path,
+        default=Path("compose.training.yaml"),
+    )
+    args = parser.parse_args(argv)
+    return run_training(compose_file=args.compose_file)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/binance-multitimeframe/sync_market_data.py
+++ b/examples/binance-multitimeframe/sync_market_data.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Synchronize the maintained Binance Vision archive set into shared storage."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Callable
+
+from trade_rl.integrations.binance import BinancePublicTransport
+from trade_rl.integrations.binance_cache import (
+    BinanceVisionCachePlan,
+    sync_binance_vision_cache,
+)
+
+_EXAMPLE_DIR = Path(__file__).resolve().parent
+if str(_EXAMPLE_DIR) not in sys.path:
+    sys.path.insert(0, str(_EXAMPLE_DIR))
+
+import full_research_pipeline as pipeline  # noqa: E402
+
+
+def _parse_utc(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError("maintained research timestamps must include a timezone")
+    return parsed.astimezone(UTC)
+
+
+def build_maintained_plan() -> BinanceVisionCachePlan:
+    from trade_rl.integrations.binance_cache import plan_binance_vision_cache
+
+    return plan_binance_vision_cache(
+        market="usds-m",
+        symbols=pipeline._SYMBOLS,
+        intervals=pipeline._NATIVE_TIMEFRAMES,
+        start_time=_parse_utc(pipeline._START),
+        end_time=_parse_utc(pipeline._END),
+    )
+
+
+def _is_cache_payload(relative: Path) -> bool:
+    if len(relative.parts) != 2 or relative.suffix != ".bin":
+        return False
+    directory, filename = relative.parts
+    stem = Path(filename).stem
+    hexadecimal = set("0123456789abcdef")
+    return (
+        len(directory) == 2
+        and set(directory) <= hexadecimal
+        and len(stem) == 64
+        and set(stem) <= hexadecimal
+        and stem.startswith(directory)
+    )
+
+
+def import_legacy_cache(*, source_root: Path, destination_root: Path) -> int:
+    """Copy valid nonempty legacy cache files without overwriting new storage."""
+
+    if not source_root.is_dir():
+        return 0
+    copied = 0
+    for source in sorted(source_root.rglob("*.bin")):
+        relative = source.relative_to(source_root)
+        if not _is_cache_payload(relative) or source.stat().st_size <= 0:
+            continue
+        destination = destination_root / relative
+        if destination.exists():
+            continue
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+        copied += 1
+    return copied
+
+
+def _atomic_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def run_sync(
+    *,
+    cache_root: Path,
+    legacy_cache_root: Path | None = None,
+    transport_factory: Callable[..., BinancePublicTransport] = BinancePublicTransport,
+) -> dict[str, object]:
+    root = cache_root.resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    legacy_imported_count = 0
+    if legacy_cache_root is not None:
+        legacy_imported_count = import_legacy_cache(
+            source_root=legacy_cache_root,
+            destination_root=root,
+        )
+    plan = build_maintained_plan()
+    transport = transport_factory(
+        timeout_seconds=60.0,
+        max_attempts=4,
+        retry_backoff_seconds=0.5,
+        cache_root=root,
+    )
+    report = sync_binance_vision_cache(plan, transport=transport)
+    payload = {
+        "schema_version": "binance_vision_cache_sync_v1",
+        "legacy_imported_count": legacy_imported_count,
+        **plan.to_dict(),
+        **report.to_dict(),
+    }
+    _atomic_json(root / "sync-report.json", payload)
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--cache-root",
+        type=Path,
+        default=Path(
+            os.environ.get(
+                "TRADE_RL_MARKET_DATA_CACHE_ROOT",
+                "/workspace/market-data/binance-vision",
+            )
+        ),
+    )
+    parser.add_argument(
+        "--legacy-cache-root",
+        type=Path,
+        default=Path(
+            os.environ.get(
+                "TRADE_RL_LEGACY_MARKET_DATA_CACHE_ROOT",
+                "/workspace/legacy-var/cache/binance-vision",
+            )
+        ),
+    )
+    args = parser.parse_args(argv)
+    result = run_sync(
+        cache_root=args.cache_root,
+        legacy_cache_root=args.legacy_cache_root,
+    )
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/binance-multitimeframe/training_bootstrap.py
+++ b/examples/binance-multitimeframe/training_bootstrap.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Validate shared market archives before CUDA preflight and full research."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Callable
+
+from trade_rl.integrations.binance_cache import (
+    BinanceVisionCacheReport,
+    require_complete_binance_vision_cache,
+)
+
+_EXAMPLE_DIR = Path(__file__).resolve().parent
+if str(_EXAMPLE_DIR) not in sys.path:
+    sys.path.insert(0, str(_EXAMPLE_DIR))
+
+import full_run_entrypoint  # noqa: E402
+import sync_market_data  # noqa: E402
+
+
+def check_maintained_cache(cache_root: Path) -> BinanceVisionCacheReport:
+    return require_complete_binance_vision_cache(
+        sync_market_data.build_maintained_plan(),
+        cache_root=cache_root,
+    )
+
+
+def ensure_cache_root_argument(argv: list[str], cache_root: Path) -> list[str]:
+    result = list(argv)
+    if "--cache-root" not in result:
+        result.extend(("--cache-root", str(cache_root)))
+    return result
+
+
+def run_bootstrap(
+    *,
+    cache_root: Path,
+    check_cache: Callable[[Path], object] = check_maintained_cache,
+    full_entrypoint: Callable[[], int] = full_run_entrypoint.main,
+) -> int:
+    try:
+        report = check_cache(cache_root)
+    except FileNotFoundError as error:
+        raise FileNotFoundError(
+            f"{error}. Run `python examples/binance-multitimeframe/"
+            "run_docker_training.py` or "
+            "`docker compose -f compose.training.yaml run --rm market-data-sync` "
+            "before starting trainer."
+        ) from error
+
+    if isinstance(report, BinanceVisionCacheReport):
+        print(
+            json.dumps(
+                {
+                    "cache_root": str(report.cache_root),
+                    "cached_count": report.cached_count,
+                    "planned_count": report.planned_count,
+                    "schema_version": "training_market_cache_preflight_v1",
+                },
+                ensure_ascii=False,
+                sort_keys=True,
+            )
+        )
+    return full_entrypoint()
+
+
+def main() -> int:
+    cache_root = Path(
+        os.environ.get(
+            "TRADE_RL_MARKET_DATA_CACHE_ROOT",
+            "/workspace/market-data/binance-vision",
+        )
+    )
+    sys.argv[:] = ensure_cache_root_argument(sys.argv, cache_root)
+    return run_bootstrap(cache_root=cache_root)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/examples/test_market_data_sync.py
+++ b/tests/examples/test_market_data_sync.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import importlib.util
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+def _load_module():
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "examples"
+        / "binance-multitimeframe"
+        / "sync_market_data.py"
+    )
+    spec = importlib.util.spec_from_file_location("sync_market_data", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_maintained_plan_uses_pipeline_identity() -> None:
+    module = _load_module()
+
+    plan = module.build_maintained_plan()
+
+    assert plan.symbols == tuple(module.pipeline._SYMBOLS)
+    assert plan.intervals == tuple(module.pipeline._NATIVE_TIMEFRAMES)
+    assert plan.start_time == datetime.fromisoformat(
+        module.pipeline._START.replace("Z", "+00:00")
+    ).astimezone(UTC)
+    assert plan.end_time == datetime.fromisoformat(
+        module.pipeline._END.replace("Z", "+00:00")
+    ).astimezone(UTC)
+    assert plan.urls
+
+
+def test_import_legacy_cache_copies_only_missing_nonempty_payloads(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    legacy = tmp_path / "legacy"
+    destination = tmp_path / "destination"
+    source_payload = legacy / "ab" / ("ab" + "1" * 62 + ".bin")
+    empty_payload = legacy / "cd" / ("cd" + "2" * 62 + ".bin")
+    existing_payload = destination / "ef" / ("ef" + "3" * 62 + ".bin")
+    replacement_source = legacy / "ef" / ("ef" + "3" * 62 + ".bin")
+    source_payload.parent.mkdir(parents=True)
+    empty_payload.parent.mkdir(parents=True)
+    existing_payload.parent.mkdir(parents=True)
+    replacement_source.parent.mkdir(parents=True, exist_ok=True)
+    source_payload.write_bytes(b"legacy")
+    empty_payload.write_bytes(b"")
+    existing_payload.write_bytes(b"new")
+    replacement_source.write_bytes(b"old")
+
+    copied = module.import_legacy_cache(
+        source_root=legacy,
+        destination_root=destination,
+    )
+
+    assert copied == 1
+    assert (destination / source_payload.relative_to(legacy)).read_bytes() == b"legacy"
+    assert existing_payload.read_bytes() == b"new"
+    assert not (destination / empty_payload.relative_to(legacy)).exists()

--- a/tests/examples/test_training_bootstrap.py
+++ b/tests/examples/test_training_bootstrap.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _load_module():
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "examples"
+        / "binance-multitimeframe"
+        / "training_bootstrap.py"
+    )
+    spec = importlib.util.spec_from_file_location("training_bootstrap", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_bootstrap_checks_cache_before_full_entrypoint(tmp_path: Path) -> None:
+    module = _load_module()
+    calls: list[str] = []
+
+    result = module.run_bootstrap(
+        cache_root=tmp_path,
+        check_cache=lambda _root: calls.append("check"),
+        full_entrypoint=lambda: calls.append("run") or 7,
+    )
+
+    assert result == 7
+    assert calls == ["check", "run"]
+
+
+def test_bootstrap_does_not_start_training_when_cache_is_incomplete(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    calls: list[str] = []
+
+    def fail_check(_root: Path) -> None:
+        raise FileNotFoundError("missing=2")
+
+    with pytest.raises(FileNotFoundError, match="market-data-sync"):
+        module.run_bootstrap(
+            cache_root=tmp_path,
+            check_cache=fail_check,
+            full_entrypoint=lambda: calls.append("run") or 0,
+        )
+
+    assert calls == []
+
+
+def test_bootstrap_forwards_shared_cache_root_to_full_entrypoint(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+
+    argv = module.ensure_cache_root_argument(["training_bootstrap.py"], tmp_path)
+
+    assert argv == [
+        "training_bootstrap.py",
+        "--cache-root",
+        str(tmp_path),
+    ]
+
+
+def test_bootstrap_preserves_explicit_cache_root(tmp_path: Path) -> None:
+    module = _load_module()
+    explicit = tmp_path / "explicit"
+
+    argv = module.ensure_cache_root_argument(
+        ["training_bootstrap.py", "--cache-root", str(explicit)],
+        tmp_path,
+    )
+
+    assert argv == ["training_bootstrap.py", "--cache-root", str(explicit)]

--- a/tests/integrations/test_binance_cache.py
+++ b/tests/integrations/test_binance_cache.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from trade_rl.integrations.binance_cache import (
+    plan_binance_vision_cache,
+    require_complete_binance_vision_cache,
+    sync_binance_vision_cache,
+    vision_cache_path,
+)
+
+
+def _utc(year: int, month: int, day: int) -> datetime:
+    return datetime(year, month, day, tzinfo=UTC)
+
+
+def test_plan_is_deterministic_and_includes_completed_funding_months() -> None:
+    plan = plan_binance_vision_cache(
+        market="usds-m",
+        symbols=("BTCUSDT", "ETHUSDT"),
+        intervals=("15m", "1h"),
+        start_time=_utc(2026, 1, 1),
+        end_time=_utc(2026, 3, 1),
+    )
+
+    assert plan.urls == tuple(dict.fromkeys(plan.urls))
+    assert any("BTCUSDT-15m-2026-01.zip" in url for url in plan.urls)
+    assert any("ETHUSDT-1h-2026-02.zip" in url for url in plan.urls)
+    assert any("BTCUSDT-fundingRate-2026-01.zip" in url for url in plan.urls)
+    assert any("ETHUSDT-fundingRate-2026-02.zip" in url for url in plan.urls)
+
+
+def test_plan_excludes_incomplete_trailing_funding_month() -> None:
+    plan = plan_binance_vision_cache(
+        market="usds-m",
+        symbols=("BTCUSDT",),
+        intervals=("1h",),
+        start_time=_utc(2026, 1, 1),
+        end_time=_utc(2026, 2, 15),
+    )
+
+    funding_urls = tuple(url for url in plan.urls if "fundingRate" in url)
+    assert len(funding_urls) == 1
+    assert "2026-01.zip" in funding_urls[0]
+
+
+class _FakeTransport:
+    def __init__(self, cache_root: Path) -> None:
+        self.cache_root = cache_root
+        self.calls: list[str] = []
+
+    def _request_bytes(self, url: str) -> bytes:
+        self.calls.append(url)
+        payload = f"payload:{url}".encode()
+        path = vision_cache_path(self.cache_root, url)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(payload)
+        return payload
+
+
+def test_sync_downloads_only_missing_archives(tmp_path: Path) -> None:
+    plan = plan_binance_vision_cache(
+        market="spot",
+        symbols=("BTCUSDT",),
+        intervals=("1h",),
+        start_time=_utc(2026, 1, 1),
+        end_time=_utc(2026, 3, 1),
+    )
+    first_url, second_url = plan.urls
+    first_path = vision_cache_path(tmp_path, first_url)
+    first_path.parent.mkdir(parents=True)
+    first_path.write_bytes(b"already-cached")
+    transport = _FakeTransport(tmp_path)
+
+    report = sync_binance_vision_cache(plan, transport=transport)
+
+    assert transport.calls == [second_url]
+    assert report.planned_count == 2
+    assert report.cached_count == 1
+    assert report.downloaded_count == 1
+    assert report.missing_urls == ()
+    assert report.empty_urls == ()
+
+
+def test_complete_check_rejects_empty_cache_file(tmp_path: Path) -> None:
+    plan = plan_binance_vision_cache(
+        market="spot",
+        symbols=("BTCUSDT",),
+        intervals=("1h",),
+        start_time=_utc(2026, 1, 1),
+        end_time=_utc(2026, 2, 1),
+    )
+    cache_path = vision_cache_path(tmp_path, plan.urls[0])
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_bytes(b"")
+
+    with pytest.raises(FileNotFoundError, match="empty=1"):
+        require_complete_binance_vision_cache(plan, cache_root=tmp_path)
+
+
+def test_cache_path_is_stable_and_rejects_non_vision_url(tmp_path: Path) -> None:
+    url = (
+        "https://data.binance.vision/data/spot/monthly/klines/"
+        "BTCUSDT/1h/BTCUSDT-1h-2026-01.zip"
+    )
+
+    path = vision_cache_path(tmp_path, url)
+
+    digest = hashlib.sha256(url.encode("utf-8")).hexdigest()
+    assert path == tmp_path / digest[:2] / f"{digest}.bin"
+    with pytest.raises(ValueError, match="Binance Vision"):
+        vision_cache_path(tmp_path, "https://example.com/archive.zip")

--- a/tests/scripts/test_run_docker_training.py
+++ b/tests/scripts/test_run_docker_training.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_module():
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "examples"
+        / "binance-multitimeframe"
+        / "run_docker_training.py"
+    )
+    spec = importlib.util.spec_from_file_location("run_docker_training", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_launcher_runs_sync_before_trainer() -> None:
+    module = _load_module()
+    commands = module.build_commands(Path("compose.training.yaml"))
+
+    assert commands[0][-1] == "market-data-sync"
+    assert commands[1][-1] == "trainer"
+    assert "--no-deps" in commands[1]
+
+
+def test_launcher_stops_when_sync_fails() -> None:
+    module = _load_module()
+    calls: list[tuple[str, ...]] = []
+
+    def runner(command: tuple[str, ...]) -> int:
+        calls.append(command)
+        return 9
+
+    result = module.run_training(
+        compose_file=Path("compose.training.yaml"),
+        runner=runner,
+    )
+
+    assert result == 9
+    assert len(calls) == 1
+    assert calls[0][-1] == "market-data-sync"

--- a/tests/test_training_compose_contract.py
+++ b/tests/test_training_compose_contract.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_training_compose_separates_market_data_ownership() -> None:
+    compose = (Path(__file__).resolve().parents[1] / "compose.training.yaml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "market-data-sync:" in compose
+    assert "trade-rl-market-archives:/workspace/market-data/binance-vision" in compose
+    assert (
+        "trade-rl-market-archives:/workspace/market-data/binance-vision:ro" in compose
+    )
+    assert "trade-rl-training-data:/workspace/legacy-var:ro" in compose
+    assert "trade-rl-training-data:/workspace/var" in compose
+    assert "--legacy-cache-root" in compose
+    assert "trade-rl-training-runs:" not in compose
+    assert "trade-rl-teacher-cache:" not in compose

--- a/tests/test_training_workflow_market_sync.py
+++ b/tests/test_training_workflow_market_sync.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_gpu_control_syncs_market_data_before_supervised_start() -> None:
+    workflow = (
+        ROOT / ".github" / "workflows" / "launch-binance-frozen-226.yml"
+    ).read_text(encoding="utf-8")
+
+    sync = workflow.index(
+        "docker compose -f compose.training.yaml run --rm market-data-sync"
+    )
+    supervised = workflow.index("full_run_supervisor.py start")
+
+    assert sync < supervised

--- a/trade_rl/integrations/binance_cache.py
+++ b/trade_rl/integrations/binance_cache.py
@@ -1,0 +1,229 @@
+"""Deterministic planning and synchronization for shared Binance Vision archives."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Protocol
+
+from trade_rl.integrations.binance import (
+    BinanceMarket,
+    BinancePublicTransport,
+    plan_vision_kline_urls,
+    vision_funding_url,
+)
+
+_VISION_PREFIX = "https://data.binance.vision/data/"
+
+
+class _VisionArchiveTransport(Protocol):
+    cache_root: Path | None
+
+    def _request_bytes(self, url: str) -> bytes: ...
+
+
+@dataclass(frozen=True, slots=True)
+class BinanceVisionCachePlan:
+    market: BinanceMarket
+    symbols: tuple[str, ...]
+    intervals: tuple[str, ...]
+    start_time: datetime
+    end_time: datetime
+    urls: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "end_time": self.end_time.isoformat(),
+            "intervals": list(self.intervals),
+            "market": self.market.value,
+            "planned_count": len(self.urls),
+            "start_time": self.start_time.isoformat(),
+            "symbols": list(self.symbols),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BinanceVisionCacheReport:
+    cache_root: Path
+    planned_count: int
+    cached_count: int
+    downloaded_count: int
+    missing_urls: tuple[str, ...]
+    empty_urls: tuple[str, ...]
+
+    @property
+    def complete(self) -> bool:
+        return not self.missing_urls and not self.empty_urls
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "cache_root": str(self.cache_root),
+            "cached_count": self.cached_count,
+            "complete": self.complete,
+            "downloaded_count": self.downloaded_count,
+            "empty_count": len(self.empty_urls),
+            "missing_count": len(self.missing_urls),
+            "planned_count": self.planned_count,
+        }
+
+
+def _aware_utc(value: datetime, *, field: str) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field} must be timezone-aware")
+    return value.astimezone(UTC)
+
+
+def _ordered_nonempty(values: Sequence[str], *, field: str) -> tuple[str, ...]:
+    result = tuple(dict.fromkeys(str(value) for value in values))
+    if not result or any(not value for value in result):
+        raise ValueError(f"{field} must contain non-empty values")
+    return result
+
+
+def _next_month(value: datetime) -> datetime:
+    if value.month == 12:
+        return value.replace(year=value.year + 1, month=1, day=1)
+    return value.replace(month=value.month + 1, day=1)
+
+
+def plan_binance_vision_cache(
+    *,
+    market: BinanceMarket | str,
+    symbols: Sequence[str],
+    intervals: Sequence[str],
+    start_time: datetime,
+    end_time: datetime,
+) -> BinanceVisionCachePlan:
+    """Plan every immutable Vision archive required by one research range."""
+
+    resolved_market = BinanceMarket(market)
+    resolved_symbols = _ordered_nonempty(symbols, field="symbols")
+    resolved_intervals = _ordered_nonempty(intervals, field="intervals")
+    resolved_start = _aware_utc(start_time, field="start_time")
+    resolved_end = _aware_utc(end_time, field="end_time")
+    if resolved_end <= resolved_start:
+        raise ValueError("end_time must be later than start_time")
+
+    urls: list[str] = []
+    for symbol in resolved_symbols:
+        for interval in resolved_intervals:
+            urls.extend(
+                plan_vision_kline_urls(
+                    resolved_market,
+                    symbol,
+                    interval,
+                    resolved_start,
+                    resolved_end,
+                )
+            )
+
+    if resolved_market is not BinanceMarket.SPOT:
+        month = resolved_start.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        while _next_month(month) <= resolved_end:
+            for symbol in resolved_symbols:
+                urls.append(vision_funding_url(resolved_market, symbol, month))
+            month = _next_month(month)
+
+    return BinanceVisionCachePlan(
+        market=resolved_market,
+        symbols=resolved_symbols,
+        intervals=resolved_intervals,
+        start_time=resolved_start,
+        end_time=resolved_end,
+        urls=tuple(dict.fromkeys(urls)),
+    )
+
+
+def vision_cache_path(cache_root: str | Path, url: str) -> Path:
+    """Return the path used by ``BinancePublicTransport`` for one Vision URL."""
+
+    if not url.startswith(_VISION_PREFIX):
+        raise ValueError("cache URL must be an official Binance Vision URL")
+    digest = hashlib.sha256(url.encode("utf-8")).hexdigest()
+    return Path(cache_root) / digest[:2] / f"{digest}.bin"
+
+
+def inspect_binance_vision_cache(
+    plan: BinanceVisionCachePlan,
+    *,
+    cache_root: str | Path,
+) -> BinanceVisionCacheReport:
+    root = Path(cache_root)
+    cached: list[str] = []
+    missing: list[str] = []
+    empty: list[str] = []
+    for url in plan.urls:
+        path = vision_cache_path(root, url)
+        if not path.is_file():
+            missing.append(url)
+        elif path.stat().st_size <= 0:
+            empty.append(url)
+        else:
+            cached.append(url)
+    return BinanceVisionCacheReport(
+        cache_root=root,
+        planned_count=len(plan.urls),
+        cached_count=len(cached),
+        downloaded_count=0,
+        missing_urls=tuple(missing),
+        empty_urls=tuple(empty),
+    )
+
+
+def require_complete_binance_vision_cache(
+    plan: BinanceVisionCachePlan,
+    *,
+    cache_root: str | Path,
+) -> BinanceVisionCacheReport:
+    report = inspect_binance_vision_cache(plan, cache_root=cache_root)
+    if not report.complete:
+        raise FileNotFoundError(
+            "incomplete Binance Vision cache: "
+            f"missing={len(report.missing_urls)} empty={len(report.empty_urls)}"
+        )
+    return report
+
+
+def sync_binance_vision_cache(
+    plan: BinanceVisionCachePlan,
+    *,
+    transport: _VisionArchiveTransport | BinancePublicTransport,
+) -> BinanceVisionCacheReport:
+    """Download only absent or empty archives into the transport cache root."""
+
+    if transport.cache_root is None:
+        raise ValueError("transport cache_root is required for Vision synchronization")
+    root = Path(transport.cache_root)
+    before = inspect_binance_vision_cache(plan, cache_root=root)
+    required = set(before.missing_urls) | set(before.empty_urls)
+    targets = tuple(url for url in plan.urls if url in required)
+
+    for url in targets:
+        path = vision_cache_path(root, url)
+        if path.exists() and path.stat().st_size <= 0:
+            path.unlink()
+        payload = transport._request_bytes(url)
+        if not payload:
+            raise RuntimeError(f"downloaded empty Binance Vision archive: {url}")
+        if not path.is_file() or path.stat().st_size <= 0:
+            raise RuntimeError(
+                f"transport did not publish Binance Vision cache file: {path}"
+            )
+
+    after = inspect_binance_vision_cache(plan, cache_root=root)
+    if not after.complete:
+        raise FileNotFoundError(
+            "Binance Vision synchronization incomplete: "
+            f"missing={len(after.missing_urls)} empty={len(after.empty_urls)}"
+        )
+    return BinanceVisionCacheReport(
+        cache_root=root,
+        planned_count=after.planned_count,
+        cached_count=before.cached_count,
+        downloaded_count=len(targets),
+        missing_urls=after.missing_urls,
+        empty_urls=after.empty_urls,
+    )


### PR DESCRIPTION
Temporary history-normalization PR. PR #200 was squash-merged into `main`; this merges that new main parent into the existing H1 branch without changing H1 content, so PR #202 contains only its performance-evidence diff.