### PR TITLE
Add explicit cross-triplet checkpoint transfer

### DIFF
--- a/tests/integrations/test_sb3_checkpoint_transfer.py
+++ b/tests/integrations/test_sb3_checkpoint_transfer.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from trade_rl.artifacts.hashing import content_digest
+from trade_rl.integrations.sb3_model_assembly import SB3PolicyAssembly
+from trade_rl.rl.algorithm_configs import build_algorithm_config
+from trade_rl.rl.training import ResidualTrainingConfig
+
+
+def _config(**changes: object) -> ResidualTrainingConfig:
+    payload: dict[str, object] = {
+        "timesteps": 8,
+        "gamma": 0.99,
+        "seeds": (0,),
+        "observation_encoder": "hierarchical_sequence_v2",
+        "policy": "MultiInputPolicy",
+        "device": "cpu",
+    }
+    payload.update(changes)
+    return ResidualTrainingConfig(**payload)  # type: ignore[arg-type]
+
+
+def _policy(config: ResidualTrainingConfig) -> SB3PolicyAssembly:
+    return SB3PolicyAssembly(
+        policy_identifier=config.policy,
+        policy_kwargs={"net_arch": {"pi": [128], "vf": [128]}},
+        rollout_buffer_bytes=None,
+        sequence_metadata=None,
+        sequence_reconstructor=None,
+        uses_shared_asset_actor=True,
+    )
+
+
+def _checkpoint_identity(binding: str) -> dict[str, object]:
+    return {
+        "schema_version": "sb3_checkpoint_identity_v2",
+        "policy": {
+            "schema_version": "sb3_policy_identity_v4",
+            "observation_encoder": "hierarchical_sequence_v2",
+            "policy_architecture_digest": "a" * 64,
+            "asset_binding_digest": binding * 64,
+        },
+        "algorithm": {"schema_version": "ppo_identity_v1"},
+    }
+
+
+def _manifest(config: ResidualTrainingConfig, **changes: object) -> SimpleNamespace:
+    identity = _checkpoint_identity("b")
+    payload: dict[str, object] = {
+        "algorithm": config.algorithm,
+        "seed": 7,
+        "environment_digest": "s" * 64,
+        "training_config_digest": content_digest(config.digest_payload()),
+        "policy_path": Path("/tmp/policy.zip"),
+        "observed_timestep": 12,
+        "algorithm_identity": identity,
+        "algorithm_identity_digest": content_digest(identity),
+    }
+    payload.update(changes)
+    return SimpleNamespace(**payload)
+
+
+def test_transfer_loader_accepts_new_environment_with_compatible_architecture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import trade_rl.integrations.sb3_checkpoint_assembly as assembly_module
+    from trade_rl.integrations.sb3_checkpoint_assembly import (
+        load_sb3_checkpoint_transfer_model,
+    )
+
+    config = _config()
+    manifest = _manifest(config)
+    source_identity = manifest.algorithm_identity
+    target_identity = _checkpoint_identity("c")
+    loaded_model = SimpleNamespace(num_timesteps=12)
+    compatibility_calls: list[tuple[object, object]] = []
+    load_calls: list[tuple[str, object, str]] = []
+
+    monkeypatch.setattr(assembly_module, "load_checkpoint_manifest", lambda _: manifest)
+    monkeypatch.setattr(
+        assembly_module,
+        "checkpoint_identity_payload_for_model",
+        lambda _: target_identity,
+    )
+    monkeypatch.setattr(
+        assembly_module,
+        "validate_sb3_policy_architecture_compatibility",
+        lambda observed, expected: compatibility_calls.append((observed, expected)),
+    )
+    monkeypatch.setattr(
+        assembly_module,
+        "bind_sb3_policy_identity",
+        lambda model, policy: target_identity["policy"],
+    )
+
+    class Loader:
+        @staticmethod
+        def load(path: str, *, env: object, device: str) -> object:
+            load_calls.append((path, env, device))
+            return loaded_model
+
+    monkeypatch.setattr(assembly_module, "_checkpoint_loader", lambda _: Loader)
+    environment = object()
+
+    result = load_sb3_checkpoint_transfer_model(
+        checkpoint_root=Path("checkpoint.json"),
+        environment=environment,
+        seed=7,
+        config=config,
+        identity={"environment_digest": "t" * 64},
+        algorithm_config=build_algorithm_config(config),
+        policy=_policy(config),
+        fresh_model=SimpleNamespace(),
+    )
+
+    assert result.model is loaded_model
+    assert result.manifest is manifest
+    assert load_calls == [(str(manifest.policy_path), environment, "cpu")]
+    assert compatibility_calls == [
+        (source_identity["policy"], target_identity["policy"]),
+        (source_identity["policy"], target_identity["policy"]),
+    ]
+
+
+def test_transfer_loader_rejects_same_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import trade_rl.integrations.sb3_checkpoint_assembly as assembly_module
+    from trade_rl.integrations.sb3_checkpoint_assembly import (
+        load_sb3_checkpoint_transfer_model,
+    )
+
+    config = _config()
+    manifest = _manifest(config)
+    monkeypatch.setattr(assembly_module, "load_checkpoint_manifest", lambda _: manifest)
+
+    with pytest.raises(ValueError, match="different environment"):
+        load_sb3_checkpoint_transfer_model(
+            checkpoint_root=Path("checkpoint.json"),
+            environment=object(),
+            seed=7,
+            config=config,
+            identity={"environment_digest": manifest.environment_digest},
+            algorithm_config=build_algorithm_config(config),
+            policy=_policy(config),
+            fresh_model=SimpleNamespace(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("change", "message"),
+    (
+        ({"algorithm": "sac"}, "checkpoint algorithm mismatch"),
+        ({"seed": 8}, "checkpoint seed mismatch"),
+        (
+            {"training_config_digest": "x" * 64},
+            "checkpoint training configuration mismatch",
+        ),
+    ),
+)
+def test_transfer_loader_rejects_non_environment_identity_mismatch(
+    change: dict[str, object],
+    message: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import trade_rl.integrations.sb3_checkpoint_assembly as assembly_module
+    from trade_rl.integrations.sb3_checkpoint_assembly import (
+        load_sb3_checkpoint_transfer_model,
+    )
+
+    config = _config()
+    monkeypatch.setattr(
+        assembly_module,
+        "load_checkpoint_manifest",
+        lambda _: _manifest(config, **change),
+    )
+
+    with pytest.raises(ValueError, match=message):
+        load_sb3_checkpoint_transfer_model(
+            checkpoint_root=Path("checkpoint.json"),
+            environment=object(),
+            seed=7,
+            config=config,
+            identity={"environment_digest": "t" * 64},
+            algorithm_config=build_algorithm_config(config),
+            policy=_policy(config),
+            fresh_model=SimpleNamespace(),
+        )
+
+
+def test_transfer_loader_rejects_algorithm_identity_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import trade_rl.integrations.sb3_checkpoint_assembly as assembly_module
+    from trade_rl.integrations.sb3_checkpoint_assembly import (
+        load_sb3_checkpoint_transfer_model,
+    )
+
+    config = _config()
+    manifest = _manifest(config)
+    target_identity = _checkpoint_identity("c")
+    target_identity["algorithm"] = {"schema_version": "other_algorithm_v1"}
+    monkeypatch.setattr(assembly_module, "load_checkpoint_manifest", lambda _: manifest)
+    monkeypatch.setattr(
+        assembly_module,
+        "checkpoint_identity_payload_for_model",
+        lambda _: target_identity,
+    )
+
+    with pytest.raises(ValueError, match="algorithm identity mismatch"):
+        load_sb3_checkpoint_transfer_model(
+            checkpoint_root=Path("checkpoint.json"),
+            environment=object(),
+            seed=7,
+            config=config,
+            identity={"environment_digest": "t" * 64},
+            algorithm_config=build_algorithm_config(config),
+            policy=_policy(config),
+            fresh_model=SimpleNamespace(),
+        )

--- a/tests/integrations/test_sb3_checkpoint_transfer.py
+++ b/tests/integrations/test_sb3_checkpoint_transfer.py
@@ -24,13 +24,17 @@ def _config(**changes: object) -> ResidualTrainingConfig:
     return ResidualTrainingConfig(**payload)  # type: ignore[arg-type]
 
 
-def _policy(config: ResidualTrainingConfig) -> SB3PolicyAssembly:
+def _policy(
+    config: ResidualTrainingConfig,
+    *,
+    sequence_reconstructor: object | None = None,
+) -> SB3PolicyAssembly:
     return SB3PolicyAssembly(
         policy_identifier=config.policy,
         policy_kwargs={"net_arch": {"pi": [128], "vf": [128]}},
         rollout_buffer_bytes=None,
         sequence_metadata=None,
-        sequence_reconstructor=None,
+        sequence_reconstructor=sequence_reconstructor,
         uses_shared_asset_actor=True,
     )
 
@@ -76,7 +80,22 @@ def test_transfer_loader_accepts_new_environment_with_compatible_architecture(
     manifest = _manifest(config)
     source_identity = manifest.algorithm_identity
     target_identity = _checkpoint_identity("c")
-    loaded_model = SimpleNamespace(num_timesteps=12)
+    reconstructor = object()
+    bound: list[tuple[object, str]] = []
+
+    def bind_sequence_reconstructor(
+        value: object,
+        *,
+        sequence_transfer_mode: str,
+    ) -> None:
+        bound.append((value, sequence_transfer_mode))
+
+    loaded_model = SimpleNamespace(
+        num_timesteps=12,
+        rollout_buffer=SimpleNamespace(
+            bind_sequence_reconstructor=bind_sequence_reconstructor
+        ),
+    )
     compatibility_calls: list[tuple[object, object]] = []
     load_calls: list[tuple[str, object, str]] = []
 
@@ -113,7 +132,7 @@ def test_transfer_loader_accepts_new_environment_with_compatible_architecture(
         config=config,
         identity={"environment_digest": "t" * 64},
         algorithm_config=build_algorithm_config(config),
-        policy=_policy(config),
+        policy=_policy(config, sequence_reconstructor=reconstructor),
         fresh_model=SimpleNamespace(),
     )
 
@@ -124,6 +143,11 @@ def test_transfer_loader_accepts_new_environment_with_compatible_architecture(
         (source_identity["policy"], target_identity["policy"]),
         (source_identity["policy"], target_identity["policy"]),
     ]
+    assert bound == [(reconstructor, config.sequence_transfer_mode)]
+    assert loaded_model.rollout_buffer_kwargs == {
+        "sequence_reconstructor": reconstructor,
+        "sequence_transfer_mode": config.sequence_transfer_mode,
+    }
 
 
 def test_transfer_loader_rejects_same_environment(
@@ -212,6 +236,44 @@ def test_transfer_loader_rejects_algorithm_identity_mismatch(
     )
 
     with pytest.raises(ValueError, match="algorithm identity mismatch"):
+        load_sb3_checkpoint_transfer_model(
+            checkpoint_root=Path("checkpoint.json"),
+            environment=object(),
+            seed=7,
+            config=config,
+            identity={"environment_digest": "t" * 64},
+            algorithm_config=build_algorithm_config(config),
+            policy=_policy(config),
+            fresh_model=SimpleNamespace(),
+        )
+
+
+def test_transfer_loader_rejects_policy_architecture_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import trade_rl.integrations.sb3_checkpoint_assembly as assembly_module
+    from trade_rl.integrations.sb3_checkpoint_assembly import (
+        load_sb3_checkpoint_transfer_model,
+    )
+
+    config = _config()
+    manifest = _manifest(config)
+    target_identity = _checkpoint_identity("c")
+    monkeypatch.setattr(assembly_module, "load_checkpoint_manifest", lambda _: manifest)
+    monkeypatch.setattr(
+        assembly_module,
+        "checkpoint_identity_payload_for_model",
+        lambda _: target_identity,
+    )
+    monkeypatch.setattr(
+        assembly_module,
+        "validate_sb3_policy_architecture_compatibility",
+        lambda observed, expected: (_ for _ in ()).throw(
+            ValueError("SB3 policy architecture compatibility mismatch")
+        ),
+    )
+
+    with pytest.raises(ValueError, match="architecture compatibility mismatch"):
         load_sb3_checkpoint_transfer_model(
             checkpoint_root=Path("checkpoint.json"),
             environment=object(),

--- a/trade_rl/integrations/sb3_checkpoint_assembly.py
+++ b/trade_rl/integrations/sb3_checkpoint_assembly.py
@@ -24,6 +24,10 @@ from trade_rl.rl.checkpointing import (
     load_checkpoint_manifest,
     validate_checkpoint_algorithm_identity,
 )
+from trade_rl.rl.policy_identity import (
+    bind_sb3_policy_identity,
+    validate_sb3_policy_architecture_compatibility,
+)
 from trade_rl.rl.training import ResidualTrainingConfig
 
 
@@ -76,6 +80,115 @@ def _checkpoint_loader(algorithm_config: AlgorithmConfig) -> object:
     return TQC
 
 
+def _manifest_path(checkpoint_root: Path) -> Path:
+    return (
+        checkpoint_root / CHECKPOINT_MANIFEST_NAME
+        if checkpoint_root.is_dir()
+        else checkpoint_root
+    )
+
+
+def _validate_checkpoint_run_identity(
+    manifest: CheckpointManifest,
+    *,
+    seed: int,
+    config: ResidualTrainingConfig,
+) -> None:
+    if manifest.algorithm != config.algorithm:
+        raise ValueError("checkpoint algorithm mismatch")
+    if manifest.seed != seed:
+        raise ValueError("checkpoint seed mismatch")
+    expected_training_digest = content_digest(config.digest_payload())
+    if manifest.training_config_digest != expected_training_digest:
+        raise ValueError("checkpoint training configuration mismatch")
+
+
+def _checkpoint_transfer_identity_parts(
+    value: object,
+    *,
+    field: str,
+) -> tuple[dict[str, object], dict[str, object] | None]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field} must be a checkpoint identity object")
+    payload = dict(value)
+    required = {"algorithm", "policy", "schema_version"}
+    if set(payload) != required:
+        raise ValueError(f"{field} field closure mismatch")
+    if payload.get("schema_version") != "sb3_checkpoint_identity_v2":
+        raise ValueError(f"{field} schema mismatch")
+    raw_policy = payload.get("policy")
+    if not isinstance(raw_policy, Mapping) or not raw_policy:
+        raise ValueError(f"{field} policy identity is missing")
+    raw_algorithm = payload.get("algorithm")
+    if raw_algorithm is None:
+        algorithm = None
+    elif isinstance(raw_algorithm, Mapping) and raw_algorithm:
+        algorithm = dict(raw_algorithm)
+    else:
+        raise ValueError(f"{field} algorithm identity is invalid")
+    return dict(raw_policy), algorithm
+
+
+def _validate_checkpoint_transfer_identity(
+    source: object,
+    target: object,
+) -> None:
+    source_policy, source_algorithm = _checkpoint_transfer_identity_parts(
+        source,
+        field="checkpoint transfer source identity",
+    )
+    target_policy, target_algorithm = _checkpoint_transfer_identity_parts(
+        target,
+        field="checkpoint transfer target identity",
+    )
+    if source_algorithm != target_algorithm:
+        raise ValueError("checkpoint transfer algorithm identity mismatch")
+    validate_sb3_policy_architecture_compatibility(source_policy, target_policy)
+
+
+def _bind_loaded_sequence_runtime(
+    model: Any,
+    *,
+    policy: SB3PolicyAssembly,
+    config: ResidualTrainingConfig,
+) -> None:
+    if config.observation_encoder != "hierarchical_sequence_v2":
+        return
+    reconstructor = policy.sequence_reconstructor
+    if reconstructor is None:
+        raise RuntimeError("sequence reconstructor was not resolved")
+    rollout_buffer = getattr(model, "rollout_buffer", None)
+    bind = getattr(rollout_buffer, "bind_sequence_reconstructor", None)
+    if not callable(bind):
+        raise ValueError("checkpoint rollout buffer cannot bind sequences")
+    bind(
+        reconstructor,
+        sequence_transfer_mode=config.sequence_transfer_mode,
+    )
+    model.rollout_buffer_kwargs = {
+        "sequence_reconstructor": reconstructor,
+        "sequence_transfer_mode": config.sequence_transfer_mode,
+    }
+
+
+def _load_checkpoint_model(
+    *,
+    manifest: CheckpointManifest,
+    environment: object,
+    config: ResidualTrainingConfig,
+    algorithm_config: AlgorithmConfig,
+) -> Any:
+    loader: Any = _checkpoint_loader(algorithm_config)
+    model: Any = loader.load(
+        str(manifest.policy_path),
+        env=environment,
+        device=config.device,
+    )
+    if int(model.num_timesteps) != manifest.observed_timestep:
+        raise ValueError("checkpoint timestep identity mismatch")
+    return model
+
+
 def load_sb3_checkpoint_model(
     *,
     checkpoint_root: Path,
@@ -87,57 +200,64 @@ def load_sb3_checkpoint_model(
     policy: SB3PolicyAssembly,
     fresh_model: Any,
 ) -> LoadedSB3Checkpoint:
-    """Load and validate one algorithm-matched SB3 checkpoint."""
+    """Load one exact-environment checkpoint for ordinary resume."""
 
-    manifest_path = (
-        checkpoint_root / CHECKPOINT_MANIFEST_NAME
-        if checkpoint_root.is_dir()
-        else checkpoint_root
-    )
-    manifest = load_checkpoint_manifest(manifest_path)
-    if manifest.algorithm != config.algorithm:
-        raise ValueError("checkpoint algorithm mismatch")
-    if manifest.seed != seed:
-        raise ValueError("checkpoint seed mismatch")
+    manifest = load_checkpoint_manifest(_manifest_path(checkpoint_root))
+    _validate_checkpoint_run_identity(manifest, seed=seed, config=config)
     if manifest.environment_digest != _environment_digest(identity):
         raise ValueError("checkpoint environment identity mismatch")
-    expected_training_digest = content_digest(config.digest_payload())
-    if manifest.training_config_digest != expected_training_digest:
-        raise ValueError("checkpoint training configuration mismatch")
     expected_algorithm_identity = _checkpoint_algorithm_identity(
         fresh_model, algorithm_config
     )
     validate_checkpoint_algorithm_identity(manifest, expected_algorithm_identity)
-    loader: Any = _checkpoint_loader(algorithm_config)
-    model: Any = loader.load(
-        str(manifest.policy_path),
-        env=environment,
-        device=config.device,
+    model = _load_checkpoint_model(
+        manifest=manifest,
+        environment=environment,
+        config=config,
+        algorithm_config=algorithm_config,
     )
-    if int(model.num_timesteps) != manifest.observed_timestep:
-        raise ValueError("checkpoint timestep identity mismatch")
-    from trade_rl.rl.policy_identity import bind_sb3_policy_identity
-
     bind_sb3_policy_identity(model, policy)
     loaded_identity = _checkpoint_algorithm_identity(model, algorithm_config)
     validate_checkpoint_algorithm_identity(manifest, loaded_identity)
-    if config.observation_encoder == "hierarchical_sequence_v2":
-        reconstructor = policy.sequence_reconstructor
-        if reconstructor is None:
-            raise RuntimeError("sequence reconstructor was not resolved")
-        rollout_buffer = getattr(model, "rollout_buffer", None)
-        bind = getattr(rollout_buffer, "bind_sequence_reconstructor", None)
-        if not callable(bind):
-            raise ValueError("checkpoint rollout buffer cannot bind sequences")
-        bind(
-            reconstructor,
-            sequence_transfer_mode=config.sequence_transfer_mode,
-        )
-        model.rollout_buffer_kwargs = {
-            "sequence_reconstructor": reconstructor,
-            "sequence_transfer_mode": config.sequence_transfer_mode,
-        }
+    _bind_loaded_sequence_runtime(model, policy=policy, config=config)
     return LoadedSB3Checkpoint(model=model, manifest=manifest)
 
 
-__all__ = ["LoadedSB3Checkpoint", "load_sb3_checkpoint_model"]
+def load_sb3_checkpoint_transfer_model(
+    *,
+    checkpoint_root: Path,
+    environment: object,
+    seed: int,
+    config: ResidualTrainingConfig,
+    identity: Mapping[str, object],
+    algorithm_config: AlgorithmConfig,
+    policy: SB3PolicyAssembly,
+    fresh_model: Any,
+) -> LoadedSB3Checkpoint:
+    """Load policy state into a different asset binding under strict compatibility."""
+
+    manifest = load_checkpoint_manifest(_manifest_path(checkpoint_root))
+    _validate_checkpoint_run_identity(manifest, seed=seed, config=config)
+    target_environment_digest = _environment_digest(identity)
+    if manifest.environment_digest == target_environment_digest:
+        raise ValueError("checkpoint transfer requires a different environment")
+    target_identity = _checkpoint_algorithm_identity(fresh_model, algorithm_config)
+    _validate_checkpoint_transfer_identity(manifest.algorithm_identity, target_identity)
+    model = _load_checkpoint_model(
+        manifest=manifest,
+        environment=environment,
+        config=config,
+        algorithm_config=algorithm_config,
+    )
+    bind_sb3_policy_identity(model, policy)
+    loaded_identity = _checkpoint_algorithm_identity(model, algorithm_config)
+    _validate_checkpoint_transfer_identity(manifest.algorithm_identity, loaded_identity)
+    _bind_loaded_sequence_runtime(model, policy=policy, config=config)
+    return LoadedSB3Checkpoint(model=model, manifest=manifest)
+
+
+__all__ = [
+    "LoadedSB3Checkpoint",
+    "load_sb3_checkpoint_model",
+    "load_sb3_checkpoint_transfer_model",
+]


### PR DESCRIPTION
## Stage A4.4.1

- keeps ordinary checkpoint resume environment-digest exact
- adds a separate cross-triplet checkpoint-transfer loader that requires a different environment digest
- keeps algorithm, seed, training configuration, and observed timestep exact
- compares source and target checkpoint algorithm identities exactly
- permits a new runtime asset binding only through the existing SB3 policy architecture-compatibility contract
- rebinds the target policy identity and target sequence reconstructor after loading
- validates transfer compatibility both before and after model loading

## TDD evidence

RED:
- Ruff, Format, MyPy, import architecture, compatibility, and Training image passed
- exactly six new tests failed because `load_sb3_checkpoint_transfer_model` did not exist
- 2,370 existing tests passed

GREEN:
- seven transfer tests cover successful asset-binding transfer, target runtime rebinding, same-environment rejection, algorithm/seed/training-config rejection, algorithm-identity rejection, and policy-architecture rejection
- full CI: 2,377 passed, 2 skipped
- total coverage: 83.69%
- Critical coverage, CLI smoke, Ubuntu/Windows compatibility, and Training image passed

The branch contains current main (`behind_by=0`) and changes only the transfer loader module and its tests.

Final verified head: `e419316e36f85a78c81ad218024bb82db2456f10`.