### PR TITLE
ci: trigger H2 shared feature cache implementation

### DIFF
--- a/.github/h2-cost-feature-cache-trigger
+++ b/.github/h2-cost-feature-cache-trigger
@@ -1,1 +1,1 @@
-trigger H2 shared feature cache implementation v2
+trigger H2 shared feature cache implementation v3

--- a/.github/h2-cost-feature-cache-trigger
+++ b/.github/h2-cost-feature-cache-trigger
@@ -1,1 +1,1 @@
-trigger H2 shared feature cache implementation v3
+trigger H2 shared feature cache implementation v4

--- a/.github/h2-cost-feature-cache-trigger
+++ b/.github/h2-cost-feature-cache-trigger
@@ -1,1 +1,1 @@
-trigger H2 shared feature cache implementation v5
+trigger H2 shared feature cache implementation v6

--- a/.github/h2-cost-feature-cache-trigger
+++ b/.github/h2-cost-feature-cache-trigger
@@ -1,1 +1,1 @@
-trigger H2 shared feature cache implementation v4
+trigger H2 shared feature cache implementation v5

--- a/.github/h2-cost-feature-cache-trigger
+++ b/.github/h2-cost-feature-cache-trigger
@@ -1,0 +1,1 @@
+trigger H2 shared feature cache implementation

--- a/.github/h2-cost-feature-cache-trigger
+++ b/.github/h2-cost-feature-cache-trigger
@@ -1,1 +1,1 @@
-trigger H2 shared feature cache implementation
+trigger H2 shared feature cache implementation v2

--- a/.github/h2-cost-feature-cache-trigger
+++ b/.github/h2-cost-feature-cache-trigger
@@ -1,1 +1,1 @@
-trigger H2 shared feature cache implementation v6
+trigger H2 shared feature cache implementation v7


### PR DESCRIPTION
Temporary child PR that triggers the reviewed H2 updater on the feature branch. It must remain unmerged and will be closed after the verified implementation is pushed to `agent/cost-critic-shared-feature-cache`.