### PR TITLE
fix: separate dataset publication from catalog sync

### DIFF
--- a/docs/superpowers/plans/2026-07-27-dataset-catalog-reconciliation.md
+++ b/docs/superpowers/plans/2026-07-27-dataset-catalog-reconciliation.md
@@ -1,0 +1,73 @@
+# Dataset Catalog Reconciliation Implementation Plan
+
+> **For agentic workers:** Use superpowers:test-driven-development and verification-before-completion for every task.
+
+**Goal:** Decouple immutable dataset publication from optional PostgreSQL registration and provide a retryable reconciliation workflow and CLI.
+
+**Architecture:** Keep `trade_rl.data` filesystem-only. Reconstruct a validated `PublishedDatasetArtifact` from an existing artifact directory, compose registration at workflow level, and expose an explicit catalog reconciliation command.
+
+## Task 1: RED publication boundary contracts
+
+**Files:**
+- Create: `tests/data/test_dataset_catalog_boundary.py`
+- Modify later: `trade_rl/data/artifact.py`
+
+- [ ] Publish a canonical dataset while `TRADE_RL_DATABASE_URL` is set and patch catalog construction to fail if consulted.
+- [ ] Assert publication succeeds and the artifact loads correctly.
+- [ ] Add an architecture assertion that Python files under `trade_rl/data` contain no `trade_rl.catalog` imports.
+- [ ] Run the focused tests and confirm they fail because publication still invokes catalog registration.
+
+## Task 2: RED retryable reconciliation contracts
+
+**Files:**
+- Create: `tests/workflows/test_dataset_catalog_reconciliation.py`
+- Modify later: `trade_rl/data/artifact.py`
+- Create later: `trade_rl/workflows/dataset_catalog_reconciliation.py`
+
+- [ ] Publish one dataset artifact.
+- [ ] Use a fake catalog whose first `register()` call fails and second call succeeds.
+- [ ] Assert the artifact remains valid after failure and the second call uses the same immutable digest and location.
+- [ ] Assert reconstructed registration metadata and dataset identity are exact.
+- [ ] Run the focused tests and confirm failure because the reconciliation workflow does not exist.
+
+## Task 3: Implement filesystem-only publication and artifact inspection
+
+**Files:**
+- Modify: `trade_rl/data/artifact.py`
+- Modify: `trade_rl/data/__init__.py`
+
+- [ ] Remove catalog imports and implicit registration from `publish_market_dataset_artifact()`.
+- [ ] Add `inspect_published_market_dataset_artifact(root)` that validates the complete artifact, reads the canonical manifest digest, and returns `PublishedDatasetArtifact`.
+- [ ] Keep the directory contract exactly `manifest.json` and `arrays.npz`.
+- [ ] Run focused data tests.
+
+## Task 4: Implement reconciliation workflow
+
+**Files:**
+- Create: `trade_rl/workflows/dataset_catalog_reconciliation.py`
+- Test: `tests/workflows/test_dataset_catalog_reconciliation.py`
+
+- [ ] Implement `reconcile_market_dataset_catalog(artifact_root, catalog)`.
+- [ ] Load the dataset and typed published identity.
+- [ ] Build registration with `market_dataset_registration()`.
+- [ ] Call `catalog.register()` without migration or environment lookup.
+- [ ] Run focused workflow and catalog tests.
+
+## Task 5: Add CLI reconciliation command
+
+**Files:**
+- Modify: `trade_rl/cli/catalog.py`
+- Modify: `tests/cli/test_catalog_commands.py`
+
+- [ ] Add `catalog reconcile-market-dataset --artifact-root PATH`.
+- [ ] Resolve catalog using the existing explicit database URL contract.
+- [ ] Invoke the workflow and print the normal artifact record schema.
+- [ ] Add CLI tests for success and failure propagation.
+
+## Task 6: Exact-head verification
+
+- [ ] Run full pytest and coverage.
+- [ ] Run Ruff, format, Mypy, Import Linter, dead-code, critical coverage, CLI smoke, Windows, Ubuntu, training image, and PostgreSQL Catalog workflows.
+- [ ] Confirm final diff contains no temporary source-export or updater files.
+- [ ] Record RED and GREEN evidence in the PR.
+- [ ] Squash merge the exact verified head into main; production remains `NO-GO`.

--- a/docs/superpowers/specs/2026-07-27-dataset-catalog-reconciliation-design.md
+++ b/docs/superpowers/specs/2026-07-27-dataset-catalog-reconciliation-design.md
@@ -1,0 +1,79 @@
+# Dataset Publication and Catalog Reconciliation Design
+
+## Problem
+
+`publish_market_dataset_artifact()` currently performs two different operations behind one API:
+
+1. atomically publishes an immutable dataset directory to the filesystem;
+2. if `TRADE_RL_DATABASE_URL` is present, registers the published artifact in PostgreSQL.
+
+The filesystem rename completes before catalog registration. If PostgreSQL registration then fails, the caller receives an exception even though the immutable artifact already exists. Retrying the same publication fails with `FileExistsError`, so the apparent failure cannot be recovered by repeating the original operation.
+
+The data layer also imports the catalog service directly, coupling canonical artifact persistence to optional infrastructure and ambient environment.
+
+## Decision
+
+Make filesystem publication and catalog synchronization separate, explicit operations.
+
+`publish_market_dataset_artifact()` will only validate, stage, atomically rename, and return `PublishedDatasetArtifact`. It will never inspect `TRADE_RL_DATABASE_URL` or contact PostgreSQL.
+
+Add a workflow-level reconciliation operation:
+
+```python
+reconcile_market_dataset_catalog(
+    artifact_root: Path,
+    catalog: ArtifactCatalog,
+) -> ArtifactRecord
+```
+
+The workflow will:
+
+1. load and fully validate the existing immutable dataset artifact;
+2. reconstruct its typed `PublishedDatasetArtifact` identity from the canonical manifest;
+3. build the existing `ArtifactRegistration`;
+4. call the catalog's idempotent `register()` method.
+
+A failed catalog attempt leaves the filesystem artifact unchanged and can be retried with the same artifact path. No republishing is required.
+
+## CLI
+
+Add:
+
+```text
+trade-rl catalog reconcile-market-dataset --artifact-root PATH
+```
+
+The command resolves PostgreSQL through the existing `--database-url` / `TRADE_RL_DATABASE_URL` mechanism and runs the reconciliation workflow. Catalog migration remains a separate explicit command.
+
+## Dependency Direction
+
+- `trade_rl.data` owns filesystem publication, loading, and artifact inspection only.
+- `trade_rl.catalog` owns catalog contracts and adapters.
+- `trade_rl.workflows.dataset_catalog_reconciliation` composes data and catalog.
+- `trade_rl.cli.catalog` exposes the explicit operational command.
+
+The data package must not import `trade_rl.catalog`.
+
+## Compatibility
+
+`publish_market_dataset_artifact()` keeps its signature and return type. Existing callers that only need the artifact continue to work, but no longer receive an exception from optional catalog infrastructure.
+
+`register_artifact_if_configured()` remains available for unrelated legacy callers during this PR; the dataset publication path stops using it.
+
+## Evidence and Error Handling
+
+- Filesystem publication errors remain exceptions and leave no final destination.
+- Catalog reconciliation errors remain exceptions, but the exception occurs in a clearly named catalog operation after publication has already been acknowledged.
+- Reconciliation is safely repeatable because PostgreSQL registration is keyed by immutable artifact identity.
+- The artifact directory remains exactly `manifest.json` and `arrays.npz`; no mutable sidecar is added.
+
+## Testing
+
+Tests must prove:
+
+1. publication never constructs a catalog even when the database environment is set;
+2. catalog failure does not change or remove the published artifact;
+3. the same artifact can be reconciled successfully after an earlier failed attempt;
+4. reconciliation reconstructs the exact artifact digest, dataset ID, location, and metadata;
+5. the CLI invokes reconciliation with the explicitly resolved catalog;
+6. an architecture test prevents `trade_rl.data` from importing `trade_rl.catalog`.

--- a/tests/cli/test_catalog_commands.py
+++ b/tests/cli/test_catalog_commands.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import io
 import json
 from datetime import UTC, datetime
+from pathlib import Path
 
+import numpy as np
 import pytest
 
 from trade_rl.catalog import (
@@ -13,6 +15,7 @@ from trade_rl.catalog import (
     ArtifactRegistration,
 )
 from trade_rl.cli import app
+from trade_rl.data import MarketDataset, publish_market_dataset_artifact
 
 
 class FakeCatalog:
@@ -45,6 +48,35 @@ class FakeCatalog:
 
     def add_dependency(self, parent_digest: str, child_digest: str, role: str) -> None:
         raise AssertionError("not used")
+
+
+def _dataset() -> MarketDataset:
+    n_bars = 8
+    timestamps = np.datetime64("2026-01-01T00:00:00", "ns") + np.arange(
+        n_bars
+    ) * np.timedelta64(1, "h")
+    close = (100.0 + np.arange(n_bars, dtype=np.float64))[:, None]
+    return MarketDataset(
+        dataset_id="0" * 64,
+        symbols=("BTCUSDT",),
+        timestamps=timestamps,
+        features=np.arange(n_bars, dtype=np.float32)[:, None, None],
+        global_features=np.ones((n_bars, 1), dtype=np.float32),
+        open=close,
+        high=close + 1.0,
+        low=close - 1.0,
+        close=close,
+        volume=np.full((n_bars, 1), 1_000_000.0),
+        funding_rate=np.zeros((n_bars, 1)),
+        tradable=np.ones((n_bars, 1), dtype=np.bool_),
+        feature_available=np.ones((n_bars, 1, 1), dtype=np.bool_),
+        feature_names=("feature",),
+        global_feature_names=("regime",),
+        periods_per_year=8_760,
+        tick_size=np.full((n_bars, 1), 0.1),
+        lot_size=np.full((n_bars, 1), 0.001),
+        minimum_notional=np.full((n_bars, 1), 5.0),
+    ).with_content_identity()
 
 
 def test_catalog_migrate_uses_environment_without_printing_password(
@@ -114,6 +146,36 @@ def test_catalog_register_parses_json_payloads(monkeypatch: pytest.MonkeyPatch) 
     assert registration.artifact_kind is ArtifactKind.MARKET_DATASET
     assert registration.cache_key == {"dataset_id": "b"}
     assert json.loads(stdout.getvalue())["artifact_digest"] == "a" * 64
+
+
+def test_catalog_reconciles_existing_market_dataset(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    published = publish_market_dataset_artifact(tmp_path / "dataset", _dataset())
+    catalog = FakeCatalog("postgresql://catalog")
+    from trade_rl.cli import catalog as catalog_cli
+
+    monkeypatch.setattr(catalog_cli, "catalog_factory", lambda _: catalog)
+    stdout = io.StringIO()
+
+    exit_code = app.main(
+        [
+            "catalog",
+            "reconcile-market-dataset",
+            "--database-url",
+            "postgresql://catalog",
+            "--artifact-root",
+            str(published.root),
+        ],
+        stdout=stdout,
+    )
+
+    assert exit_code == 0
+    payload = json.loads(stdout.getvalue())
+    assert payload["artifact_digest"] == published.artifact_digest
+    assert payload["dataset_id"] == _dataset().dataset_id
+    assert catalog.registrations[0].location == str(published.root.resolve())
 
 
 def test_catalog_requires_database_url(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/data/test_dataset_catalog_boundary.py
+++ b/tests/data/test_dataset_catalog_boundary.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from trade_rl.data import (
+    MarketDataset,
+    load_market_dataset_artifact,
+    publish_market_dataset_artifact,
+)
+
+
+def _dataset() -> MarketDataset:
+    n_bars = 8
+    timestamps = np.datetime64("2026-01-01T00:00:00", "ns") + np.arange(
+        n_bars
+    ) * np.timedelta64(1, "h")
+    close = (100.0 + np.arange(n_bars, dtype=np.float64))[:, None]
+    return MarketDataset(
+        dataset_id="0" * 64,
+        symbols=("BTCUSDT",),
+        timestamps=timestamps,
+        features=np.arange(n_bars, dtype=np.float32)[:, None, None],
+        global_features=np.ones((n_bars, 1), dtype=np.float32),
+        open=close,
+        high=close + 1.0,
+        low=close - 1.0,
+        close=close,
+        volume=np.full((n_bars, 1), 1_000_000.0),
+        funding_rate=np.zeros((n_bars, 1)),
+        tradable=np.ones((n_bars, 1), dtype=np.bool_),
+        feature_available=np.ones((n_bars, 1, 1), dtype=np.bool_),
+        feature_names=("feature",),
+        global_feature_names=("regime",),
+        periods_per_year=8_760,
+        tick_size=np.full((n_bars, 1), 0.1),
+        lot_size=np.full((n_bars, 1), 0.001),
+        minimum_notional=np.full((n_bars, 1), 5.0),
+    ).with_content_identity()
+
+
+def test_dataset_publication_never_consults_catalog(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TRADE_RL_DATABASE_URL", "postgresql://must-not-be-used")
+    monkeypatch.setattr(
+        "trade_rl.catalog.service.catalog_factory",
+        lambda _: pytest.fail("dataset publication consulted the artifact catalog"),
+    )
+
+    published = publish_market_dataset_artifact(tmp_path / "dataset", _dataset())
+
+    loaded = load_market_dataset_artifact(published.root)
+    assert loaded.dataset_id == _dataset().dataset_id
+    assert published.root.is_dir()
+
+
+def test_data_package_does_not_import_catalog() -> None:
+    violations: list[str] = []
+    for path in sorted(Path("trade_rl/data").rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        if "trade_rl.catalog" in source:
+            violations.append(path.as_posix())
+    assert violations == []

--- a/tests/data/test_market_artifact_catalog.py
+++ b/tests/data/test_market_artifact_catalog.py
@@ -16,6 +16,9 @@ from trade_rl.data.contracts import (
     MarketBuildConfig,
 )
 from trade_rl.data.source import InMemoryMarketDataSource, RawMarketSeries
+from trade_rl.workflows.dataset_catalog_reconciliation import (
+    reconcile_market_dataset_catalog,
+)
 
 
 def _dataset():
@@ -48,21 +51,21 @@ def _dataset():
     )
 
 
-def test_publish_registers_after_atomic_filesystem_publication(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+def test_explicit_reconciliation_registers_after_atomic_publication(
+    tmp_path: Path,
 ) -> None:
     observed: dict[str, object] = {}
 
-    def capture(registration):
-        observed["registration"] = registration
-        observed["root_exists"] = (tmp_path / "artifact").is_dir()
-        return None
-
-    monkeypatch.setattr(artifact_module, "register_artifact_if_configured", capture)
+    class Catalog:
+        def register(self, registration):
+            observed["registration"] = registration
+            observed["root_exists"] = (tmp_path / "artifact").is_dir()
+            return None
 
     published = artifact_module.publish_market_dataset_artifact(
         tmp_path / "artifact", _dataset()
     )
+    reconcile_market_dataset_catalog(published.root, Catalog())
 
     registration = observed["registration"]
     assert observed["root_exists"] is True
@@ -72,16 +75,17 @@ def test_publish_registers_after_atomic_filesystem_publication(
 
 
 def test_catalog_failure_does_not_remove_valid_published_artifact(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
 ) -> None:
-    def fail(_):
-        raise RuntimeError("catalog unavailable")
+    class Catalog:
+        def register(self, _):
+            raise RuntimeError("catalog unavailable")
 
-    monkeypatch.setattr(artifact_module, "register_artifact_if_configured", fail)
     root = tmp_path / "artifact"
+    artifact_module.publish_market_dataset_artifact(root, _dataset())
 
     with pytest.raises(RuntimeError, match="catalog unavailable"):
-        artifact_module.publish_market_dataset_artifact(root, _dataset())
+        reconcile_market_dataset_catalog(root, Catalog())
 
     assert (root / "manifest.json").is_file()
     assert (root / "arrays.npz").is_file()

--- a/tests/workflows/test_dataset_catalog_reconciliation.py
+++ b/tests/workflows/test_dataset_catalog_reconciliation.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from trade_rl.catalog.contracts import ArtifactRecord, ArtifactRegistration
+from trade_rl.data import MarketDataset, load_market_dataset_artifact, publish_market_dataset_artifact
+from trade_rl.workflows.dataset_catalog_reconciliation import (
+    reconcile_market_dataset_catalog,
+)
+
+
+def _dataset() -> MarketDataset:
+    n_bars = 8
+    timestamps = np.datetime64("2026-01-01T00:00:00", "ns") + np.arange(
+        n_bars
+    ) * np.timedelta64(1, "h")
+    close = (100.0 + np.arange(n_bars, dtype=np.float64))[:, None]
+    return MarketDataset(
+        dataset_id="0" * 64,
+        symbols=("BTCUSDT",),
+        timestamps=timestamps,
+        features=np.arange(n_bars, dtype=np.float32)[:, None, None],
+        global_features=np.ones((n_bars, 1), dtype=np.float32),
+        open=close,
+        high=close + 1.0,
+        low=close - 1.0,
+        close=close,
+        volume=np.full((n_bars, 1), 1_000_000.0),
+        funding_rate=np.zeros((n_bars, 1)),
+        tradable=np.ones((n_bars, 1), dtype=np.bool_),
+        feature_available=np.ones((n_bars, 1, 1), dtype=np.bool_),
+        feature_names=("feature",),
+        global_feature_names=("regime",),
+        periods_per_year=8_760,
+        tick_size=np.full((n_bars, 1), 0.1),
+        lot_size=np.full((n_bars, 1), 0.001),
+        minimum_notional=np.full((n_bars, 1), 5.0),
+    ).with_content_identity()
+
+
+class _RetryCatalog:
+    def __init__(self) -> None:
+        self.attempts: list[ArtifactRegistration] = []
+
+    def register(self, registration: ArtifactRegistration) -> ArtifactRecord:
+        self.attempts.append(registration)
+        if len(self.attempts) == 1:
+            raise ConnectionError("catalog unavailable")
+        now = datetime(2026, 1, 2, tzinfo=UTC)
+        return ArtifactRecord(registration=registration, created_at=now, last_seen_at=now)
+
+
+def test_reconciliation_retries_without_republishing_dataset(tmp_path: Path) -> None:
+    published = publish_market_dataset_artifact(tmp_path / "dataset", _dataset())
+    catalog = _RetryCatalog()
+
+    with pytest.raises(ConnectionError, match="catalog unavailable"):
+        reconcile_market_dataset_catalog(published.root, catalog)
+
+    loaded_after_failure = load_market_dataset_artifact(published.root)
+    assert loaded_after_failure.dataset_id == _dataset().dataset_id
+
+    record = reconcile_market_dataset_catalog(published.root, catalog)
+
+    assert len(catalog.attempts) == 2
+    first, second = catalog.attempts
+    assert first == second
+    assert record.registration.artifact_digest == published.artifact_digest
+    assert record.registration.dataset_id == _dataset().dataset_id
+    assert record.registration.location == str(published.root.resolve())
+    assert record.registration.metadata["n_bars"] == 8
+    assert record.registration.metadata["symbols"] == ("BTCUSDT",)

--- a/tests/workflows/test_dataset_catalog_reconciliation.py
+++ b/tests/workflows/test_dataset_catalog_reconciliation.py
@@ -12,9 +12,6 @@ from trade_rl.data import (
     load_market_dataset_artifact,
     publish_market_dataset_artifact,
 )
-from trade_rl.workflows.dataset_catalog_reconciliation import (
-    reconcile_market_dataset_catalog,
-)
 
 
 def _dataset() -> MarketDataset:
@@ -61,6 +58,10 @@ class _RetryCatalog:
 
 
 def test_reconciliation_retries_without_republishing_dataset(tmp_path: Path) -> None:
+    from trade_rl.workflows.dataset_catalog_reconciliation import (
+        reconcile_market_dataset_catalog,
+    )
+
     published = publish_market_dataset_artifact(tmp_path / "dataset", _dataset())
     catalog = _RetryCatalog()
 

--- a/tests/workflows/test_dataset_catalog_reconciliation.py
+++ b/tests/workflows/test_dataset_catalog_reconciliation.py
@@ -55,7 +55,9 @@ class _RetryCatalog:
         if len(self.attempts) == 1:
             raise ConnectionError("catalog unavailable")
         now = datetime(2026, 1, 2, tzinfo=UTC)
-        return ArtifactRecord(registration=registration, created_at=now, last_seen_at=now)
+        return ArtifactRecord(
+            registration=registration, created_at=now, last_seen_at=now
+        )
 
 
 def test_reconciliation_retries_without_republishing_dataset(tmp_path: Path) -> None:

--- a/tests/workflows/test_dataset_catalog_reconciliation.py
+++ b/tests/workflows/test_dataset_catalog_reconciliation.py
@@ -7,7 +7,11 @@ import numpy as np
 import pytest
 
 from trade_rl.catalog.contracts import ArtifactRecord, ArtifactRegistration
-from trade_rl.data import MarketDataset, load_market_dataset_artifact, publish_market_dataset_artifact
+from trade_rl.data import (
+    MarketDataset,
+    load_market_dataset_artifact,
+    publish_market_dataset_artifact,
+)
 from trade_rl.workflows.dataset_catalog_reconciliation import (
     reconcile_market_dataset_catalog,
 )

--- a/trade_rl/cli/catalog.py
+++ b/trade_rl/cli/catalog.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 from collections.abc import Mapping
+from pathlib import Path
 from typing import TextIO
 
 from trade_rl.catalog import (
@@ -17,6 +18,9 @@ from trade_rl.catalog import (
 )
 from trade_rl.catalog.contracts import thaw_json
 from trade_rl.catalog.postgres import PostgresArtifactCatalog
+from trade_rl.workflows.dataset_catalog_reconciliation import (
+    reconcile_market_dataset_catalog,
+)
 
 catalog_factory = PostgresArtifactCatalog
 
@@ -104,6 +108,16 @@ def _register(args: argparse.Namespace, stdout: TextIO) -> int:
     return 0
 
 
+def _reconcile_market_dataset(args: argparse.Namespace, stdout: TextIO) -> int:
+    catalog = catalog_factory(_database_url(args))
+    record = reconcile_market_dataset_catalog(Path(args.artifact_root), catalog)
+    _write_json(
+        stdout,
+        {**_record_payload(record), "schema": "artifact_catalog_record_v1"},
+    )
+    return 0
+
+
 def _find(args: argparse.Namespace, stdout: TextIO) -> int:
     record = catalog_factory(_database_url(args)).find(
         ArtifactKind(args.kind),
@@ -176,6 +190,14 @@ def add_catalog_parser(subparsers: argparse._SubParsersAction) -> None:
         default=ArtifactStatus.READY.value,
     )
     register.set_defaults(handler=_register)
+
+    reconcile_dataset = commands.add_parser(
+        "reconcile-market-dataset",
+        help="register an existing immutable market dataset artifact",
+    )
+    _add_database_url(reconcile_dataset)
+    reconcile_dataset.add_argument("--artifact-root", required=True)
+    reconcile_dataset.set_defaults(handler=_reconcile_market_dataset)
 
     find = commands.add_parser("find", help="find an exact reusable artifact")
     _add_database_url(find)

--- a/trade_rl/data/__init__.py
+++ b/trade_rl/data/__init__.py
@@ -2,6 +2,7 @@
 
 from trade_rl.data.artifact import (
     PublishedDatasetArtifact,
+    inspect_published_market_dataset_artifact,
     load_market_dataset_artifact,
     publish_market_dataset_artifact,
 )
@@ -18,6 +19,7 @@ __all__ = [
     "MarketCalendarKind",
     "MarketDataset",
     "PublishedDatasetArtifact",
+    "inspect_published_market_dataset_artifact",
     "load_market_dataset_artifact",
     "publish_market_dataset_artifact",
     "write_market_dataset_files",

--- a/trade_rl/data/artifact.py
+++ b/trade_rl/data/artifact.py
@@ -2,16 +2,13 @@
 
 from __future__ import annotations
 
+import json
 import shutil
 import tempfile
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
 
-from trade_rl.catalog.service import (
-    market_dataset_registration,
-    register_artifact_if_configured,
-)
 from trade_rl.data.artifact_codec import (
     DATASET_ARRAYS_NAME as MARKET_ARTIFACT_ARRAYS,
 )
@@ -46,10 +43,30 @@ class PublishedDatasetArtifact:
     schema_version: str = MARKET_ARTIFACT_SCHEMA
 
 
+def inspect_published_market_dataset_artifact(
+    root: str | Path,
+) -> PublishedDatasetArtifact:
+    """Validate and reconstruct the typed identity of an existing artifact."""
+
+    artifact_root = Path(root)
+    load_dataset_files(artifact_root)
+    manifest_path = artifact_root / MARKET_ARTIFACT_MANIFEST
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    artifact_digest = manifest.get("artifact_digest")
+    if not isinstance(artifact_digest, str):
+        raise ValueError("dataset artifact manifest is missing artifact_digest")
+    return PublishedDatasetArtifact(
+        root=artifact_root,
+        manifest_path=manifest_path,
+        arrays_path=artifact_root / MARKET_ARTIFACT_ARRAYS,
+        artifact_digest=artifact_digest,
+    )
+
+
 def publish_market_dataset_artifact(
     root: str | Path, dataset: MarketDataset
 ) -> PublishedDatasetArtifact:
-    """Atomically publish one immutable artifact into a new destination."""
+    """Atomically publish one immutable filesystem artifact."""
 
     if not dataset.identity_verified:
         raise ValueError("market dataset publication requires a canonical identity")
@@ -69,14 +86,12 @@ def publish_market_dataset_artifact(
     except BaseException:
         shutil.rmtree(staging, ignore_errors=True)
         raise
-    published = PublishedDatasetArtifact(
+    return PublishedDatasetArtifact(
         root=output,
         manifest_path=output / MARKET_ARTIFACT_MANIFEST,
         arrays_path=output / MARKET_ARTIFACT_ARRAYS,
         artifact_digest=files.artifact_digest,
     )
-    register_artifact_if_configured(market_dataset_registration(published, dataset))
-    return published
 
 
 def write_market_dataset_artifact(root: str | Path, dataset: MarketDataset) -> str:
@@ -100,6 +115,7 @@ __all__ = [
     "MARKET_ARTIFACT_MANIFEST",
     "MARKET_ARTIFACT_SCHEMA",
     "PublishedDatasetArtifact",
+    "inspect_published_market_dataset_artifact",
     "load_market_dataset_artifact",
     "publish_market_dataset_artifact",
     "write_market_dataset_artifact",

--- a/trade_rl/workflows/dataset_catalog_reconciliation.py
+++ b/trade_rl/workflows/dataset_catalog_reconciliation.py
@@ -1,0 +1,27 @@
+"""Explicit retryable catalog synchronization for published market datasets."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from trade_rl.catalog.contracts import ArtifactCatalog, ArtifactRecord
+from trade_rl.catalog.service import market_dataset_registration
+from trade_rl.data import (
+    inspect_published_market_dataset_artifact,
+    load_market_dataset_artifact,
+)
+
+
+def reconcile_market_dataset_catalog(
+    artifact_root: str | Path,
+    catalog: ArtifactCatalog,
+) -> ArtifactRecord:
+    """Validate an existing dataset artifact and register its immutable identity."""
+
+    published = inspect_published_market_dataset_artifact(artifact_root)
+    dataset = load_market_dataset_artifact(published.root)
+    registration = market_dataset_registration(published, dataset)
+    return catalog.register(registration)
+
+
+__all__ = ["reconcile_market_dataset_catalog"]


### PR DESCRIPTION
## Summary

- make `publish_market_dataset_artifact()` a filesystem-only atomic publication operation;
- remove the `trade_rl.data → trade_rl.catalog` dependency and ambient PostgreSQL side effect;
- add validated reconstruction of `PublishedDatasetArtifact` from an existing immutable directory;
- add retryable `reconcile_market_dataset_catalog()` without migration or republishing;
- add `catalog reconcile-market-dataset --artifact-root PATH` using the existing explicit database URL contract;
- update former implicit-registration tests to the explicit reconciliation boundary.

## TDD evidence

RED contracts demonstrated that:

- publication still consulted optional catalog infrastructure;
- the reconciliation workflow and CLI did not exist;
- legacy tests encoded the old implicit-registration behavior.

GREEN implementation separates publication from catalog synchronization and keeps the artifact valid across failed registration attempts.

## Verification

Exact verified head: `aeb6ce90616cf2cedbc83907c2f513b3df210be4`

- Pytest: 1,913 passed, 2 skipped
- Total coverage: 85.83%
- Branch coverage: 74.28%
- Ruff: PASS
- Ruff format: PASS
- Mypy: PASS
- Import architecture: PASS
- Dead-code report: PASS
- Recovery and structured Serving smoke: PASS
- Critical branch coverage: PASS
- CLI smoke: PASS
- PostgreSQL Catalog workflow: PASS
- Ubuntu compatibility: PASS
- Windows compatibility: PASS
- Training image and non-root runtime probe: PASS

Final diff contains only the approved design/plan, production implementation, and regression tests. No temporary updater, source-export, or trigger files remain.

Production remains `NO-GO`.