### PR TITLE
ci: inventory stale branch refs

### DIFF
--- a/.github/workflows/temporary-branch-inventory.yml
+++ b/.github/workflows/temporary-branch-inventory.yml
@@ -14,9 +14,16 @@ permissions:
 jobs:
   inventory:
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
-      - name: List repository branches
+      - name: Checkout inventory branch
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fetch and classify repository branches
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
@@ -27,13 +34,50 @@ jobs:
             "repos/${GITHUB_REPOSITORY}/branches?per_page=100" \
             --jq '.[].name' \
             | sort > branch-inventory/branches.txt
+          git fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'
+          main_tree="$(git rev-parse 'origin/main^{tree}')"
+          printf 'branch\tsha\tbehind_main\tahead_main\tclassification\tmerge_tree\tdiff_shortstat\n' \
+            > branch-inventory/classification.tsv
+          while IFS= read -r branch; do
+            sha="$(git rev-parse "origin/${branch}")"
+            read -r behind ahead < <(
+              git rev-list --left-right --count "origin/main...origin/${branch}"
+            )
+            if [[ "$branch" == "main" ]]; then
+              classification="main"
+              merge_tree="$main_tree"
+            else
+              set +e
+              merge_output="$(git merge-tree --write-tree "origin/main" "origin/${branch}" 2>&1)"
+              merge_status=$?
+              set -e
+              merge_tree="$(printf '%s\n' "$merge_output" | head -n 1)"
+              if [[ $merge_status -ne 0 ]]; then
+                classification="conflict"
+              elif [[ "$merge_tree" == "$main_tree" ]]; then
+                classification="redundant"
+              else
+                classification="contributes"
+              fi
+            fi
+            diff_shortstat="$(
+              git diff --shortstat "origin/main...origin/${branch}" \
+                | tr '\t\n' '  ' \
+                | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//'
+            )"
+            printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+              "$branch" "$sha" "$behind" "$ahead" "$classification" \
+              "$merge_tree" "$diff_shortstat" \
+              >> branch-inventory/classification.tsv
+          done < branch-inventory/branches.txt
           wc -l branch-inventory/branches.txt
-          cat branch-inventory/branches.txt
+          column -t -s $'\t' branch-inventory/classification.tsv || \
+            cat branch-inventory/classification.tsv
 
       - name: Upload branch inventory
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: branch-inventory-${{ github.run_id }}
-          path: branch-inventory/branches.txt
+          name: branch-classification-${{ github.run_id }}
+          path: branch-inventory
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/temporary-branch-inventory.yml
+++ b/.github/workflows/temporary-branch-inventory.yml
@@ -1,0 +1,39 @@
+name: Temporary Branch Inventory
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+
+permissions:
+  contents: read
+
+jobs:
+  inventory:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: List repository branches
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p branch-inventory
+          gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/branches?per_page=100" \
+            --jq '.[].name' \
+            | sort > branch-inventory/branches.txt
+          wc -l branch-inventory/branches.txt
+          cat branch-inventory/branches.txt
+
+      - name: Upload branch inventory
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: branch-inventory-${{ github.run_id }}
+          path: branch-inventory/branches.txt
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/temporary-branch-inventory.yml
+++ b/.github/workflows/temporary-branch-inventory.yml
@@ -34,6 +34,21 @@ jobs:
             "repos/${GITHUB_REPOSITORY}/branches?per_page=100" \
             --jq '.[].name' \
             | sort > branch-inventory/branches.txt
+          gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/pulls?state=all&per_page=100&sort=created&direction=asc" \
+            --jq '.[] | {
+              number,
+              state,
+              draft,
+              merged_at,
+              closed_at,
+              title,
+              head: .head.ref,
+              head_sha: .head.sha,
+              base: .base.ref,
+              url: .html_url
+            }' \
+            > branch-inventory/pulls.jsonl
           git fetch --prune origin '+refs/heads/*:refs/remotes/origin/*'
           main_tree="$(git rev-parse 'origin/main^{tree}')"
           printf 'branch\tsha\tbehind_main\tahead_main\tclassification\tmerge_tree\tdiff_shortstat\n' \
@@ -70,14 +85,71 @@ jobs:
               "$merge_tree" "$diff_shortstat" \
               >> branch-inventory/classification.tsv
           done < branch-inventory/branches.txt
+          python - <<'PY'
+          import csv
+          import json
+          from collections import defaultdict
+          from pathlib import Path
+
+          root = Path("branch-inventory")
+          pulls_by_head: dict[str, list[dict[str, object]]] = defaultdict(list)
+          for line in (root / "pulls.jsonl").read_text(encoding="utf-8").splitlines():
+              if line.strip():
+                  pull = json.loads(line)
+                  pulls_by_head[str(pull["head"])].append(pull)
+          with (root / "classification.tsv").open(
+              encoding="utf-8", newline=""
+          ) as source, (root / "branch-pr-summary.tsv").open(
+              "w", encoding="utf-8", newline=""
+          ) as destination:
+              reader = csv.DictReader(source, delimiter="\t")
+              fields = [
+                  "branch",
+                  "classification",
+                  "ahead_main",
+                  "behind_main",
+                  "pull_count",
+                  "merged_prs",
+                  "closed_unmerged_prs",
+                  "open_prs",
+                  "titles",
+              ]
+              writer = csv.DictWriter(destination, fieldnames=fields, delimiter="\t")
+              writer.writeheader()
+              for row in reader:
+                  pulls = pulls_by_head.get(row["branch"], [])
+                  merged = [str(item["number"]) for item in pulls if item["merged_at"]]
+                  closed = [
+                      str(item["number"])
+                      for item in pulls
+                      if item["state"] == "closed" and not item["merged_at"]
+                  ]
+                  opened = [
+                      str(item["number"])
+                      for item in pulls
+                      if item["state"] == "open"
+                  ]
+                  writer.writerow(
+                      {
+                          "branch": row["branch"],
+                          "classification": row["classification"],
+                          "ahead_main": row["ahead_main"],
+                          "behind_main": row["behind_main"],
+                          "pull_count": len(pulls),
+                          "merged_prs": ",".join(merged),
+                          "closed_unmerged_prs": ",".join(closed),
+                          "open_prs": ",".join(opened),
+                          "titles": " | ".join(str(item["title"]) for item in pulls),
+                      }
+                  )
+          PY
           wc -l branch-inventory/branches.txt
-          column -t -s $'\t' branch-inventory/classification.tsv || \
-            cat branch-inventory/classification.tsv
+          cat branch-inventory/branch-pr-summary.tsv
 
       - name: Upload branch inventory
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: branch-classification-${{ github.run_id }}
+          name: branch-history-${{ github.run_id }}
           path: branch-inventory
           if-no-files-found: error
           retention-days: 1


### PR DESCRIPTION
Temporary read-only hosted workflow to enumerate every remote branch before normalizing stale refs to the merged main commit. This PR will not be merged and will be closed after the inventory artifact is collected.