### PR TITLE
Add Stage A0/A1 generalization contracts

### DIFF
--- a/tests/workflows/test_generalization_control.py
+++ b/tests/workflows/test_generalization_control.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from trade_rl.workflows.generalization_control import (
+    build_generalization_control_manifest,
+    load_generalization_control_manifest,
+    write_generalization_control_manifest,
+)
+
+DIGESTS = tuple(f"{index:064x}" for index in range(1, 7))
+BASE_COMMIT = "d60c091e21d06894d074144a4518ed9dd32e5c6b"
+
+
+def _build_control():
+    return build_generalization_control_manifest(
+        control_name="stage-a-control",
+        base_commit=BASE_COMMIT,
+        action_schema="portfolio_action_v3",
+        policy_identity=DIGESTS[0],
+        dataset_identity=DIGESTS[1],
+        feature_identity=DIGESTS[2],
+        execution_identity=DIGESTS[3],
+        evaluation_identity=DIGESTS[4],
+        seeds=(2, 0, 1),
+        folds=(1, 0),
+        stage_scope="stage_a_b",
+    )
+
+
+def test_control_manifest_binds_comparison_identities_and_round_trips(
+    tmp_path: Path,
+) -> None:
+    manifest = _build_control()
+
+    assert manifest.base_commit == BASE_COMMIT
+    assert manifest.seeds == (0, 1, 2)
+    assert manifest.folds == (0, 1)
+    assert manifest.comparison_identities == {
+        "dataset": DIGESTS[1],
+        "evaluation": DIGESTS[4],
+        "execution": DIGESTS[3],
+        "feature": DIGESTS[2],
+        "policy": DIGESTS[0],
+    }
+    path = write_generalization_control_manifest(tmp_path / "control.json", manifest)
+    assert load_generalization_control_manifest(path) == manifest
+
+
+def test_control_manifest_rejects_tampered_identity(tmp_path: Path) -> None:
+    manifest = _build_control()
+    path = write_generalization_control_manifest(tmp_path / "control.json", manifest)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["execution_identity"] = DIGESTS[5]
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="digest mismatch"):
+        load_generalization_control_manifest(path)
+
+
+@pytest.mark.parametrize(
+    "overrides,message",
+    [
+        ({"base_commit": "abc"}, "Git SHA"),
+        ({"policy_identity": "ABC"}, "SHA-256"),
+        ({"seeds": (0, 0)}, "unique"),
+        ({"folds": ()}, "not be empty"),
+        ({"stage_scope": "stage_c"}, "stage scope"),
+    ],
+)
+def test_control_manifest_rejects_invalid_control_contract(
+    overrides: dict[str, object], message: str
+) -> None:
+    kwargs: dict[str, object] = {
+        "control_name": "stage-a-control",
+        "base_commit": BASE_COMMIT,
+        "action_schema": "portfolio_action_v3",
+        "policy_identity": DIGESTS[0],
+        "dataset_identity": DIGESTS[1],
+        "feature_identity": DIGESTS[2],
+        "execution_identity": DIGESTS[3],
+        "evaluation_identity": DIGESTS[4],
+        "seeds": (0, 1, 2),
+        "folds": (0, 1),
+        "stage_scope": "stage_a_b",
+    }
+    kwargs.update(overrides)
+    with pytest.raises(ValueError, match=message):
+        build_generalization_control_manifest(**kwargs)

--- a/tests/workflows/test_symbol_disjoint_manifest.py
+++ b/tests/workflows/test_symbol_disjoint_manifest.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from trade_rl.workflows.symbol_disjoint_manifest import (
+    build_symbol_disjoint_manifest,
+    load_symbol_disjoint_manifest,
+    write_symbol_disjoint_manifest,
+)
+
+SYMBOLS = tuple(f"ASSET-{index:02d}" for index in range(15))
+
+
+def test_manifest_is_seed_stable_order_independent_and_symbol_disjoint() -> None:
+    first = build_symbol_disjoint_manifest(
+        SYMBOLS,
+        seed=20260730,
+        validation_count=3,
+        test_count=3,
+    )
+    repeated = build_symbol_disjoint_manifest(
+        tuple(reversed(SYMBOLS)),
+        seed=20260730,
+        validation_count=3,
+        test_count=3,
+    )
+    changed_seed = build_symbol_disjoint_manifest(
+        SYMBOLS,
+        seed=20260731,
+        validation_count=3,
+        test_count=3,
+    )
+
+    assert first == repeated
+    assert first.digest == repeated.digest
+    assert first.digest != changed_seed.digest
+    assert len(first.train_symbols) == 9
+    assert len(first.validation_symbols) == 3
+    assert len(first.test_symbols) == 3
+    assert set(first.train_symbols).isdisjoint(first.validation_symbols)
+    assert set(first.train_symbols).isdisjoint(first.test_symbols)
+    assert set(first.validation_symbols).isdisjoint(first.test_symbols)
+    assert set(first.all_symbols) == set(SYMBOLS)
+
+
+def test_triplets_are_generated_only_within_each_symbol_split() -> None:
+    manifest = build_symbol_disjoint_manifest(
+        SYMBOLS,
+        seed=17,
+        validation_count=3,
+        test_count=3,
+    )
+
+    for split in ("train", "validation", "test"):
+        split_symbols = set(manifest.symbols_for(split))
+        triplets = manifest.combinations_for(split, size=3)
+        assert triplets
+        assert all(set(triplet) <= split_symbols for triplet in triplets)
+
+
+def test_manifest_json_round_trip_and_overlap_tamper_rejection(tmp_path: Path) -> None:
+    manifest = build_symbol_disjoint_manifest(
+        SYMBOLS,
+        seed=99,
+        validation_count=3,
+        test_count=3,
+    )
+    path = write_symbol_disjoint_manifest(tmp_path / "symbol-disjoint.json", manifest)
+
+    assert load_symbol_disjoint_manifest(path) == manifest
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["validation_symbols"][0] = payload["train_symbols"][0]
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="disjoint|closure|digest"):
+        load_symbol_disjoint_manifest(path)
+
+
+@pytest.mark.parametrize(
+    "symbols,validation_count,test_count,message",
+    [
+        (SYMBOLS[:8], 3, 3, "minimum"),
+        (SYMBOLS, 2, 3, "minimum"),
+        (SYMBOLS, 3, 0, "minimum"),
+        (SYMBOLS[:-1] + (SYMBOLS[0],), 3, 3, "unique"),
+    ],
+)
+def test_manifest_rejects_invalid_symbol_disjoint_contract(
+    symbols: tuple[str, ...],
+    validation_count: int,
+    test_count: int,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        build_symbol_disjoint_manifest(
+            symbols,
+            seed=0,
+            validation_count=validation_count,
+            test_count=test_count,
+        )

--- a/trade_rl/workflows/generalization_control.py
+++ b/trade_rl/workflows/generalization_control.py
@@ -1,0 +1,206 @@
+"""Immutable comparison control for Stage A and Stage B generalization work."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final, Literal, cast
+
+from trade_rl.artifacts.codec import canonical_json_bytes
+from trade_rl.artifacts.hashing import content_digest
+from trade_rl.domain.common import require_git_sha, require_non_empty, require_sha256
+
+GENERALIZATION_CONTROL_SCHEMA: Final = "generalization_control_manifest_v1"
+GeneralizationStageScope = Literal["stage_a", "stage_a_b"]
+_ALLOWED_STAGE_SCOPES: Final = frozenset({"stage_a", "stage_a_b"})
+
+
+def _normalize_non_negative_ints(
+    values: tuple[int, ...], *, field: str
+) -> tuple[int, ...]:
+    if not values:
+        raise ValueError(f"{field} must not be empty")
+    if any(
+        isinstance(value, bool) or not isinstance(value, int) or value < 0
+        for value in values
+    ):
+        raise ValueError(f"{field} must contain non-negative integers")
+    if len(set(values)) != len(values):
+        raise ValueError(f"{field} must contain unique values")
+    return tuple(sorted(values))
+
+
+@dataclass(frozen=True, slots=True)
+class GeneralizationControlManifest:
+    """Content-addressed identities required for an apples-to-apples control."""
+
+    control_name: str
+    base_commit: str
+    action_schema: str
+    policy_identity: str
+    dataset_identity: str
+    feature_identity: str
+    execution_identity: str
+    evaluation_identity: str
+    seeds: tuple[int, ...]
+    folds: tuple[int, ...]
+    stage_scope: GeneralizationStageScope
+    schema_version: str = GENERALIZATION_CONTROL_SCHEMA
+    digest: str = ""
+
+    def __post_init__(self) -> None:
+        if self.schema_version != GENERALIZATION_CONTROL_SCHEMA:
+            raise ValueError("unsupported generalization control schema")
+        if self.stage_scope not in _ALLOWED_STAGE_SCOPES:
+            raise ValueError("generalization control stage scope is invalid")
+
+        control_name = require_non_empty(
+            self.control_name, field="generalization_control.control_name"
+        )
+        action_schema = require_non_empty(
+            self.action_schema, field="generalization_control.action_schema"
+        )
+        base_commit = require_git_sha(
+            self.base_commit, field="generalization_control.base_commit"
+        )
+        for field, value in self.comparison_identities.items():
+            require_sha256(value, field=f"generalization_control.{field}_identity")
+        seeds = _normalize_non_negative_ints(
+            self.seeds, field="generalization_control.seeds"
+        )
+        folds = _normalize_non_negative_ints(
+            self.folds, field="generalization_control.folds"
+        )
+
+        object.__setattr__(self, "control_name", control_name)
+        object.__setattr__(self, "action_schema", action_schema)
+        object.__setattr__(self, "base_commit", base_commit)
+        object.__setattr__(self, "seeds", seeds)
+        object.__setattr__(self, "folds", folds)
+
+        expected_digest = content_digest(self.digest_payload())
+        if self.digest and self.digest != expected_digest:
+            raise ValueError("generalization control digest mismatch")
+        object.__setattr__(self, "digest", expected_digest)
+
+    @property
+    def comparison_identities(self) -> dict[str, str]:
+        return {
+            "dataset": self.dataset_identity,
+            "evaluation": self.evaluation_identity,
+            "execution": self.execution_identity,
+            "feature": self.feature_identity,
+            "policy": self.policy_identity,
+        }
+
+    def digest_payload(self) -> dict[str, object]:
+        return {
+            "action_schema": self.action_schema,
+            "base_commit": self.base_commit,
+            "control_name": self.control_name,
+            "dataset_identity": self.dataset_identity,
+            "evaluation_identity": self.evaluation_identity,
+            "execution_identity": self.execution_identity,
+            "feature_identity": self.feature_identity,
+            "folds": self.folds,
+            "policy_identity": self.policy_identity,
+            "schema_version": self.schema_version,
+            "seeds": self.seeds,
+            "stage_scope": self.stage_scope,
+        }
+
+    def to_json_dict(self) -> dict[str, object]:
+        return {"digest": self.digest, **self.digest_payload()}
+
+
+def build_generalization_control_manifest(
+    *,
+    control_name: str,
+    base_commit: str,
+    action_schema: str,
+    policy_identity: str,
+    dataset_identity: str,
+    feature_identity: str,
+    execution_identity: str,
+    evaluation_identity: str,
+    seeds: tuple[int, ...],
+    folds: tuple[int, ...],
+    stage_scope: GeneralizationStageScope,
+) -> GeneralizationControlManifest:
+    return GeneralizationControlManifest(
+        control_name=control_name,
+        base_commit=base_commit,
+        action_schema=action_schema,
+        policy_identity=policy_identity,
+        dataset_identity=dataset_identity,
+        feature_identity=feature_identity,
+        execution_identity=execution_identity,
+        evaluation_identity=evaluation_identity,
+        seeds=seeds,
+        folds=folds,
+        stage_scope=stage_scope,
+    )
+
+
+def write_generalization_control_manifest(
+    path: str | Path, manifest: GeneralizationControlManifest
+) -> Path:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(canonical_json_bytes(manifest.to_json_dict()))
+    return output
+
+
+def load_generalization_control_manifest(
+    path: str | Path,
+) -> GeneralizationControlManifest:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("generalization control manifest must be a JSON object")
+    required = {
+        "action_schema",
+        "base_commit",
+        "control_name",
+        "dataset_identity",
+        "digest",
+        "evaluation_identity",
+        "execution_identity",
+        "feature_identity",
+        "folds",
+        "policy_identity",
+        "schema_version",
+        "seeds",
+        "stage_scope",
+    }
+    if set(payload) != required:
+        raise ValueError("generalization control field closure mismatch")
+    raw_seeds = payload["seeds"]
+    raw_folds = payload["folds"]
+    if not isinstance(raw_seeds, list) or not isinstance(raw_folds, list):
+        raise ValueError("generalization control seeds and folds must be lists")
+    return GeneralizationControlManifest(
+        control_name=payload["control_name"],
+        base_commit=payload["base_commit"],
+        action_schema=payload["action_schema"],
+        policy_identity=payload["policy_identity"],
+        dataset_identity=payload["dataset_identity"],
+        feature_identity=payload["feature_identity"],
+        execution_identity=payload["execution_identity"],
+        evaluation_identity=payload["evaluation_identity"],
+        seeds=tuple(raw_seeds),
+        folds=tuple(raw_folds),
+        stage_scope=cast(GeneralizationStageScope, payload["stage_scope"]),
+        schema_version=payload["schema_version"],
+        digest=payload["digest"],
+    )
+
+
+__all__ = [
+    "GENERALIZATION_CONTROL_SCHEMA",
+    "GeneralizationControlManifest",
+    "GeneralizationStageScope",
+    "build_generalization_control_manifest",
+    "load_generalization_control_manifest",
+    "write_generalization_control_manifest",
+]

--- a/trade_rl/workflows/symbol_disjoint_manifest.py
+++ b/trade_rl/workflows/symbol_disjoint_manifest.py
@@ -87,7 +87,9 @@ class SymbolDisjointManifest:
                     f"symbol-disjoint {split} split is below the minimum size"
                 )
         if not set(train).isdisjoint(validation):
-            raise ValueError("symbol-disjoint train and validation splits must be disjoint")
+            raise ValueError(
+                "symbol-disjoint train and validation splits must be disjoint"
+            )
         if not set(train).isdisjoint(test):
             raise ValueError("symbol-disjoint train and test splits must be disjoint")
         if not set(validation).isdisjoint(test):

--- a/trade_rl/workflows/symbol_disjoint_manifest.py
+++ b/trade_rl/workflows/symbol_disjoint_manifest.py
@@ -1,0 +1,274 @@
+"""Deterministic symbol-disjoint train/validation/test evaluation manifests."""
+
+from __future__ import annotations
+
+import itertools
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final, Literal
+
+from trade_rl.artifacts.codec import canonical_json_bytes
+from trade_rl.artifacts.hashing import content_digest
+from trade_rl.domain.common import require_unique_non_empty
+
+SYMBOL_DISJOINT_MANIFEST_SCHEMA: Final = "symbol_disjoint_manifest_v1"
+SymbolSplit = Literal["train", "validation", "test"]
+_SPLITS: Final[tuple[SymbolSplit, ...]] = ("train", "validation", "test")
+
+
+def _validate_non_negative_int(value: int, *, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{field} must be a non-negative integer")
+    return value
+
+
+def _validate_positive_int(value: int, *, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{field} must be a positive integer")
+    return value
+
+
+def _canonical_symbols(symbols: tuple[str, ...], *, field: str) -> tuple[str, ...]:
+    return tuple(sorted(require_unique_non_empty(tuple(symbols), field=field)))
+
+
+def _rank(seed: int, symbol: str) -> tuple[str, str]:
+    return (
+        content_digest(
+            {
+                "schema_version": "symbol_disjoint_rank_v1",
+                "seed": seed,
+                "symbol": symbol,
+            }
+        ),
+        symbol,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class SymbolDisjointManifest:
+    """A content-addressed partition whose symbol sets cannot overlap."""
+
+    source_universe: tuple[str, ...]
+    universe_digest: str
+    seed: int
+    train_symbols: tuple[str, ...]
+    validation_symbols: tuple[str, ...]
+    test_symbols: tuple[str, ...]
+    minimum_symbols_per_split: int = 3
+    schema_version: str = SYMBOL_DISJOINT_MANIFEST_SCHEMA
+    digest: str = ""
+
+    def __post_init__(self) -> None:
+        if self.schema_version != SYMBOL_DISJOINT_MANIFEST_SCHEMA:
+            raise ValueError("unsupported symbol-disjoint manifest schema")
+        seed = _validate_non_negative_int(self.seed, field="symbol_disjoint.seed")
+        minimum = _validate_positive_int(
+            self.minimum_symbols_per_split,
+            field="symbol_disjoint.minimum_symbols_per_split",
+        )
+        source_universe = _canonical_symbols(
+            self.source_universe, field="symbol_disjoint.source_universe"
+        )
+        train = _canonical_symbols(
+            self.train_symbols, field="symbol_disjoint.train_symbols"
+        )
+        validation = _canonical_symbols(
+            self.validation_symbols, field="symbol_disjoint.validation_symbols"
+        )
+        test = _canonical_symbols(
+            self.test_symbols, field="symbol_disjoint.test_symbols"
+        )
+        split_values = {"train": train, "validation": validation, "test": test}
+        for split, values in split_values.items():
+            if len(values) < minimum:
+                raise ValueError(
+                    f"symbol-disjoint {split} split is below the minimum size"
+                )
+        if not set(train).isdisjoint(validation):
+            raise ValueError("symbol-disjoint train and validation splits must be disjoint")
+        if not set(train).isdisjoint(test):
+            raise ValueError("symbol-disjoint train and test splits must be disjoint")
+        if not set(validation).isdisjoint(test):
+            raise ValueError(
+                "symbol-disjoint validation and test splits must be disjoint"
+            )
+        if set(train) | set(validation) | set(test) != set(source_universe):
+            raise ValueError("symbol-disjoint universe closure mismatch")
+
+        expected_universe_digest = content_digest(
+            {
+                "schema_version": "canonical_symbol_universe_v1",
+                "symbols": source_universe,
+            }
+        )
+        if self.universe_digest != expected_universe_digest:
+            raise ValueError("symbol-disjoint universe digest mismatch")
+
+        object.__setattr__(self, "seed", seed)
+        object.__setattr__(self, "minimum_symbols_per_split", minimum)
+        object.__setattr__(self, "source_universe", source_universe)
+        object.__setattr__(self, "train_symbols", train)
+        object.__setattr__(self, "validation_symbols", validation)
+        object.__setattr__(self, "test_symbols", test)
+
+        expected_digest = content_digest(self.digest_payload())
+        if self.digest and self.digest != expected_digest:
+            raise ValueError("symbol-disjoint manifest digest mismatch")
+        object.__setattr__(self, "digest", expected_digest)
+
+    @property
+    def all_symbols(self) -> tuple[str, ...]:
+        return self.source_universe
+
+    @property
+    def split_counts(self) -> dict[str, int]:
+        return {split: len(self.symbols_for(split)) for split in _SPLITS}
+
+    def symbols_for(self, split: SymbolSplit) -> tuple[str, ...]:
+        if split == "train":
+            return self.train_symbols
+        if split == "validation":
+            return self.validation_symbols
+        if split == "test":
+            return self.test_symbols
+        raise ValueError("symbol-disjoint split is invalid")
+
+    def combinations_for(
+        self, split: SymbolSplit, *, size: int
+    ) -> tuple[tuple[str, ...], ...]:
+        resolved_size = _validate_positive_int(
+            size, field="symbol_disjoint.combination_size"
+        )
+        symbols = self.symbols_for(split)
+        if resolved_size > len(symbols):
+            raise ValueError("symbol-disjoint combination size exceeds split size")
+        return tuple(itertools.combinations(symbols, resolved_size))
+
+    def digest_payload(self) -> dict[str, object]:
+        return {
+            "minimum_symbols_per_split": self.minimum_symbols_per_split,
+            "schema_version": self.schema_version,
+            "seed": self.seed,
+            "source_universe": self.source_universe,
+            "split_counts": self.split_counts,
+            "test_symbols": self.test_symbols,
+            "train_symbols": self.train_symbols,
+            "universe_digest": self.universe_digest,
+            "validation_symbols": self.validation_symbols,
+        }
+
+    def to_json_dict(self) -> dict[str, object]:
+        return {"digest": self.digest, **self.digest_payload()}
+
+
+def build_symbol_disjoint_manifest(
+    symbols: tuple[str, ...],
+    *,
+    seed: int,
+    validation_count: int,
+    test_count: int,
+    minimum_symbols_per_split: int = 3,
+) -> SymbolDisjointManifest:
+    source_universe = _canonical_symbols(
+        symbols, field="symbol_disjoint.source_universe"
+    )
+    resolved_seed = _validate_non_negative_int(seed, field="symbol_disjoint.seed")
+    validation_size = _validate_non_negative_int(
+        validation_count, field="symbol_disjoint.validation_count"
+    )
+    test_size = _validate_non_negative_int(
+        test_count, field="symbol_disjoint.test_count"
+    )
+    minimum = _validate_positive_int(
+        minimum_symbols_per_split,
+        field="symbol_disjoint.minimum_symbols_per_split",
+    )
+    train_size = len(source_universe) - validation_size - test_size
+    if min(train_size, validation_size, test_size) < minimum:
+        raise ValueError("each symbol-disjoint split must satisfy the minimum size")
+
+    ranked = tuple(
+        sorted(source_universe, key=lambda symbol: _rank(resolved_seed, symbol))
+    )
+    train = tuple(sorted(ranked[:train_size]))
+    validation = tuple(sorted(ranked[train_size : train_size + validation_size]))
+    test = tuple(sorted(ranked[train_size + validation_size :]))
+    universe_digest = content_digest(
+        {
+            "schema_version": "canonical_symbol_universe_v1",
+            "symbols": source_universe,
+        }
+    )
+    return SymbolDisjointManifest(
+        source_universe=source_universe,
+        universe_digest=universe_digest,
+        seed=resolved_seed,
+        train_symbols=train,
+        validation_symbols=validation,
+        test_symbols=test,
+        minimum_symbols_per_split=minimum,
+    )
+
+
+def write_symbol_disjoint_manifest(
+    path: str | Path, manifest: SymbolDisjointManifest
+) -> Path:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(canonical_json_bytes(manifest.to_json_dict()))
+    return output
+
+
+def load_symbol_disjoint_manifest(path: str | Path) -> SymbolDisjointManifest:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("symbol-disjoint manifest must be a JSON object")
+    required = {
+        "digest",
+        "minimum_symbols_per_split",
+        "schema_version",
+        "seed",
+        "source_universe",
+        "split_counts",
+        "test_symbols",
+        "train_symbols",
+        "universe_digest",
+        "validation_symbols",
+    }
+    if set(payload) != required:
+        raise ValueError("symbol-disjoint manifest field closure mismatch")
+    list_fields = (
+        "source_universe",
+        "train_symbols",
+        "validation_symbols",
+        "test_symbols",
+    )
+    if any(not isinstance(payload[field], list) for field in list_fields):
+        raise ValueError("symbol-disjoint symbol fields must be lists")
+    manifest = SymbolDisjointManifest(
+        source_universe=tuple(payload["source_universe"]),
+        universe_digest=payload["universe_digest"],
+        seed=payload["seed"],
+        train_symbols=tuple(payload["train_symbols"]),
+        validation_symbols=tuple(payload["validation_symbols"]),
+        test_symbols=tuple(payload["test_symbols"]),
+        minimum_symbols_per_split=payload["minimum_symbols_per_split"],
+        schema_version=payload["schema_version"],
+        digest=payload["digest"],
+    )
+    raw_counts = payload["split_counts"]
+    if not isinstance(raw_counts, dict) or raw_counts != manifest.split_counts:
+        raise ValueError("symbol-disjoint split counts mismatch")
+    return manifest
+
+
+__all__ = [
+    "SYMBOL_DISJOINT_MANIFEST_SCHEMA",
+    "SymbolDisjointManifest",
+    "SymbolSplit",
+    "build_symbol_disjoint_manifest",
+    "load_symbol_disjoint_manifest",
+    "write_symbol_disjoint_manifest",
+]


### PR DESCRIPTION
## What changed

- adds a content-addressed Stage A/Stage B comparison-control manifest
- binds the base Git commit, action schema, policy, dataset, feature, execution, and evaluation identities
- normalizes and binds the seed/fold sets used for apples-to-apples comparisons
- adds a deterministic symbol-disjoint train/validation/test manifest
- makes split assignment stable under input reordering while remaining seed-dependent
- rejects symbol overlap, incomplete universe closure, undersized splits, invalid identities, and JSON tampering
- exposes split-local combinations so dynamic triplet generation cannot cross evaluation boundaries

## Why

The existing triplet manifest separates triplet identities, but every symbol can still appear in every split. Stage A requires a stronger evaluation contract where train, validation, and test symbol sets themselves are disjoint. A0 also needs the current control run and all comparison identities frozen before architecture changes begin.

## Validation

- TDD red phase: both new test modules failed to import before production modules existed
- focused unit suite: `14 passed`
- Python compile check passed for both new workflow modules
- branch diff is limited to two workflow modules and two test modules

Full repository CI is expected to run on this draft PR. The execution environment could not directly clone GitHub because outbound DNS was blocked, so the focused standard-library test harness reproduced the repository hashing and canonical JSON dependencies locally.