### PR TITLE
ci: trigger PR227 capability correction

### DIFF
--- a/docs/verification/.pr227-capability-fix-trigger.md
+++ b/docs/verification/.pr227-capability-fix-trigger.md
@@ -1,0 +1,1 @@
+Temporary merge trigger for the self-deleting PR227 capability-audit correction workflow.


### PR DESCRIPTION
Temporary trigger PR. Its merge causes the branch-local self-deleting workflow to normalize the four migrated encoder constants, verify Ruff/MyPy, restore temporary diagnostics, and publish one clean commit to PR #227. This PR has no product scope.