### PR TITLE
fix: preserve Live Training diagnostics workspace

### DIFF
--- a/studio/package.json
+++ b/studio/package.json
@@ -24,6 +24,7 @@
     "@types/node": "24.0.15",
     "@types/react": "19.1.9",
     "@types/react-dom": "19.1.7",
+    "@vitejs/plugin-react": "6.0.3",
     "jsdom": "26.1.0",
     "typescript": "7.0.2",
     "vite": "8.1.5",

--- a/studio/package.json
+++ b/studio/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview --host 127.0.0.1",
     "test": "vitest",
     "typecheck": "tsc -b --pretty false",
-    "check:layout": "node scripts/check-no-page-scroll.mjs"
+    "check:layout": "node scripts/check-no-page-scroll.mjs && node scripts/check-live-training-layout.mjs"
   },
   "dependencies": {
     "lucide-react": "1.25.0",
@@ -24,7 +24,6 @@
     "@types/node": "24.0.15",
     "@types/react": "19.1.9",
     "@types/react-dom": "19.1.7",
-    "@vitejs/plugin-react": "6.0.3",
     "jsdom": "26.1.0",
     "typescript": "7.0.2",
     "vite": "8.1.5",

--- a/studio/scripts/check-live-training-layout.mjs
+++ b/studio/scripts/check-live-training-layout.mjs
@@ -1,0 +1,103 @@
+import { chromium } from '@playwright/test'
+import { statSync } from 'node:fs'
+import { mkdir, readFile, readdir } from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+
+const studioRoot = path.resolve(new URL('..', import.meta.url).pathname)
+const assetsDir = path.join(studioRoot, 'dist', 'assets')
+const assets = await readdir(assetsDir)
+const cssFile = assets.find((name) => name.endsWith('.css'))
+const jsFile = assets.find((name) => name.endsWith('.js'))
+if (!cssFile || !jsFile) throw new Error('Build assets are missing; run npm run build first')
+
+const [css, rawJs] = await Promise.all([
+  readFile(path.join(assetsDir, cssFile), 'utf8'),
+  readFile(path.join(assetsDir, jsFile), 'utf8'),
+])
+const js = rawJs.replaceAll('</script>', '<\\/script>')
+const html = `<!doctype html><html lang="ja"><head><base href="http://127.0.0.1:4173/"><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><style>${css}</style></head><body><div id="root"></div><script type="module">${js}</script></body></html>`
+
+const browserCandidates = [
+  process.env.CHROMIUM_PATH,
+  '/usr/bin/chromium',
+  '/usr/bin/chromium-browser',
+  '/usr/bin/google-chrome',
+  '/usr/bin/google-chrome-stable',
+].filter(Boolean)
+const executablePath = browserCandidates.find((candidate) => {
+  try {
+    return statSync(candidate).isFile()
+  } catch {
+    return false
+  }
+})
+if (!executablePath) {
+  throw new Error(`Chromium executable was not found. Checked: ${browserCandidates.join(', ')}`)
+}
+
+const outputDir = process.env.STUDIO_QA_OUTPUT_DIR ?? '/mnt/data'
+await mkdir(outputDir, { recursive: true })
+const browser = await chromium.launch({ headless: true, executablePath, args: ['--no-sandbox'] })
+
+try {
+  const page = await browser.newPage({ viewport: { width: 1440, height: 900 } })
+  await page.route('**/api/studio/**', async (route) => {
+    const url = new URL(route.request().url())
+    let payload = null
+    if (url.pathname.endsWith('/overview')) {
+      payload = {
+        system: { gpuName: 'QA GPU', cudaReady: false, pythonVersion: '3.12', metrics: [] },
+        latestDataset: null,
+        activeJobs: [],
+        runs: [],
+        alerts: [{ level: 'info', message: 'QA fixture', age: 'now' }],
+        equity: [],
+        stability: [],
+        assessment: { status: 'NO-GO', reasons: ['QA fixture'] },
+      }
+    } else if (url.pathname.endsWith('/jobs')) {
+      payload = { items: [], total: 0 }
+    }
+    if (payload === null) return route.abort()
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(payload) })
+  })
+
+  await page.setContent(html, { waitUntil: 'networkidle' })
+  await page.getByText('最新の実験結果サマリー').waitFor()
+  await page.getByRole('button', { name: 'Live Training' }).click()
+  await page.getByRole('heading', { name: 'Live Training' }).waitFor()
+  await page.getByRole('button', { name: '学習診断' }).click()
+  await page.getByText('Runを選択してください。').waitFor()
+
+  const geometry = await page.evaluate(() => {
+    const selector = document.querySelector('.live-view-selector')
+    const diagnostics = document.querySelector('.training-diagnostics')
+    if (!(selector instanceof HTMLElement) || !(diagnostics instanceof HTMLElement)) {
+      throw new Error('Live Training diagnostics layout nodes are missing')
+    }
+    const selectorBox = selector.getBoundingClientRect()
+    const diagnosticsBox = diagnostics.getBoundingClientRect()
+    return {
+      viewportHeight: window.innerHeight,
+      selectorHeight: selectorBox.height,
+      diagnosticsHeight: diagnosticsBox.height,
+      diagnosticsBottom: diagnosticsBox.bottom,
+    }
+  })
+
+  if (geometry.selectorHeight > 80) {
+    throw new Error(`Live Training view selector consumed the workspace: ${JSON.stringify(geometry)}`)
+  }
+  if (geometry.diagnosticsHeight < 300) {
+    throw new Error(`Live Training diagnostics was compressed below the usable workspace: ${JSON.stringify(geometry)}`)
+  }
+  if (geometry.diagnosticsBottom > geometry.viewportHeight + 1) {
+    throw new Error(`Live Training diagnostics overflowed the viewport: ${JSON.stringify(geometry)}`)
+  }
+
+  await page.screenshot({ path: path.join(outputDir, 'trade-rl-studio-live-training-diagnostics.png'), fullPage: false })
+  await page.close()
+} finally {
+  await browser.close()
+}

--- a/studio/scripts/check-live-training-layout.mjs
+++ b/studio/scripts/check-live-training-layout.mjs
@@ -15,7 +15,7 @@ const [css, rawJs] = await Promise.all([
   readFile(path.join(assetsDir, cssFile), 'utf8'),
   readFile(path.join(assetsDir, jsFile), 'utf8'),
 ])
-const js = rawJs.replaceAll('</script>', '<\\/script>')
+const js = rawJs.replaceAll('</script>', '<\/script>')
 const html = `<!doctype html><html lang="ja"><head><base href="http://127.0.0.1:4173/"><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><style>${css}</style></head><body><div id="root"></div><script type="module">${js}</script></body></html>`
 
 const browserCandidates = [
@@ -36,7 +36,9 @@ if (!executablePath) {
   throw new Error(`Chromium executable was not found. Checked: ${browserCandidates.join(', ')}`)
 }
 
-const outputDir = process.env.STUDIO_QA_OUTPUT_DIR ?? '/mnt/data'
+const outputDir = process.env.STUDIO_QA_OUTPUT_DIR
+  ? path.resolve(studioRoot, '..', process.env.STUDIO_QA_OUTPUT_DIR)
+  : '/mnt/data'
 await mkdir(outputDir, { recursive: true })
 const browser = await chromium.launch({ headless: true, executablePath, args: ['--no-sandbox'] })
 

--- a/studio/src/liveTraining.css
+++ b/studio/src/liveTraining.css
@@ -14,7 +14,7 @@
   min-height: 0;
   padding: 14px 16px 12px;
   display: grid;
-  grid-template-rows: auto minmax(300px, 1fr) 132px 164px;
+  grid-template-rows: auto auto minmax(0, 1fr);
   gap: 10px;
   overflow: hidden;
   color: var(--live-text);
@@ -179,7 +179,8 @@
 }
 
 @media (max-height: 900px) {
-  .live-page { grid-template-rows: auto minmax(280px, 1fr) 116px 142px; padding-top: 10px; }
+  .live-page { grid-template-rows: auto auto minmax(0, 1fr); padding-top: 10px; }
+  .live-replay-workspace { grid-template-rows: minmax(280px, 1fr) 116px 142px; }
   .live-title-block p { display: none; }
   .live-sparkline { height: 56px; }
   .live-agent-panel dl > div { padding: 7px 0; }
@@ -188,9 +189,9 @@
 .live-view-selector { display: inline-flex; gap: 4px; padding: 3px; border: 1px solid var(--border); border-radius: 9px; background: rgba(10, 18, 30, .72); }
 .live-view-selector button { border: 0; border-radius: 7px; padding: 7px 15px; background: transparent; color: var(--text-muted); font-weight: 700; }
 .live-view-selector button[aria-pressed="true"] { background: var(--accent); color: #07111f; }
-.live-replay-workspace { display: contents; }
+.live-replay-workspace { min-height: 0; display: grid; grid-template-rows: minmax(300px, 1fr) 132px 164px; gap: 10px; overflow: hidden; }
 .live-replay-workspace[hidden], [hidden] { display: none !important; }
-.training-diagnostics { min-height: 0; display: grid; grid-template-rows: auto auto auto minmax(0, 1fr); gap: 8px; padding: 10px; border: 1px solid var(--border); border-radius: 12px; background: rgba(8, 15, 27, .86); overflow: hidden; }
+.training-diagnostics { height: 100%; min-height: 0; display: grid; grid-template-rows: auto auto auto minmax(0, 1fr); gap: 8px; padding: 10px; border: 1px solid var(--border); border-radius: 12px; background: rgba(8, 15, 27, .86); overflow: hidden; }
 .training-diagnostics-warning, .training-diagnostics-error, .training-diagnostics-empty { display: flex; align-items: center; gap: 8px; padding: 8px 10px; border-radius: 8px; background: rgba(245, 158, 11, .12); color: #f6d28b; font-size: 12px; }
 .training-diagnostics-tabs { display: flex; gap: 5px; }
 .training-diagnostics-tabs button { border: 1px solid var(--border); border-radius: 8px; padding: 6px 12px; background: transparent; color: var(--text-muted); }


### PR DESCRIPTION
## 問題

`LiveTrainingPage` に表示切替行が追加された後も、`.live-page` は従来の「ヘッダー + リプレイ + 指標 + イベント」4行グリッドのままでした。そのため `学習診断` 表示では、切替行が可変領域を占有し、診断パネルが固定132px行へ押し込まれていました。

既存の固定ビューポート監査は Live Training を開いていなかったため、この回帰を検出できませんでした。

## 修正

- 親グリッドを「ヘッダー + 表示切替 + ワークスペース」の3行へ変更
- 市場リプレイ内に従来の3行構成を移動
- 学習診断パネルをワークスペース全高へ拡張
- `Live Training -> 学習診断` のPlaywright固定画面監査を追加
- 切替行の肥大化、診断領域300px未満、画面外オーバーフローを失敗条件化
- CI成果物へ診断画面スクリーンショットを保存

## TDD evidence

RED: Studio tests/typecheck/buildは成功し、`Verify Studio fixed viewport layout`だけが失敗。

GREEN: head `52a8007b325c0bf91c4eda13e562d06d4c68f3c7` のCI #3779で全ジョブ成功。

- Studio: 14 files / 41 tests passed
- TypeScript typecheck: passed
- Production build: passed
- Live Training fixed viewport + interaction audit: passed at 1440x900
- Ruff / format / Mypy / import architecture / dead-code: passed
- Python: 2005 passed, 2 skipped; total coverage 85.85%
- Compatibility: Ubuntu + Windows passed
- Training image + packaged non-root runtime: passed
- Screenshot artifact: `trade-rl-studio-live-training-diagnostics.png`

Production判定は引き続き `NO-GO` です。