### PR TITLE
Remove symbol identity leakage from PostgreSQL policy features

### DIFF
--- a/tests/integrations/test_postgres_identity_free_features.py
+++ b/tests/integrations/test_postgres_identity_free_features.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import numpy as np
+
+from trade_rl.integrations.binance import binance_multitimeframe_feature_specs
+from trade_rl.integrations.postgres_indicator_artifacts import (
+    NativeIndicatorArtifact,
+    NativeIndicatorArtifactBundle,
+)
+from trade_rl.integrations.postgres_market_dataset import (
+    NATIVE_TIMEFRAMES,
+    _align_indicators,
+)
+
+
+def _bundle(symbols: tuple[str, ...], timestamps_ms: np.ndarray) -> NativeIndicatorArtifactBundle:
+    specs = binance_multitimeframe_feature_specs(
+        base_timeframe="15m", feature_timeframes=("1h", "4h", "1d")
+    )
+    artifacts: list[NativeIndicatorArtifact] = []
+    for symbol_index, symbol in enumerate(symbols):
+        for timeframe in NATIVE_TIMEFRAMES:
+            names = tuple(
+                spec.name for spec in specs if spec.name.startswith(f"{timeframe}__")
+            )
+            values = np.full(
+                (len(timestamps_ms), len(names)),
+                float(symbol_index + 1),
+                dtype=np.float32,
+            )
+            artifacts.append(
+                NativeIndicatorArtifact(
+                    symbol=symbol,
+                    timeframe=timeframe,
+                    feature_names=names,
+                    event_time_ms=timestamps_ms.copy(),
+                    values=values,
+                    available=np.ones(values.shape, dtype=np.bool_),
+                    payload_schema=f"npz_native_indicator_v1:{'1' * 64}",
+                    payload_sha256=f"{symbol_index + 1:064x}",
+                )
+            )
+    return NativeIndicatorArtifactBundle(
+        cache_id="cache",
+        market="usds-m",
+        symbols=symbols,
+        timeframes=NATIVE_TIMEFRAMES,
+        start_time=datetime(2021, 1, 1, tzinfo=UTC),
+        end_time=datetime(2026, 7, 1, tzinfo=UTC),
+        feature_config_digest="2" * 64,
+        artifacts=tuple(artifacts),
+    )
+
+
+def test_postgres_policy_features_do_not_encode_symbol_vocabulary() -> None:
+    symbols = ("SOLUSDT", "ETHUSDT", "BNBUSDT")
+    timestamps_ms = 1_704_067_200_000 + np.arange(4, dtype=np.int64) * 900_000
+    bundle = _bundle(symbols, timestamps_ms)
+    first_vocabulary = (
+        "BTCUSDT",
+        "ETHUSDT",
+        "BNBUSDT",
+        "SOLUSDT",
+        "XRPUSDT",
+    )
+    second_vocabulary = tuple(reversed(first_vocabulary))
+
+    first = _align_indicators(
+        bundle,
+        timestamps_ms=timestamps_ms,
+        symbol_vocabulary=first_vocabulary,
+    )
+    second = _align_indicators(
+        bundle,
+        timestamps_ms=timestamps_ms,
+        symbol_vocabulary=second_vocabulary,
+    )
+
+    first_values, first_available, first_age, first_staleness, names, digest = first
+    second_values, second_available, second_age, second_staleness, other_names, other_digest = second
+
+    assert len(names) == 226
+    assert names == other_names
+    assert not any("symbol_id" in name for name in names)
+    assert digest == other_digest
+    np.testing.assert_array_equal(first_values, second_values)
+    np.testing.assert_array_equal(first_available, second_available)
+    np.testing.assert_array_equal(first_age, second_age)
+    np.testing.assert_array_equal(first_staleness, second_staleness)

--- a/tests/integrations/test_postgres_identity_free_features.py
+++ b/tests/integrations/test_postgres_identity_free_features.py
@@ -15,7 +15,9 @@ from trade_rl.integrations.postgres_market_dataset import (
 )
 
 
-def _bundle(symbols: tuple[str, ...], timestamps_ms: np.ndarray) -> NativeIndicatorArtifactBundle:
+def _bundle(
+    symbols: tuple[str, ...], timestamps_ms: np.ndarray
+) -> NativeIndicatorArtifactBundle:
     specs = binance_multitimeframe_feature_specs(
         base_timeframe="15m", feature_timeframes=("1h", "4h", "1d")
     )
@@ -79,7 +81,14 @@ def test_postgres_policy_features_do_not_encode_symbol_vocabulary() -> None:
     )
 
     first_values, first_available, first_age, first_staleness, names, digest = first
-    second_values, second_available, second_age, second_staleness, other_names, other_digest = second
+    (
+        second_values,
+        second_available,
+        second_age,
+        second_staleness,
+        other_names,
+        other_digest,
+    ) = second
 
     assert len(names) == 226
     assert names == other_names

--- a/tests/integrations/test_postgres_market_dataset.py
+++ b/tests/integrations/test_postgres_market_dataset.py
@@ -22,6 +22,7 @@ from trade_rl.integrations.postgres_indicator_artifacts import (
 )
 from trade_rl.integrations.postgres_market_dataset import (
     NATIVE_TIMEFRAMES,
+    POLICY_ASSET_IDENTITY_MODE,
     build_postgres_market_dataset,
 )
 
@@ -208,7 +209,7 @@ def _raw_source(symbols: tuple[str, ...], start: datetime) -> InMemoryMarketData
     return InMemoryMarketDataSource(values)
 
 
-def test_builds_btc_free_triplet_with_stable_symbol_identity() -> None:
+def test_builds_btc_free_triplet_with_identity_free_policy_features() -> None:
     symbols = ("SOLUSDT", "ETHUSDT", "BNBUSDT")
     vocabulary = (
         "BTCUSDT",
@@ -234,16 +235,11 @@ def test_builds_btc_free_triplet_with_stable_symbol_identity() -> None:
         slot_symbols=("SLOT0", "SLOT1", "SLOT2"),
     )
 
+    assert POLICY_ASSET_IDENTITY_MODE == "identity_free_v1"
     assert dataset.symbols == ("SLOT0", "SLOT1", "SLOT2")
-    assert dataset.n_features == 226 + len(vocabulary)
+    assert dataset.n_features == 226
     assert dataset.identity_verified
-    assert dataset.feature_names[-5:] == tuple(
-        f"15m__symbol_id_{symbol}" for symbol in vocabulary
-    )
-    identity = dataset.features[:, :, -5:]
-    np.testing.assert_array_equal(identity[0, 0], [0, 0, 0, 0, 0])
-    np.testing.assert_array_equal(identity[1, 0], [0, 0, 0, 1, 0])
-    np.testing.assert_array_equal(identity[0, 1], [0, 1, 0, 0, 0])
+    assert not any("symbol_id" in name for name in dataset.feature_names)
     np.testing.assert_array_equal(
         dataset.symbol_active[:, 0], [False, True, True, True]
     )

--- a/trade_rl/integrations/postgres_market_dataset.py
+++ b/trade_rl/integrations/postgres_market_dataset.py
@@ -30,7 +30,7 @@ KLINE_TABLE: Final = "market_raw.binance_usds_m_klines_202101_202606"
 FUNDING_TABLE: Final = "market_raw.binance_usds_m_funding_202101_202606"
 BASE_TIMEFRAME: Final = "15m"
 NATIVE_TIMEFRAMES: Final = ("15m", "1h", "4h", "1d")
-SYMBOL_IDENTITY_SCHEMA: Final = "stable_symbol_identity_v1"
+POLICY_ASSET_IDENTITY_MODE: Final = "identity_free_v1"
 _STEP_MS: Final = 15 * 60 * 1000
 _MS_PER_HOUR: Final = 60 * 60 * 1000
 _ZERO_DIGEST: Final = "0" * 64
@@ -245,19 +245,20 @@ def _align_indicators(
     tuple[str, ...],
     str,
 ]:
+    vocabulary = _ordered_unique(symbol_vocabulary, field="symbol_vocabulary")
+    if not set(bundle.symbols) <= set(vocabulary):
+        raise ValueError("indicator symbols must belong to symbol_vocabulary")
     specs = _feature_specs()
     spec_by_name = {spec.name: spec for spec in specs}
-    native_names = tuple(
+    feature_names = tuple(
         name
         for timeframe in NATIVE_TIMEFRAMES
         for name in bundle.get(bundle.symbols[0], timeframe).feature_names
     )
-    if native_names != tuple(spec.name for spec in specs):
+    if feature_names != tuple(spec.name for spec in specs):
         raise ValueError(
             "PostgreSQL indicator feature order differs from code contract"
         )
-    identity_names = tuple(f"15m__symbol_id_{symbol}" for symbol in symbol_vocabulary)
-    feature_names = (*native_names, *identity_names)
     shape = (len(timestamps_ms), len(bundle.symbols), len(feature_names))
     values = np.zeros(shape, dtype=np.float32)
     available = np.zeros(shape, dtype=np.bool_)
@@ -303,19 +304,12 @@ def _align_indicators(
                 )
         offset += len(names)
 
-    vocabulary_index = {symbol: index for index, symbol in enumerate(symbol_vocabulary)}
-    identity_offset = len(native_names)
-    for slot, symbol in enumerate(bundle.symbols):
-        identity_index = vocabulary_index[symbol]
-        values[:, slot, identity_offset + identity_index] = 1.0
-    available[:, :, identity_offset:] = True
-    staleness[:, :, identity_offset:] = 0.0
     feature_digest = content_digest(
         {
-            "indicator_feature_config_digest": bundle.feature_config_digest,
-            "schema_version": SYMBOL_IDENTITY_SCHEMA,
-            "symbol_vocabulary": symbol_vocabulary,
+            "asset_identity_mode": POLICY_ASSET_IDENTITY_MODE,
             "feature_names": feature_names,
+            "indicator_feature_config_digest": bundle.feature_config_digest,
+            "schema_version": "postgres_indicator_alignment_v2",
         }
     )
     return values, available, age_hours, staleness, feature_names, feature_digest
@@ -336,7 +330,7 @@ def build_postgres_market_dataset(
     slot_symbols: Sequence[str] | None = None,
     symbol_triplet_provenance: Mapping[str, object] | None = None,
 ) -> MarketDataset:
-    """Build one three-slot dataset without requiring BTC to be a traded symbol."""
+    """Build one identity-free three-slot dataset from selected market symbols."""
 
     selected = _ordered_unique(symbols, field="symbols")
     if len(selected) != 3:
@@ -462,8 +456,9 @@ def build_postgres_market_dataset(
 
     normalization_digest = content_and_arrays_digest(
         {
+            "asset_identity_mode": POLICY_ASSET_IDENTITY_MODE,
             "feature_config_digest": feature_config_digest,
-            "schema_version": "postgres_indicator_alignment_v1",
+            "schema_version": "postgres_indicator_alignment_v2",
         },
         (
             ("features", features),
@@ -533,8 +528,9 @@ def build_postgres_market_dataset(
             "kline_table": KLINE_TABLE,
             "funding_table": FUNDING_TABLE,
             "metadata_evidence_digest": metadata_evidence_digest,
+            "policy_asset_identity_mode": POLICY_ASSET_IDENTITY_MODE,
             "range": (start.isoformat(), end.isoformat()),
-            "schema_version": "postgres_dynamic_triplet_dataset_v1",
+            "schema_version": "postgres_dynamic_triplet_dataset_v2",
             "selected_symbols": selected,
             "slot_symbols": resolved_slots,
             "symbol_triplet": dict(symbol_triplet_provenance or {}),
@@ -548,6 +544,6 @@ __all__ = [
     "FUNDING_TABLE",
     "KLINE_TABLE",
     "NATIVE_TIMEFRAMES",
-    "SYMBOL_IDENTITY_SCHEMA",
+    "POLICY_ASSET_IDENTITY_MODE",
     "build_postgres_market_dataset",
 ]


### PR DESCRIPTION
## Stage A4.1

- removes all `15m__symbol_id_*` one-hot channels from PostgreSQL policy observations
- restores the maintained causal market feature contract to exactly 226 features
- keeps selected symbols and the full vocabulary only in dataset provenance and runtime Asset binding
- introduces `POLICY_ASSET_IDENTITY_MODE = "identity_free_v1"`
- advances indicator alignment and dynamic triplet dataset schemas to v2
- makes feature arrays and feature configuration digest independent of vocabulary ordering
- preserves availability, staleness, execution rules, funding, and economic-semantic parity

## TDD evidence

RED:
- the new regression test failed with `231 != 226`
- 1 failed, 2,343 passed, 2 skipped; coverage 83.74%

GREEN:
- the identity-free regression test passes
- the former symbol-identity test was migrated to the 226-feature contract
- final CI passed Ruff, Format, MyPy, import architecture, serving smoke, all tests and coverage, critical branch coverage, CLI smoke, Ubuntu and Windows compatibility, and the complete training image

Final verified head: `4aaf2d9956d6f66383581892d4d3732e8e4b6f1c`.