### PR TITLE
Separate asset-agnostic policy structure from runtime asset binding

### DIFF
--- a/tests/integrations/test_sb3_policy_identity_v3.py
+++ b/tests/integrations/test_sb3_policy_identity_v3.py
@@ -63,20 +63,36 @@ def _assembly() -> SimpleNamespace:
     return SimpleNamespace(
         observation_encoder="hierarchical_sequence_v2",
         sequence_symbols=("BTCUSDT", "ETHUSDT", "BNBUSDT"),
-        sequence_action_names=("BTCUSDT", "ETHUSDT", "BNBUSDT"),
+        sequence_action_names=(
+            "target_weight:BTCUSDT",
+            "target_weight:ETHUSDT",
+            "target_weight:BNBUSDT",
+        ),
         policy_actor_head="hierarchical_gate_target_v1",
         hierarchical_gate_temperature=1.0,
     )
 
 
-def test_identity_binds_actual_architecture_and_exploration_contract() -> None:
+def test_identity_binds_structure_binding_and_exploration_contract() -> None:
     model = _model(_architecture())
     payload = bind_sb3_policy_identity(model, _assembly())
 
-    assert payload["schema_version"] == "sb3_policy_identity_v3"
+    assert payload["schema_version"] == "sb3_policy_identity_v4"
     assert payload["observation_encoder"] == "hierarchical_sequence_v2"
     assert payload["sequence_architecture_digest"]
     assert payload["sequence_architecture"]["asset_identity_mode"] == "identity_free_v1"
+    assert "symbols" not in payload["sequence_architecture"]
+    assert payload["asset_binding"] == {
+        "action_names": (
+            "target_weight:BTCUSDT",
+            "target_weight:ETHUSDT",
+            "target_weight:BNBUSDT",
+        ),
+        "n_symbols": 3,
+        "schema_version": "sequence_asset_binding_v1",
+        "symbols": ("BTCUSDT", "ETHUSDT", "BNBUSDT"),
+    }
+    assert payload["asset_binding_digest"]
     assert payload["policy_architecture_digest"]
     assert payload["actor_head"] == "hierarchical_gate_target_v1"
     assert payload["gate_temperature"] == 1.0
@@ -92,11 +108,16 @@ def test_identity_binds_actual_architecture_and_exploration_contract() -> None:
     assert model_sb3_policy_identity(model) == payload
 
 
-def test_legacy_v2_identity_is_rejected_with_migration_error() -> None:
+@pytest.mark.parametrize(
+    "legacy_schema", ("sb3_policy_identity_v2", "sb3_policy_identity_v3")
+)
+def test_legacy_identity_is_rejected_with_migration_error(
+    legacy_schema: str,
+) -> None:
     payload = bind_sb3_policy_identity(_model(_architecture()), _assembly())
-    legacy = {**payload, "schema_version": "sb3_policy_identity_v2"}
+    legacy = {**payload, "schema_version": legacy_schema}
 
-    with pytest.raises(ValueError, match="migrate sb3_policy_identity_v2"):
+    with pytest.raises(ValueError, match=f"migrate {legacy_schema}"):
         validated_sb3_policy_identity(legacy)
 
 

--- a/tests/rl/test_asset_agnostic_policy_identity.py
+++ b/tests/rl/test_asset_agnostic_policy_identity.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from trade_rl.rl.policy_identity import (
+    bind_sb3_policy_identity,
+    validate_model_sb3_policy_identity,
+    validate_sb3_policy_architecture_compatibility,
+)
+from trade_rl.rl.sequence_architecture import (
+    sequence_architecture_identity,
+    sequence_asset_binding_identity,
+)
+from trade_rl.rl.sequence_policy import SequencePolicyArchitecture
+
+
+def _architecture(*, timeframe_layers: int = 1) -> SequencePolicyArchitecture:
+    return SequencePolicyArchitecture(
+        input_channels={"15m": 3, "1h": 3, "4h": 3, "1d": 3},
+        window_lengths={"15m": 4, "1h": 4, "4h": 4, "1d": 4},
+        latent_dims={"15m": 8, "1h": 8, "4h": 8, "1d": 8},
+        asset_state_width=4,
+        snapshot_width=8,
+        n_symbols=3,
+        d_model=24,
+        timeframe_attention_heads=4,
+        timeframe_attention_layers=timeframe_layers,
+        asset_attention_heads=4,
+        asset_attention_layers=1,
+        dropout=0.0,
+    )
+
+
+def _model(architecture: SequencePolicyArchitecture) -> SimpleNamespace:
+    return SimpleNamespace(
+        policy=SimpleNamespace(
+            features_extractor=SimpleNamespace(
+                asset_encoder=SimpleNamespace(architecture=architecture)
+            ),
+            shared_actor_head="hierarchical_gate_target_v1",
+            shared_actor_gate_temperature=1.0,
+            action_distribution_name="masked_shared_squashed_diag_gaussian_v1",
+            log_std=SimpleNamespace(shape=(1,)),
+            use_sde=False,
+        )
+    )
+
+
+def _assembly(symbols: tuple[str, ...]) -> SimpleNamespace:
+    return SimpleNamespace(
+        observation_encoder="hierarchical_sequence_v2",
+        sequence_symbols=symbols,
+        sequence_action_names=tuple(f"target_weight:{symbol}" for symbol in symbols),
+        policy_actor_head="hierarchical_gate_target_v1",
+        hierarchical_gate_temperature=1.0,
+    )
+
+
+def test_sequence_architecture_digest_does_not_bind_symbol_names() -> None:
+    architecture = _architecture()
+
+    first = sequence_architecture_identity(architecture)
+    repeated = sequence_architecture_identity(architecture)
+
+    assert first == repeated
+    assert first.digest == repeated.digest
+    assert "symbols" not in first.digest_payload()
+    assert "action_names" not in first.digest_payload()
+
+
+def test_asset_binding_is_separate_and_symbol_specific() -> None:
+    first = sequence_asset_binding_identity(
+        n_symbols=3,
+        symbols=("BTCUSDT", "ETHUSDT", "BNBUSDT"),
+        action_names=(
+            "target_weight:BTCUSDT",
+            "target_weight:ETHUSDT",
+            "target_weight:BNBUSDT",
+        ),
+    )
+    second = sequence_asset_binding_identity(
+        n_symbols=3,
+        symbols=("SOLUSDT", "XRPUSDT", "ADAUSDT"),
+        action_names=(
+            "target_weight:SOLUSDT",
+            "target_weight:XRPUSDT",
+            "target_weight:ADAUSDT",
+        ),
+    )
+
+    assert first.digest != second.digest
+    assert first.n_symbols == second.n_symbols == 3
+
+
+def test_policy_architecture_is_compatible_across_symbol_bindings() -> None:
+    architecture = _architecture()
+    first_model = _model(architecture)
+    second_model = _model(architecture)
+    first = bind_sb3_policy_identity(
+        first_model, _assembly(("BTCUSDT", "ETHUSDT", "BNBUSDT"))
+    )
+    second = bind_sb3_policy_identity(
+        second_model, _assembly(("SOLUSDT", "XRPUSDT", "ADAUSDT"))
+    )
+
+    assert first["policy_architecture_digest"] == second["policy_architecture_digest"]
+    assert first["asset_binding_digest"] != second["asset_binding_digest"]
+    validate_sb3_policy_architecture_compatibility(second, first)
+    with pytest.raises(ValueError, match="architecture identity mismatch"):
+        validate_model_sb3_policy_identity(second_model, first)
+
+
+def test_policy_architecture_compatibility_rejects_real_model_drift() -> None:
+    expected = bind_sb3_policy_identity(
+        _model(_architecture(timeframe_layers=1)),
+        _assembly(("BTCUSDT", "ETHUSDT", "BNBUSDT")),
+    )
+    drifted = bind_sb3_policy_identity(
+        _model(_architecture(timeframe_layers=2)),
+        _assembly(("SOLUSDT", "XRPUSDT", "ADAUSDT")),
+    )
+
+    with pytest.raises(ValueError, match="architecture compatibility"):
+        validate_sb3_policy_architecture_compatibility(drifted, expected)
+
+
+def test_asset_binding_rejects_non_target_weight_action_names() -> None:
+    with pytest.raises(ValueError, match="target-weight action names"):
+        sequence_asset_binding_identity(
+            n_symbols=3,
+            symbols=("BTCUSDT", "ETHUSDT", "BNBUSDT"),
+            action_names=("BTCUSDT", "ETHUSDT", "BNBUSDT"),
+        )

--- a/tests/rl/test_identity_free_sequence_architecture.py
+++ b/tests/rl/test_identity_free_sequence_architecture.py
@@ -28,23 +28,17 @@ def _architecture() -> SequencePolicyArchitecture:
 
 
 def _identity():
-    return sequence_architecture_identity(
-        _architecture(),
-        symbols=("BTCUSDT", "ETHUSDT", "BNBUSDT"),
-        action_names=(
-            "target_weight:BTCUSDT",
-            "target_weight:ETHUSDT",
-            "target_weight:BNBUSDT",
-        ),
-    )
+    return sequence_architecture_identity(_architecture())
 
 
 def test_sequence_identity_records_identity_free_asset_semantics() -> None:
     identity = _identity()
 
-    assert identity.schema_version == "hierarchical_sequence_policy_v3"
+    assert identity.schema_version == "hierarchical_sequence_policy_v4"
     assert identity.asset_identity_mode == "identity_free_v1"
     assert identity.digest_payload()["asset_identity_mode"] == "identity_free_v1"
+    assert "symbols" not in identity.digest_payload()
+    assert "action_names" not in identity.digest_payload()
 
 
 def test_sequence_identity_rejects_other_asset_identity_modes() -> None:

--- a/tests/rl/test_sequence_architecture_identity.py
+++ b/tests/rl/test_sequence_architecture_identity.py
@@ -50,9 +50,10 @@ def test_sequence_architecture_digest_changes_with_model_semantics() -> None:
     base = _architecture()
     deeper = replace(base, timeframe_attention_layers=3)
 
-    assert sequence_architecture_identity(base).digest != sequence_architecture_identity(
-        deeper
-    ).digest
+    assert (
+        sequence_architecture_identity(base).digest
+        != sequence_architecture_identity(deeper).digest
+    )
 
 
 def test_sequence_asset_binding_rejects_symbol_action_mismatch() -> None:

--- a/tests/rl/test_sequence_architecture_identity.py
+++ b/tests/rl/test_sequence_architecture_identity.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from dataclasses import replace
 
-from trade_rl.rl.sequence_architecture import sequence_architecture_identity
+import pytest
+
+from trade_rl.rl.sequence_architecture import (
+    sequence_architecture_identity,
+    sequence_asset_binding_identity,
+)
 from trade_rl.rl.sequence_policy import SequencePolicyArchitecture
 
 _TIMEFRAMES = ("15m", "1h", "4h", "1d")
@@ -31,66 +36,49 @@ def _architecture() -> SequencePolicyArchitecture:
 
 def test_sequence_architecture_identity_is_deterministic() -> None:
     architecture = _architecture()
-    left = sequence_architecture_identity(
-        architecture,
-        symbols=("BTCUSDT", "ETHUSDT", "BNBUSDT"),
-        action_names=(
-            "target_weight:BTCUSDT",
-            "target_weight:ETHUSDT",
-            "target_weight:BNBUSDT",
-        ),
-    )
-    right = sequence_architecture_identity(
-        architecture,
-        symbols=("BTCUSDT", "ETHUSDT", "BNBUSDT"),
-        action_names=(
-            "target_weight:BTCUSDT",
-            "target_weight:ETHUSDT",
-            "target_weight:BNBUSDT",
-        ),
-    )
+    left = sequence_architecture_identity(architecture)
+    right = sequence_architecture_identity(architecture)
 
     assert left == right
     assert left.digest == right.digest
     assert len(left.digest) == 64
+    assert "symbols" not in left.digest_payload()
+    assert "action_names" not in left.digest_payload()
 
 
 def test_sequence_architecture_digest_changes_with_model_semantics() -> None:
     base = _architecture()
     deeper = replace(base, timeframe_attention_layers=3)
-    base_identity = sequence_architecture_identity(
-        base,
-        symbols=("BTCUSDT", "ETHUSDT", "BNBUSDT"),
-        action_names=("a", "b", "c"),
-    )
-    deeper_identity = sequence_architecture_identity(
-        deeper,
-        symbols=("BTCUSDT", "ETHUSDT", "BNBUSDT"),
-        action_names=("a", "b", "c"),
-    )
 
-    assert base_identity.digest != deeper_identity.digest
+    assert sequence_architecture_identity(base).digest != sequence_architecture_identity(
+        deeper
+    ).digest
 
 
-def test_sequence_architecture_identity_rejects_symbol_action_mismatch() -> None:
-    try:
-        sequence_architecture_identity(
-            _architecture(),
+def test_sequence_asset_binding_rejects_symbol_action_mismatch() -> None:
+    with pytest.raises(ValueError, match="counts must match"):
+        sequence_asset_binding_identity(
+            n_symbols=3,
             symbols=("BTCUSDT", "ETHUSDT", "BNBUSDT"),
-            action_names=("a", "b"),
+            action_names=("target_weight:BTCUSDT", "target_weight:ETHUSDT"),
         )
-    except ValueError as error:
-        assert "symbol and action counts" in str(error)
-    else:
-        raise AssertionError("symbol/action identity mismatch must fail closed")
+
+
+def test_sequence_asset_binding_rejects_wrong_action_order() -> None:
+    with pytest.raises(ValueError, match="target-weight action names"):
+        sequence_asset_binding_identity(
+            n_symbols=3,
+            symbols=("BTCUSDT", "ETHUSDT", "BNBUSDT"),
+            action_names=(
+                "target_weight:ETHUSDT",
+                "target_weight:BTCUSDT",
+                "target_weight:BNBUSDT",
+            ),
+        )
 
 
 def test_sequence_architecture_identity_records_complete_receptive_fields() -> None:
-    identity = sequence_architecture_identity(
-        _architecture(),
-        symbols=("BTCUSDT", "ETHUSDT", "BNBUSDT"),
-        action_names=("a", "b", "c"),
-    )
+    identity = sequence_architecture_identity(_architecture())
 
     for window, dilations in zip(
         identity.window_lengths,

--- a/tests/rl/test_structured_export.py
+++ b/tests/rl/test_structured_export.py
@@ -85,18 +85,22 @@ class _FakeModel:
     def __init__(self) -> None:
         self.policy = _FakeStructuredPolicy()
         self.device = "cuda:7"
+        symbols = ("BTC", "ETH", "BNB")
+        action_names = tuple(f"target_weight:{symbol}" for symbol in symbols)
         architecture = {
-            "schema_version": "hierarchical_sequence_policy_v2",
-            "timeframes": ["15m", "1h", "4h", "1d"],
+            "asset_identity_mode": "identity_free_v1",
             "d_model": 16,
-            "action_names": (
-                "target_weight:BTC",
-                "target_weight:ETH",
-                "target_weight:BNB",
-            ),
-            "symbols": ("BTC", "ETH", "BNB"),
+            "n_symbols": 3,
+            "schema_version": "hierarchical_sequence_policy_v4",
+            "timeframes": ["15m", "1h", "4h", "1d"],
         }
         sequence_digest = content_digest(architecture)
+        asset_binding = {
+            "action_names": action_names,
+            "n_symbols": 3,
+            "schema_version": "sequence_asset_binding_v1",
+            "symbols": symbols,
+        }
         current_weight = {
             "bounds": (-1.0, 1.0),
             "dtype": "float32",
@@ -119,17 +123,19 @@ class _FakeModel:
             "exploration_contract": exploration_contract,
             "gate_temperature": 1.0,
             "observation_encoder": "hierarchical_sequence_v2",
-            "schema_version": "hierarchical_gate_target_policy_v2",
+            "schema_version": "hierarchical_gate_target_policy_v3",
             "sequence_architecture_digest": sequence_digest,
         }
         identity = {
             "actor_head": "hierarchical_gate_target_v1",
+            "asset_binding": asset_binding,
+            "asset_binding_digest": content_digest(asset_binding),
             "current_weight_observation": current_weight,
             "exploration_contract": exploration_contract,
             "gate_temperature": 1.0,
             "observation_encoder": "hierarchical_sequence_v2",
             "policy_architecture_digest": content_digest(policy_architecture),
-            "schema_version": "sb3_policy_identity_v3",
+            "schema_version": "sb3_policy_identity_v4",
             "sequence_architecture": architecture,
             "sequence_architecture_digest": sequence_digest,
         }

--- a/tests/serving/test_sb3_loader.py
+++ b/tests/serving/test_sb3_loader.py
@@ -275,12 +275,21 @@ def _structured_bundle(root: Path):
         ),
         encoding="utf-8",
     )
+    action_names = ("target_weight:BTCUSDT", "target_weight:ETHUSDT")
+    symbols = ("BTCUSDT", "ETHUSDT")
     sequence_architecture = {
-        "action_names": ("target_weight:BTCUSDT", "target_weight:ETHUSDT"),
-        "schema_version": "test_sequence_architecture_v1",
-        "symbols": ("BTCUSDT", "ETHUSDT"),
+        "asset_identity_mode": "identity_free_v1",
+        "n_symbols": 2,
+        "schema_version": "hierarchical_sequence_policy_v4",
+        "test_architecture_marker": "structured-serving-v1",
     }
     sequence_digest = content_digest(sequence_architecture)
+    asset_binding = {
+        "action_names": action_names,
+        "n_symbols": 2,
+        "schema_version": "sequence_asset_binding_v1",
+        "symbols": symbols,
+    }
     current_weight_identity = {
         "bounds": (-1.0, 1.0),
         "dtype": "float32",
@@ -303,17 +312,19 @@ def _structured_bundle(root: Path):
         "exploration_contract": exploration_contract,
         "gate_temperature": 1.0,
         "observation_encoder": "hierarchical_sequence_v2",
-        "schema_version": "hierarchical_gate_target_policy_v2",
+        "schema_version": "hierarchical_gate_target_policy_v3",
         "sequence_architecture_digest": sequence_digest,
     }
     policy_identity = {
         "actor_head": "hierarchical_gate_target_v1",
+        "asset_binding": asset_binding,
+        "asset_binding_digest": content_digest(asset_binding),
         "current_weight_observation": current_weight_identity,
         "exploration_contract": exploration_contract,
         "gate_temperature": 1.0,
         "observation_encoder": "hierarchical_sequence_v2",
         "policy_architecture_digest": content_digest(policy_architecture),
-        "schema_version": "sb3_policy_identity_v3",
+        "schema_version": "sb3_policy_identity_v4",
         "sequence_architecture": sequence_architecture,
         "sequence_architecture_digest": sequence_digest,
     }
@@ -370,7 +381,6 @@ def _structured_bundle(root: Path):
             0, np.inf, shape=shape, dtype=np.float16
         )
     observation_space = spaces.Dict(sequence_spaces)
-    action_names = ("target_weight:BTCUSDT", "target_weight:ETHUSDT")
     manifest = ServingBundleManifest.build(
         root=root,
         dataset_id=dataset.dataset_id,

--- a/tests/serving/test_structured_policy_loader.py
+++ b/tests/serving/test_structured_policy_loader.py
@@ -47,13 +47,21 @@ class _ConstantActor(nn.Module):
 def _test_policy_identity(
     architecture: str, *, action_size: int = 2
 ) -> dict[str, object]:
+    symbols = tuple(str(index) for index in range(action_size))
+    action_names = tuple(f"target_weight:{symbol}" for symbol in symbols)
     sequence_architecture = {
-        "action_names": tuple(f"target_weight:{index}" for index in range(action_size)),
-        "schema_version": "test_sequence_architecture_v1",
-        "symbols": tuple(str(index) for index in range(action_size)),
+        "asset_identity_mode": "identity_free_v1",
+        "n_symbols": action_size,
+        "schema_version": "hierarchical_sequence_policy_v4",
         "test_architecture_marker": architecture,
     }
     sequence_digest = content_digest(sequence_architecture)
+    asset_binding = {
+        "action_names": action_names,
+        "n_symbols": action_size,
+        "schema_version": "sequence_asset_binding_v1",
+        "symbols": symbols,
+    }
     current_weight = {
         "bounds": (-1.0, 1.0),
         "dtype": "float32",
@@ -76,17 +84,19 @@ def _test_policy_identity(
         "exploration_contract": exploration_contract,
         "gate_temperature": 1.0,
         "observation_encoder": "hierarchical_sequence_v2",
-        "schema_version": "hierarchical_gate_target_policy_v2",
+        "schema_version": "hierarchical_gate_target_policy_v3",
         "sequence_architecture_digest": sequence_digest,
     }
     return {
         "actor_head": "hierarchical_gate_target_v1",
+        "asset_binding": asset_binding,
+        "asset_binding_digest": content_digest(asset_binding),
         "current_weight_observation": current_weight,
         "exploration_contract": exploration_contract,
         "gate_temperature": 1.0,
         "observation_encoder": "hierarchical_sequence_v2",
         "policy_architecture_digest": content_digest(policy_architecture),
-        "schema_version": "sb3_policy_identity_v3",
+        "schema_version": "sb3_policy_identity_v4",
         "sequence_architecture": sequence_architecture,
         "sequence_architecture_digest": sequence_digest,
     }

--- a/trade_rl/rl/policy_identity.py
+++ b/trade_rl/rl/policy_identity.py
@@ -9,20 +9,29 @@ from typing import Any, Final
 from trade_rl.artifacts.codec import canonical_json_bytes
 from trade_rl.artifacts.hashing import content_digest
 from trade_rl.rl.observations import CURRENT_WEIGHT_SOURCE
-from trade_rl.rl.sequence_architecture import sequence_architecture_identity
+from trade_rl.rl.sequence_architecture import (
+    SequenceAssetBindingIdentity,
+    sequence_architecture_identity,
+    sequence_asset_binding_identity,
+)
 from trade_rl.rl.sequence_observations import SEQUENCE_OBSERVATION_SCHEMA
 from trade_rl.rl.sequence_policy import SequencePolicyArchitecture
 
 SB3_POLICY_IDENTITY_ATTRIBUTE: Final = "_trade_rl_policy_identity"
-SB3_POLICY_IDENTITY_SCHEMA: Final = "sb3_policy_identity_v3"
-LEGACY_SB3_POLICY_IDENTITY_SCHEMA: Final = "sb3_policy_identity_v2"
-POLICY_ARCHITECTURE_SCHEMA: Final = "hierarchical_gate_target_policy_v2"
+SB3_POLICY_IDENTITY_SCHEMA: Final = "sb3_policy_identity_v4"
+LEGACY_SB3_POLICY_IDENTITY_SCHEMAS: Final = frozenset(
+    {"sb3_policy_identity_v2", "sb3_policy_identity_v3"}
+)
+POLICY_ARCHITECTURE_SCHEMA: Final = "hierarchical_gate_target_policy_v3"
 HIERARCHICAL_EXPLORATION_SCHEMA: Final = "hierarchical_exploration_v1"
 HIERARCHICAL_ACTION_DISTRIBUTION: Final = "masked_shared_squashed_diag_gaussian_v1"
 HIERARCHICAL_EXPLORATION_COUPLING: Final = "post_composition_gate_independent_v1"
 HIERARCHICAL_LOG_STD_PARAMETERIZATION: Final = "shared_scalar_v1"
 HIERARCHICAL_ACTOR_HEAD: Final = "hierarchical_gate_target_v1"
 CURRENT_WEIGHT_KEY: Final = "current_weights"
+_SEQUENCE_ARCHITECTURE_SCHEMA: Final = "hierarchical_sequence_policy_v4"
+_SEQUENCE_ASSET_BINDING_SCHEMA: Final = "sequence_asset_binding_v1"
+_ASSET_IDENTITY_MODE: Final = "identity_free_v1"
 _INTERNAL_ACTION_DISTRIBUTION_NAMES: Final = frozenset(
     {
         "masked_shared_squashed_diag_gaussian",
@@ -43,6 +52,12 @@ def _string_tuple(value: object, *, field: str) -> tuple[str, ...]:
     return value
 
 
+def _serialized_string_tuple(value: object, *, field: str) -> tuple[str, ...]:
+    if not isinstance(value, list | tuple):
+        raise ValueError(f"{field} must be a string list or tuple")
+    return _string_tuple(tuple(value), field=field)
+
+
 def _positive_temperature(value: object, *, field: str) -> float:
     if (
         isinstance(value, bool)
@@ -52,6 +67,12 @@ def _positive_temperature(value: object, *, field: str) -> float:
     ):
         raise ValueError(f"{field} must be finite and positive")
     return float(value)
+
+
+def _positive_symbol_count(value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError("sequence architecture n_symbols must be a positive integer")
+    return value
 
 
 def current_weight_observation_identity(n_symbols: int) -> dict[str, object]:
@@ -137,43 +158,76 @@ def _policy_architecture_payload(
     }
 
 
+def _validated_sequence_architecture(value: object, *, digest: object) -> dict[str, object]:
+    if not isinstance(value, Mapping) or not value:
+        raise ValueError("sequence architecture identity is missing")
+    payload = dict(value)
+    if not isinstance(digest, str) or digest != content_digest(payload):
+        raise ValueError("sequence architecture identity digest mismatch")
+    if payload.get("schema_version") != _SEQUENCE_ARCHITECTURE_SCHEMA:
+        raise ValueError("sequence architecture identity schema mismatch")
+    if payload.get("asset_identity_mode") != _ASSET_IDENTITY_MODE:
+        raise ValueError("sequence architecture asset identity mode mismatch")
+    _positive_symbol_count(payload.get("n_symbols"))
+    if "symbols" in payload or "action_names" in payload:
+        raise ValueError("sequence architecture must not bind concrete assets")
+    return payload
+
+
+def _validated_asset_binding(
+    value: object, *, digest: object, n_symbols: int
+) -> SequenceAssetBindingIdentity:
+    if not isinstance(value, Mapping) or not value:
+        raise ValueError("sequence asset binding identity is missing")
+    payload = dict(value)
+    if not isinstance(digest, str) or digest != content_digest(payload):
+        raise ValueError("sequence asset binding identity digest mismatch")
+    if payload.get("schema_version") != _SEQUENCE_ASSET_BINDING_SCHEMA:
+        raise ValueError("sequence asset binding schema mismatch")
+    symbols = _serialized_string_tuple(
+        payload.get("symbols"), field="sequence asset binding symbols"
+    )
+    action_names = _serialized_string_tuple(
+        payload.get("action_names"), field="sequence asset binding action names"
+    )
+    observed_count = payload.get("n_symbols")
+    if observed_count != n_symbols:
+        raise ValueError("sequence asset binding symbol count mismatch")
+    return SequenceAssetBindingIdentity(
+        n_symbols=n_symbols,
+        symbols=symbols,
+        action_names=action_names,
+    )
+
+
 def _validated_payload(value: object) -> dict[str, object]:
     if not isinstance(value, Mapping) or not value:
         raise ValueError("SB3 policy identity must be a non-empty mapping")
     payload = dict(value)
     schema = payload.get("schema_version")
-    if schema == LEGACY_SB3_POLICY_IDENTITY_SCHEMA:
-        raise ValueError(
-            f"migrate {LEGACY_SB3_POLICY_IDENTITY_SCHEMA} to "
-            f"{SB3_POLICY_IDENTITY_SCHEMA}"
-        )
+    if schema in LEGACY_SB3_POLICY_IDENTITY_SCHEMAS:
+        raise ValueError(f"migrate {schema} to {SB3_POLICY_IDENTITY_SCHEMA}")
     if schema != SB3_POLICY_IDENTITY_SCHEMA:
         raise ValueError("unsupported SB3 policy identity schema")
     encoder = payload.get("observation_encoder")
     if encoder not in {"flat_mlp", "asset_set", "hierarchical_sequence_v2"}:
         raise ValueError("SB3 policy identity observation encoder is invalid")
     if encoder == "hierarchical_sequence_v2":
-        architecture = payload.get("sequence_architecture")
-        sequence_digest = payload.get("sequence_architecture_digest")
-        if not isinstance(architecture, Mapping) or not architecture:
-            raise ValueError("sequence architecture identity is missing")
-        architecture_payload = dict(architecture)
-        if not isinstance(sequence_digest, str) or sequence_digest != content_digest(
-            architecture_payload
-        ):
-            raise ValueError("sequence architecture identity digest mismatch")
-        for tuple_field in ("action_names", "symbols"):
-            raw_tuple = architecture_payload.get(tuple_field)
-            if isinstance(raw_tuple, list):
-                architecture_payload[tuple_field] = tuple(raw_tuple)
-        payload["sequence_architecture"] = architecture_payload
-        raw_symbols = architecture_payload.get("symbols")
-        symbols = _string_tuple(
-            tuple(raw_symbols)
-            if isinstance(raw_symbols, list | tuple)
-            else raw_symbols,
-            field="sequence architecture symbols",
+        architecture_payload = _validated_sequence_architecture(
+            payload.get("sequence_architecture"),
+            digest=payload.get("sequence_architecture_digest"),
         )
+        sequence_digest = payload["sequence_architecture_digest"]
+        assert isinstance(sequence_digest, str)
+        payload["sequence_architecture"] = architecture_payload
+        n_symbols = _positive_symbol_count(architecture_payload.get("n_symbols"))
+        binding = _validated_asset_binding(
+            payload.get("asset_binding"),
+            digest=payload.get("asset_binding_digest"),
+            n_symbols=n_symbols,
+        )
+        payload["asset_binding"] = binding.digest_payload()
+        payload["asset_binding_digest"] = binding.digest
         actor_head = payload.get("actor_head")
         if actor_head != HIERARCHICAL_ACTOR_HEAD:
             raise ValueError("hierarchical actor-head identity mismatch")
@@ -181,7 +235,7 @@ def _validated_payload(value: object) -> dict[str, object]:
             payload.get("gate_temperature"), field="gate_temperature"
         )
         current_weight = _validated_current_weight_identity(
-            payload.get("current_weight_observation"), n_symbols=len(symbols)
+            payload.get("current_weight_observation"), n_symbols=n_symbols
         )
         exploration = _validated_hierarchical_exploration(
             payload.get("exploration_contract")
@@ -205,6 +259,8 @@ def _validated_payload(value: object) -> dict[str, object]:
         key in payload
         for key in (
             "actor_head",
+            "asset_binding",
+            "asset_binding_digest",
             "current_weight_observation",
             "exploration_contract",
             "gate_temperature",
@@ -231,7 +287,8 @@ def _actual_sequence_architecture(model: object) -> SequencePolicyArchitecture:
 
 
 def bind_sb3_policy_identity(model: Any, assembly: object) -> dict[str, object]:
-    """Bind the actual assembled encoder and actor identity to an SB3 model."""
+    """Bind actual model structure and the exact runtime asset mapping."""
+
     encoder = getattr(assembly, "observation_encoder", None)
     if encoder not in {"flat_mlp", "asset_set", "hierarchical_sequence_v2"}:
         raise ValueError("SB3 assembly observation encoder is invalid")
@@ -247,8 +304,10 @@ def bind_sb3_policy_identity(model: Any, assembly: object) -> dict[str, object]:
             getattr(assembly, "sequence_action_names", None),
             field="sequence_action_names",
         )
-        identity = sequence_architecture_identity(
-            _actual_sequence_architecture(model),
+        architecture = _actual_sequence_architecture(model)
+        identity = sequence_architecture_identity(architecture)
+        binding = sequence_asset_binding_identity(
+            n_symbols=architecture.n_symbols,
             symbols=symbols,
             action_names=action_names,
         )
@@ -269,7 +328,7 @@ def bind_sb3_policy_identity(model: Any, assembly: object) -> dict[str, object]:
             actual_temperature, expected_temperature, rel_tol=0.0, abs_tol=1e-12
         ):
             raise ValueError("hierarchical gate-temperature assembly identity mismatch")
-        current_weight = current_weight_observation_identity(len(symbols))
+        current_weight = current_weight_observation_identity(architecture.n_symbols)
         exploration = _actual_hierarchical_exploration(policy)
         policy_architecture = _policy_architecture_payload(
             actor_head=actual_head,
@@ -281,6 +340,8 @@ def bind_sb3_policy_identity(model: Any, assembly: object) -> dict[str, object]:
         payload.update(
             {
                 "actor_head": actual_head,
+                "asset_binding": binding.digest_payload(),
+                "asset_binding_digest": binding.digest,
                 "current_weight_observation": current_weight,
                 "exploration_contract": exploration,
                 "gate_temperature": actual_temperature,
@@ -296,6 +357,7 @@ def bind_sb3_policy_identity(model: Any, assembly: object) -> dict[str, object]:
 
 def validated_sb3_policy_identity(value: object) -> dict[str, object]:
     """Validate and copy one serialized policy identity payload."""
+
     return dict(_validated_payload(value))
 
 
@@ -304,6 +366,22 @@ def model_sb3_policy_identity(model: object) -> dict[str, object] | None:
     if raw is None:
         return None
     return _validated_payload(raw)
+
+
+def validate_sb3_policy_architecture_compatibility(
+    observed: Mapping[str, object], expected: Mapping[str, object]
+) -> None:
+    """Allow a new asset binding only when model structure is identical."""
+
+    observed_payload = _validated_payload(observed)
+    expected_payload = _validated_payload(expected)
+    if (
+        observed_payload.get("observation_encoder")
+        != expected_payload.get("observation_encoder")
+        or observed_payload.get("policy_architecture_digest")
+        != expected_payload.get("policy_architecture_digest")
+    ):
+        raise ValueError("SB3 policy architecture compatibility mismatch")
 
 
 def validate_model_sb3_policy_identity(
@@ -322,6 +400,7 @@ __all__ = [
     "HIERARCHICAL_EXPLORATION_COUPLING",
     "HIERARCHICAL_EXPLORATION_SCHEMA",
     "HIERARCHICAL_LOG_STD_PARAMETERIZATION",
+    "LEGACY_SB3_POLICY_IDENTITY_SCHEMAS",
     "POLICY_ARCHITECTURE_SCHEMA",
     "SB3_POLICY_IDENTITY_ATTRIBUTE",
     "SB3_POLICY_IDENTITY_SCHEMA",
@@ -329,5 +408,6 @@ __all__ = [
     "current_weight_observation_identity",
     "model_sb3_policy_identity",
     "validate_model_sb3_policy_identity",
+    "validate_sb3_policy_architecture_compatibility",
     "validated_sb3_policy_identity",
 ]

--- a/trade_rl/rl/policy_identity.py
+++ b/trade_rl/rl/policy_identity.py
@@ -158,7 +158,9 @@ def _policy_architecture_payload(
     }
 
 
-def _validated_sequence_architecture(value: object, *, digest: object) -> dict[str, object]:
+def _validated_sequence_architecture(
+    value: object, *, digest: object
+) -> dict[str, object]:
     if not isinstance(value, Mapping) or not value:
         raise ValueError("sequence architecture identity is missing")
     payload = dict(value)
@@ -375,11 +377,10 @@ def validate_sb3_policy_architecture_compatibility(
 
     observed_payload = _validated_payload(observed)
     expected_payload = _validated_payload(expected)
-    if (
-        observed_payload.get("observation_encoder")
-        != expected_payload.get("observation_encoder")
-        or observed_payload.get("policy_architecture_digest")
-        != expected_payload.get("policy_architecture_digest")
+    if observed_payload.get("observation_encoder") != expected_payload.get(
+        "observation_encoder"
+    ) or observed_payload.get("policy_architecture_digest") != expected_payload.get(
+        "policy_architecture_digest"
     ):
         raise ValueError("SB3 policy architecture compatibility mismatch")
 

--- a/trade_rl/rl/sequence_architecture.py
+++ b/trade_rl/rl/sequence_architecture.py
@@ -133,10 +133,14 @@ class SequenceAssetBindingIdentity:
             self.action_names, field="asset binding action names"
         )
         if len(symbols) != self.n_symbols or len(action_names) != self.n_symbols:
-            raise ValueError("asset binding symbol and action counts must match n_symbols")
+            raise ValueError(
+                "asset binding symbol and action counts must match n_symbols"
+            )
         expected = tuple(f"target_weight:{symbol}" for symbol in symbols)
         if action_names != expected:
-            raise ValueError("asset binding requires ordered target-weight action names")
+            raise ValueError(
+                "asset binding requires ordered target-weight action names"
+            )
         object.__setattr__(self, "symbols", symbols)
         object.__setattr__(self, "action_names", action_names)
 

--- a/trade_rl/rl/sequence_architecture.py
+++ b/trade_rl/rl/sequence_architecture.py
@@ -1,4 +1,4 @@
-"""Immutable identity for the maintained hierarchical sequence policy."""
+"""Immutable identities for the maintained hierarchical sequence policy."""
 
 from __future__ import annotations
 
@@ -11,7 +11,8 @@ if TYPE_CHECKING:
     from trade_rl.rl.sequence_policy import SequencePolicyArchitecture
 
 _TIMEFRAMES = ("15m", "1h", "4h", "1d")
-_SCHEMA = "hierarchical_sequence_policy_v3"
+_ARCHITECTURE_SCHEMA = "hierarchical_sequence_policy_v4"
+_ASSET_BINDING_SCHEMA = "sequence_asset_binding_v1"
 _ASSET_IDENTITY_MODE = "identity_free_v1"
 
 
@@ -26,9 +27,17 @@ def _required_dilations(window_length: int) -> tuple[int, ...]:
     return tuple(dilations)
 
 
+def _string_tuple(values: tuple[str, ...], *, field: str) -> tuple[str, ...]:
+    if not values or any(not isinstance(value, str) or not value for value in values):
+        raise ValueError(f"{field} must be a non-empty string tuple")
+    if len(set(values)) != len(values):
+        raise ValueError(f"{field} must be unique")
+    return tuple(values)
+
+
 @dataclass(frozen=True, slots=True)
 class SequenceArchitectureIdentity:
-    """Content-addressed model semantics required for exact artifact loading."""
+    """Content-addressed model structure independent of concrete symbol names."""
 
     input_channels: tuple[int, ...]
     window_lengths: tuple[int, ...]
@@ -48,14 +57,12 @@ class SequenceArchitectureIdentity:
     asset_ffn_multiplier: int
     asset_gate_bias: float
     dropout: float
-    symbols: tuple[str, ...]
-    action_names: tuple[str, ...]
     asset_identity_mode: str = _ASSET_IDENTITY_MODE
     timeframes: tuple[str, ...] = _TIMEFRAMES
-    schema_version: str = _SCHEMA
+    schema_version: str = _ARCHITECTURE_SCHEMA
 
     def __post_init__(self) -> None:
-        if self.schema_version != _SCHEMA:
+        if self.schema_version != _ARCHITECTURE_SCHEMA:
             raise ValueError("unsupported sequence architecture identity schema")
         if self.asset_identity_mode != _ASSET_IDENTITY_MODE:
             raise ValueError("sequence architecture asset identity mode is invalid")
@@ -71,24 +78,14 @@ class SequenceArchitectureIdentity:
         ):
             if len(values) != width:
                 raise ValueError(f"{field_name} must match maintained timeframes")
-        if (
-            len(self.symbols) != self.n_symbols
-            or len(self.action_names) != self.n_symbols
-        ):
-            raise ValueError("symbol and action counts must match n_symbols")
-        if not self.symbols or any(not value for value in self.symbols):
-            raise ValueError("symbols must be non-empty")
-        if len(set(self.symbols)) != len(self.symbols):
-            raise ValueError("symbols must be unique")
-        if any(not value for value in self.action_names):
-            raise ValueError("action names must be non-empty")
+        if isinstance(self.n_symbols, bool) or self.n_symbols <= 0:
+            raise ValueError("n_symbols must be a positive integer")
         for window, dilations in zip(self.window_lengths, self.dilations, strict=True):
             if 1 + 2 * sum(dilations) < window:
                 raise ValueError("dilation schedule does not cover declared window")
 
     def digest_payload(self) -> dict[str, object]:
         return {
-            "action_names": self.action_names,
             "asset_attention_heads": self.asset_attention_heads,
             "asset_attention_layers": self.asset_attention_layers,
             "asset_ffn_multiplier": self.asset_ffn_multiplier,
@@ -104,7 +101,6 @@ class SequenceArchitectureIdentity:
             "n_symbols": self.n_symbols,
             "schema_version": self.schema_version,
             "snapshot_width": self.snapshot_width,
-            "symbols": self.symbols,
             "timeframe_attention_heads": self.timeframe_attention_heads,
             "timeframe_attention_layers": self.timeframe_attention_layers,
             "timeframe_ffn_multiplier": self.timeframe_ffn_multiplier,
@@ -118,13 +114,49 @@ class SequenceArchitectureIdentity:
         return content_digest(self.digest_payload())
 
 
+@dataclass(frozen=True, slots=True)
+class SequenceAssetBindingIdentity:
+    """Exact runtime mapping between asset slots, symbols, and actions."""
+
+    n_symbols: int
+    symbols: tuple[str, ...]
+    action_names: tuple[str, ...]
+    schema_version: str = _ASSET_BINDING_SCHEMA
+
+    def __post_init__(self) -> None:
+        if self.schema_version != _ASSET_BINDING_SCHEMA:
+            raise ValueError("unsupported sequence asset binding schema")
+        if isinstance(self.n_symbols, bool) or self.n_symbols <= 0:
+            raise ValueError("asset binding n_symbols must be a positive integer")
+        symbols = _string_tuple(self.symbols, field="asset binding symbols")
+        action_names = _string_tuple(
+            self.action_names, field="asset binding action names"
+        )
+        if len(symbols) != self.n_symbols or len(action_names) != self.n_symbols:
+            raise ValueError("asset binding symbol and action counts must match n_symbols")
+        expected = tuple(f"target_weight:{symbol}" for symbol in symbols)
+        if action_names != expected:
+            raise ValueError("asset binding requires ordered target-weight action names")
+        object.__setattr__(self, "symbols", symbols)
+        object.__setattr__(self, "action_names", action_names)
+
+    def digest_payload(self) -> dict[str, object]:
+        return {
+            "action_names": self.action_names,
+            "n_symbols": self.n_symbols,
+            "schema_version": self.schema_version,
+            "symbols": self.symbols,
+        }
+
+    @property
+    def digest(self) -> str:
+        return content_digest(self.digest_payload())
+
+
 def sequence_architecture_identity(
     architecture: SequencePolicyArchitecture,
-    *,
-    symbols: tuple[str, ...],
-    action_names: tuple[str, ...],
 ) -> SequenceArchitectureIdentity:
-    """Build an exact immutable identity from one validated architecture."""
+    """Build an immutable symbol-agnostic identity from one architecture."""
 
     if tuple(architecture.input_channels) != _TIMEFRAMES:
         raise ValueError("architecture must use ordered 15m/1h/4h/1d clocks")
@@ -153,9 +185,27 @@ def sequence_architecture_identity(
         asset_ffn_multiplier=architecture.asset_ffn_multiplier,
         asset_gate_bias=architecture.asset_gate_bias,
         dropout=architecture.dropout,
-        symbols=tuple(symbols),
-        action_names=tuple(action_names),
     )
 
 
-__all__ = ["SequenceArchitectureIdentity", "sequence_architecture_identity"]
+def sequence_asset_binding_identity(
+    *,
+    n_symbols: int,
+    symbols: tuple[str, ...],
+    action_names: tuple[str, ...],
+) -> SequenceAssetBindingIdentity:
+    """Build the exact symbol/action binding kept outside model structure."""
+
+    return SequenceAssetBindingIdentity(
+        n_symbols=n_symbols,
+        symbols=symbols,
+        action_names=action_names,
+    )
+
+
+__all__ = [
+    "SequenceArchitectureIdentity",
+    "SequenceAssetBindingIdentity",
+    "sequence_architecture_identity",
+    "sequence_asset_binding_identity",
+]


### PR DESCRIPTION
## Stage A3

- separates symbol-agnostic sequence model structure from the exact runtime symbol/action binding
- introduces content-addressed `sequence_asset_binding_v1`
- advances sequence architecture identity to `hierarchical_sequence_policy_v4`
- advances SB3 policy identity to `sb3_policy_identity_v4`
- keeps exact checkpoint and serving identity checks fail-closed
- adds a narrower architecture-compatibility check for zero-shot rebinding across symbol sets
- requires ordered `target_weight:{symbol}` bindings and rejects malformed mappings
- migrates SB3 serving, structured serving, and structured export fixtures to the new contract

## TDD evidence

- the clean branch starts from the merged Stage A2 main commit
- new tests prove identical structures keep the same architecture digest across different symbols
- separate binding digests change when the runtime symbol set changes
- exact model identity still rejects a different binding
- compatibility validation rejects genuine encoder/actor architecture drift

This PR runs the complete CI and sequence projection stability suites against an A3-only nine-file diff.