### PR TITLE
ci: trigger H5 GPU comparison implementation

### DIFF
--- a/.github/h5-trigger.txt
+++ b/.github/h5-trigger.txt
@@ -1,1 +1,1 @@
-trigger verified H5 GPU comparison implementation v4
+trigger verified H5 GPU comparison implementation v5

--- a/.github/h5-trigger.txt
+++ b/.github/h5-trigger.txt
@@ -1,1 +1,1 @@
-trigger verified H5 GPU comparison implementation v2
+trigger verified H5 GPU comparison implementation v3

--- a/.github/h5-trigger.txt
+++ b/.github/h5-trigger.txt
@@ -1,0 +1,1 @@
+trigger verified H5 GPU comparison implementation

--- a/.github/h5-trigger.txt
+++ b/.github/h5-trigger.txt
@@ -1,1 +1,1 @@
-trigger verified H5 GPU comparison implementation v6
+trigger verified H5 GPU comparison implementation v7

--- a/.github/h5-trigger.txt
+++ b/.github/h5-trigger.txt
@@ -1,1 +1,1 @@
-trigger verified H5 GPU comparison implementation
+trigger verified H5 GPU comparison implementation v2

--- a/.github/h5-trigger.txt
+++ b/.github/h5-trigger.txt
@@ -1,1 +1,1 @@
-trigger verified H5 GPU comparison implementation v5
+trigger verified H5 GPU comparison implementation v6

--- a/.github/h5-trigger.txt
+++ b/.github/h5-trigger.txt
@@ -1,1 +1,1 @@
-trigger verified H5 GPU comparison implementation v3
+trigger verified H5 GPU comparison implementation v4


### PR DESCRIPTION
Temporary child PR used only to run the reviewed H5 updater against `agent/gpu-performance-comparison`. It must remain unmerged and will be closed after the verified implementation is pushed to the parent branch.