### PR TITLE
Fix stale README contract versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Flat observationの正本は`baseline_residual_observation_v5`、Serving bundle�
 
 ## Observation encoder
 
-`training_run_config_v2`では、`observation_encoder`を1つだけ選びます。
+`training_run_config_v3`では、`observation_encoder`を1つだけ選びます。
 
 | 値 | 用途 |
 |---|---|
@@ -114,7 +114,7 @@ TensorBoard診断では、損失やKLに加えて、時間足Attention比率、A
 
 ## ServingとExport
 
-Flat policyのExportと、構造化系列PolicyのExportは別契約です。`hierarchical_sequence_v2`は`structured_policy_export_v1`を使い、Canonical input順、Shape、Dtype、Parity corpus、Policy identity、Architecture digestをManifestへ固定します。
+Flat policyのExportと、構造化系列PolicyのExportは別契約です。`hierarchical_sequence_v2`は`structured_policy_export_v2`を使い、Canonical input順、Shape、Dtype、Parity corpus、Policy identity、Architecture digestをManifestへ固定します。
 
 Serving bundleの正本は`serving_bundle_v5`です。構造化Loaderは、Bundle、Export manifest、Model digest、Observation schema、Architecture digestが一致しない場合、Policy実行前にFail closedします。
 

--- a/tests/test_maintained_documentation_v3_contract.py
+++ b/tests/test_maintained_documentation_v3_contract.py
@@ -11,6 +11,8 @@ def test_docs_match_maintained_schemas_and_boundaries() -> None:
     configuration = (root / "docs/CONFIGURATION.md").read_text()
     binance = (root / "docs/BINANCE.md").read_text()
     assert "training_run_config_v3" in readme
+    assert "training_run_config_v2" not in readme
+    assert "structured_policy_export_v1" not in readme
     assert "training_run_config_v3" in architecture
     assert "structured_policy_export_v2" in architecture
     assert "# Training Configuration v3" in configuration


### PR DESCRIPTION
## Purpose

Make the README use only the maintained training and structured-export contract versions.

## Changes

- replace the stale `training_run_config_v2` reference with `training_run_config_v3`
- replace the stale `structured_policy_export_v1` reference with `structured_policy_export_v2`
- add regression assertions that reject both obsolete versions anywhere in the README

## TDD evidence

RED: the documentation contract test failed because `training_run_config_v2` remained in the README. The test stops at the first obsolete version, while the same regression test also covers `structured_policy_export_v1`.

GREEN:

- 2296 passed, 2 skipped
- total branch coverage 83.71% (required 80%)
- critical branch coverage passed
- Ruff, format, MyPy, Import Linter, vulture passed
- recovery and structured serving smoke passed
- Ubuntu and Windows compatibility passed
- training image build and packaged non-root probe passed

## Scope

README and its maintained-contract regression test only. No runtime, configuration parsing, model, reward, environment, or serving behavior changed.