### PR TITLE
ci: prune all non-main branches

### DIFF
--- a/.github/workflows/one-shot-prune-non-main-branches.yml
+++ b/.github/workflows/one-shot-prune-non-main-branches.yml
@@ -1,0 +1,98 @@
+name: One-shot prune non-main branches
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prune:
+    if: github.event.pull_request.head.ref == 'maintenance/prune-all-non-main-20260728'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete every non-main branch and close the temporary PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import urllib.error
+          import urllib.parse
+          import urllib.request
+
+          api = "https://api.github.com"
+          repo = os.environ["GITHUB_REPOSITORY"]
+          token = os.environ["GH_TOKEN"]
+          with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
+              event = json.load(handle)
+          pull_request = event["pull_request"]
+          cleanup_branch = pull_request["head"]["ref"]
+          pr_number = int(pull_request["number"])
+
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {token}",
+              "X-GitHub-Api-Version": "2022-11-28",
+              "User-Agent": "trade-rl-branch-pruner",
+          }
+
+          def request(method: str, path: str, payload: dict | None = None):
+              data = None if payload is None else json.dumps(payload).encode("utf-8")
+              req = urllib.request.Request(
+                  f"{api}{path}", data=data, headers=headers, method=method
+              )
+              try:
+                  with urllib.request.urlopen(req) as response:
+                      body = response.read()
+                      return response.status, (json.loads(body) if body else None)
+              except urllib.error.HTTPError as exc:
+                  body = exc.read().decode("utf-8", errors="replace")
+                  raise RuntimeError(
+                      f"{method} {path} failed with HTTP {exc.code}: {body}"
+                  ) from exc
+
+          branches: list[str] = []
+          page = 1
+          while True:
+              _, payload = request(
+                  "GET", f"/repos/{repo}/branches?per_page=100&page={page}"
+              )
+              batch = [item["name"] for item in payload]
+              branches.extend(batch)
+              if len(batch) < 100:
+                  break
+              page += 1
+
+          targets = sorted(
+              name for name in branches if name not in {"main", cleanup_branch}
+          )
+          print(json.dumps({"inventory": branches, "targets": targets}, ensure_ascii=False))
+
+          deleted: list[str] = []
+          failures: list[str] = []
+          for name in targets:
+              encoded = urllib.parse.quote(name, safe="")
+              try:
+                  request("DELETE", f"/repos/{repo}/git/refs/heads/{encoded}")
+                  deleted.append(name)
+                  print(f"deleted: {name}")
+              except RuntimeError as exc:
+                  failures.append(f"{name}: {exc}")
+
+          print(json.dumps({"deleted": deleted, "failures": failures}, ensure_ascii=False))
+          if failures:
+              raise SystemExit("branch deletion failures detected")
+
+          request("PATCH", f"/repos/{repo}/pulls/{pr_number}", {"state": "closed"})
+          encoded_cleanup = urllib.parse.quote(cleanup_branch, safe="")
+          request("DELETE", f"/repos/{repo}/git/refs/heads/{encoded_cleanup}")
+          print(f"deleted cleanup branch: {cleanup_branch}")
+          PY


### PR DESCRIPTION
One-shot cleanup PR. The workflow inventories every remote branch, preserves only `main`, deletes all other refs, closes this PR, and deletes its own branch. This PR must not be merged.