### PR TITLE
ci: trigger PR229 Ruff normalization

### DIFF
--- a/.github/pr229-ruff-trigger
+++ b/.github/pr229-ruff-trigger
@@ -1,0 +1,1 @@
+trigger


### PR DESCRIPTION
Temporary child PR used only to apply repository Ruff fixes and formatting to PR #229. It must not be merged and will be closed after the parent branch receives the style commit and removes the updater workflow.