### PR TITLE
Connect cross-triplet transfer to the training backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,25 +1,32 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
+      - agent/causal-training-hardening
+      - agent/causal-sequence-feature-encoder
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  connect-transfer-backend:
-    name: Connect A4 transfer backend atomically
-    if: github.event.pull_request.head.ref == 'agent/stage-a4-transfer-training-backend'
+  quality:
+    name: Rebuilt Core
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout exact head with parent
+      - name: Checkout exact head
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 2
-          persist-credentials: true
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
 
       - name: Set up uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86
@@ -27,213 +34,209 @@ jobs:
           python-version: "3.12"
           enable-cache: true
 
-      - name: Patch backend, test, restore workflow, and commit
+      - name: Install
+        run: uv sync --extra dev --extra export --extra train-sb3 --extra studio
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: studio/package-lock.json
+
+      - name: Install Studio frontend
+        run: npm ci --prefix studio --no-audit --no-fund
+
+      - name: Verify Studio frontend
+        shell: bash
+        run: |
+          set -o pipefail
+          {
+            npm test --prefix studio -- --run
+            npm run typecheck --prefix studio
+            npm run build --prefix studio
+          } 2>&1 | tee studio-frontend.log
+
+      - name: Verify Studio fixed viewport layout
         env:
-          HEAD_BRANCH: ${{ github.head_ref }}
+          STUDIO_QA_OUTPUT_DIR: studio/qa-screenshots
+        run: npm run check:layout --prefix studio
+
+      - name: Upload Studio layout diagnostics
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: studio-layout-diagnostics
+          path: |
+            studio-frontend.log
+            studio/qa-screenshots
+          if-no-files-found: error
+
+      - name: Workflow security
+        run: uv run python .github/check_workflow_security.py .
+
+      - name: Ruff
+        shell: bash
+        run: |
+          set -o pipefail
+          uv run ruff check . 2>&1 | tee ruff.log
+
+      - name: Format
+        shell: bash
+        run: |
+          set -o pipefail
+          uv run ruff format --check --diff . 2>&1 | tee format.log
+
+      - name: Mypy
+        shell: bash
+        run: |
+          set -o pipefail
+          uv run mypy . 2>&1 | tee mypy.log
+
+      - name: Upload static diagnostics
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: static-diagnostics
+          path: |
+            ruff.log
+            format.log
+            mypy.log
+          if-no-files-found: ignore
+
+      - name: Import architecture
+        shell: bash
+        run: |
+          set -o pipefail
+          uv run lint-imports 2>&1 | tee import-linter.log
+
+      - name: Upload architecture diagnostics
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: architecture-diagnostics
+          path: import-linter.log
+          if-no-files-found: error
+
+      - name: Dead-code report
+        run: uv run vulture trade_rl tests --min-confidence 100
+
+      - name: Recovery and structured serving smoke
+        run: >-
+          uv run pytest -q
+          tests/integrations/test_sb3_training.py::test_backend_resumes_ppo_checkpoint_to_requested_total
+          tests/serving/test_sb3_loader.py::test_structured_sb3_loader_rebuilds_native_sequence_observation
+
+      - name: Tests and coverage
+        shell: bash
+        run: |
+          set -o pipefail
+          uv run pytest -q --cov=trade_rl --cov-branch --cov-report=term-missing --cov-report=json:coverage.json 2>&1 | tee pytest.log
+
+      - name: Upload pytest diagnostics
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: pytest-diagnostics
+          path: |
+            pytest.log
+            coverage.json
+          if-no-files-found: ignore
+
+      - name: Critical branch coverage
+        run: uv run python .github/check_critical_coverage.py coverage.json pyproject.toml
+
+      - name: CLI smoke test
+        run: uv run trade-rl --version
+
+  compatibility:
+    name: Compatibility (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout exact head
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86
+        with:
+          python-version: "3.12"
+          enable-cache: true
+      - run: uv sync --extra dev --extra train-sb3
+      - name: Compatibility tests
+        shell: bash
+        run: |
+          set -o pipefail
+          uv run pytest -q tests/data tests/simulation tests/evaluation tests/serving 2>&1 | tee compatibility.log
+      - name: Upload compatibility diagnostics
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: compatibility-${{ matrix.os }}
+          path: compatibility.log
+          if-no-files-found: error
+
+  training-image:
+    name: Training image
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout exact head
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Build complete training image
         shell: bash
         run: |
           set -euo pipefail
-          uv sync --extra dev --extra train-sb3
-          python - <<'PY'
-          from pathlib import Path
+          commit="$(git rev-parse HEAD)"
+          source_digest="$(python -c 'from trade_rl.artifacts.provenance import source_tree_digest; print(source_tree_digest("."))')"
+          lock_digest="$(sha256sum uv.lock | cut -d' ' -f1)"
+          docker build \
+            --build-arg TRADE_RL_GIT_COMMIT="$commit" \
+            --build-arg TRADE_RL_GIT_DIRTY=false \
+            --build-arg TRADE_RL_SOURCE_TREE_DIGEST="$source_digest" \
+            --build-arg TRADE_RL_LOCKFILE_DIGEST="$lock_digest" \
+            --file Dockerfile.training \
+            --tag trade-rl-training:ci \
+            .
 
-          path = Path("trade_rl/integrations/sb3_training.py")
-          content = path.read_text(encoding="utf-8")
-          replacements = (
-              (
-                  "from trade_rl.integrations.sb3_checkpoint_assembly import load_sb3_checkpoint_model\n",
-                  "from trade_rl.integrations.sb3_checkpoint_assembly import (\n"
-                  "    load_sb3_checkpoint_model,\n"
-                  "    load_sb3_checkpoint_transfer_model,\n"
-                  ")\n",
-              ),
-              (
-                  "        resume_replay_artifact: Path | None = None,\n"
-                  "        resume_checkpoint_artifacts: Mapping[int, Path] | None = None,\n"
-                  "        structured_export_enabled: bool = False,\n",
-                  "        resume_replay_artifact: Path | None = None,\n"
-                  "        resume_checkpoint_artifacts: Mapping[int, Path] | None = None,\n"
-                  "        transfer_checkpoint_artifacts: Mapping[int, Path] | None = None,\n"
-                  "        structured_export_enabled: bool = False,\n",
-              ),
-              (
-                  "        self.resume_replay_artifact = resume_replay_artifact\n"
-                  "        self.resume_checkpoint_artifacts = dict(resume_checkpoint_artifacts or {})\n"
-                  "        if not isinstance(structured_export_enabled, bool):\n",
-                  "        self.resume_replay_artifact = resume_replay_artifact\n"
-                  "        self.resume_checkpoint_artifacts = dict(resume_checkpoint_artifacts or {})\n"
-                  "        self.transfer_checkpoint_artifacts = dict(\n"
-                  "            transfer_checkpoint_artifacts or {}\n"
-                  "        )\n"
-                  "        overlapping_seeds = (\n"
-                  "            self.resume_checkpoint_artifacts.keys()\n"
-                  "            & self.transfer_checkpoint_artifacts.keys()\n"
-                  "        )\n"
-                  "        if overlapping_seeds:\n"
-                  "            raise ValueError(\n"
-                  "                \"checkpoint resume and transfer cannot target the same seed\"\n"
-                  "            )\n"
-                  "        if (\n"
-                  "            self.resume_replay_artifact is not None\n"
-                  "            and self.transfer_checkpoint_artifacts\n"
-                  "        ):\n"
-                  "            raise ValueError(\n"
-                  "                \"replay resume cannot be combined with checkpoint transfer\"\n"
-                  "            )\n"
-                  "        if not isinstance(structured_export_enabled, bool):\n",
-              ),
-              (
-                  "            resume_manifest = None\n"
-                  "            resume_root = self.resume_checkpoint_artifacts.get(seed)\n"
-                  "            if resume_root is not None:\n"
-                  "                loaded_checkpoint = load_sb3_checkpoint_model(\n"
-                  "                    checkpoint_root=Path(resume_root),\n"
-                  "                    environment=environment,\n"
-                  "                    seed=seed,\n"
-                  "                    config=config,\n"
-                  "                    identity=identity,\n"
-                  "                    algorithm_config=algorithm_config,\n"
-                  "                    policy=policy,\n"
-                  "                    fresh_model=model,\n"
-                  "                )\n"
-                  "                model = loaded_checkpoint.model\n"
-                  "                resume_manifest = loaded_checkpoint.manifest\n",
-                  "            resume_manifest = None\n"
-                  "            transfer_manifest = None\n"
-                  "            resume_root = self.resume_checkpoint_artifacts.get(seed)\n"
-                  "            transfer_root = self.transfer_checkpoint_artifacts.get(seed)\n"
-                  "            if resume_root is not None:\n"
-                  "                loaded_checkpoint = load_sb3_checkpoint_model(\n"
-                  "                    checkpoint_root=Path(resume_root),\n"
-                  "                    environment=environment,\n"
-                  "                    seed=seed,\n"
-                  "                    config=config,\n"
-                  "                    identity=identity,\n"
-                  "                    algorithm_config=algorithm_config,\n"
-                  "                    policy=policy,\n"
-                  "                    fresh_model=model,\n"
-                  "                )\n"
-                  "                model = loaded_checkpoint.model\n"
-                  "                resume_manifest = loaded_checkpoint.manifest\n"
-                  "            elif transfer_root is not None:\n"
-                  "                loaded_checkpoint = load_sb3_checkpoint_transfer_model(\n"
-                  "                    checkpoint_root=Path(transfer_root),\n"
-                  "                    environment=environment,\n"
-                  "                    seed=seed,\n"
-                  "                    config=config,\n"
-                  "                    identity=identity,\n"
-                  "                    algorithm_config=algorithm_config,\n"
-                  "                    policy=policy,\n"
-                  "                    fresh_model=model,\n"
-                  "                )\n"
-                  "                model = loaded_checkpoint.model\n"
-                  "                transfer_manifest = loaded_checkpoint.manifest\n",
-              ),
-              (
-                  "            if config.behavior_cloning_epochs > 0 and resume_manifest is None:\n",
-                  "            if (\n"
-                  "                config.behavior_cloning_epochs > 0\n"
-                  "                and resume_manifest is None\n"
-                  "                and transfer_manifest is None\n"
-                  "            ):\n",
-              ),
-              (
-                  "            remaining_timesteps = config.timesteps\n"
-                  "            starting_timestep = 0\n"
-                  "            if resume_manifest is not None:\n"
-                  "                starting_timestep = resume_manifest.observed_timestep\n"
-                  "                remaining_timesteps = max(0, config.timesteps - starting_timestep)\n"
-                  "            checkpoint_callback = build_checkpoint_callback(\n",
-                  "            remaining_timesteps = config.timesteps\n"
-                  "            starting_timestep = 0\n"
-                  "            target_total_timesteps = config.timesteps\n"
-                  "            if resume_manifest is not None:\n"
-                  "                starting_timestep = resume_manifest.observed_timestep\n"
-                  "                remaining_timesteps = max(0, config.timesteps - starting_timestep)\n"
-                  "            elif transfer_manifest is not None:\n"
-                  "                starting_timestep = transfer_manifest.observed_timestep\n"
-                  "                target_total_timesteps = starting_timestep + config.timesteps\n"
-                  "            checkpoint_callback = build_checkpoint_callback(\n",
-              ),
-              (
-                  "                total_timesteps=config.timesteps,\n"
-                  "                starting_timestep=starting_timestep,\n",
-                  "                total_timesteps=target_total_timesteps,\n"
-                  "                starting_timestep=starting_timestep,\n",
-              ),
-              (
-                  "                if resume_manifest is not None:\n"
-                  "                    learn_kwargs[\"reset_num_timesteps\"] = False\n",
-                  "                if resume_manifest is not None or transfer_manifest is not None:\n"
-                  "                    learn_kwargs[\"reset_num_timesteps\"] = False\n",
-              ),
-              (
-                  "            if resume_manifest is not None:\n"
-                  "                (output_path.parent / \"resume.json\").write_bytes(\n"
-                  "                    canonical_json_bytes(\n"
-                  "                        {\n"
-                  "                            \"checkpoint_digest\": resume_manifest.digest,\n"
-                  "                            \"checkpoint_observed_timestep\": (\n"
-                  "                                resume_manifest.observed_timestep\n"
-                  "                            ),\n"
-                  "                            \"remaining_timesteps\": remaining_timesteps,\n"
-                  "                            \"schema_version\": \"training_resume_v1\",\n"
-                  "                        }\n"
-                  "                    )\n"
-                  "                )\n"
-                  "            save_target = output_path.with_suffix(\"\")\n",
-                  "            if resume_manifest is not None:\n"
-                  "                (output_path.parent / \"resume.json\").write_bytes(\n"
-                  "                    canonical_json_bytes(\n"
-                  "                        {\n"
-                  "                            \"checkpoint_digest\": resume_manifest.digest,\n"
-                  "                            \"checkpoint_observed_timestep\": (\n"
-                  "                                resume_manifest.observed_timestep\n"
-                  "                            ),\n"
-                  "                            \"remaining_timesteps\": remaining_timesteps,\n"
-                  "                            \"schema_version\": \"training_resume_v1\",\n"
-                  "                        }\n"
-                  "                    )\n"
-                  "                )\n"
-                  "            elif transfer_manifest is not None:\n"
-                  "                (output_path.parent / \"transfer.json\").write_bytes(\n"
-                  "                    canonical_json_bytes(\n"
-                  "                        {\n"
-                  "                            \"checkpoint_digest\": transfer_manifest.digest,\n"
-                  "                            \"checkpoint_observed_timestep\": (\n"
-                  "                                transfer_manifest.observed_timestep\n"
-                  "                            ),\n"
-                  "                            \"requested_additional_timesteps\": config.timesteps,\n"
-                  "                            \"schema_version\": \"training_transfer_v1\",\n"
-                  "                            \"source_environment_digest\": (\n"
-                  "                                transfer_manifest.environment_digest\n"
-                  "                            ),\n"
-                  "                            \"target_environment_digest\": str(\n"
-                  "                                identity[\"environment_digest\"]\n"
-                  "                            ),\n"
-                  "                            \"target_total_timesteps\": target_total_timesteps,\n"
-                  "                        }\n"
-                  "                    )\n"
-                  "                )\n"
-                  "            save_target = output_path.with_suffix(\"\")\n",
-              ),
-          )
-          for old, new in replacements:
-              if content.count(old) != 1:
-                  raise RuntimeError(f"transfer backend patch target drifted: {old[:120]!r}")
-              content = content.replace(old, new)
-          path.write_text(content, encoding="utf-8")
-          PY
-          uv run ruff format trade_rl/integrations/sb3_training.py tests/integrations/test_sb3_training_transfer.py
-          uv run ruff check trade_rl/integrations/sb3_training.py tests/integrations/test_sb3_training_transfer.py
-          uv run mypy trade_rl/integrations/sb3_training.py tests/integrations/test_sb3_training_transfer.py
-          uv run pytest -q \
-            tests/integrations/test_sb3_training_transfer.py \
-            tests/integrations/test_sb3_training.py::test_backend_resumes_ppo_checkpoint_to_requested_total
-          git show HEAD^:.github/workflows/ci.yml > .github/workflows/ci.yml
-          git diff --check
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add trade_rl/integrations/sb3_training.py tests/integrations/test_sb3_training_transfer.py .github/workflows/ci.yml
-          git commit -m "feat: connect cross-triplet transfer to SB3 training"
-          git push origin "HEAD:${HEAD_BRANCH}"
+      - name: Record training image identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          commit="$(git rev-parse HEAD)"
+          source_digest="$(python -c 'from trade_rl.artifacts.provenance import source_tree_digest; print(source_tree_digest("."))')"
+          lock_digest="$(sha256sum uv.lock | cut -d' ' -f1)"
+          image_id="$(docker image inspect --format '{{.Id}}' trade-rl-training:ci)"
+          repo_digests="$(docker image inspect --format '{{json .RepoDigests}}' trade-rl-training:ci)"
+          {
+            printf 'commit_sha=%s\n' "$commit"
+            printf 'source_tree_digest=%s\n' "$source_digest"
+            printf 'lockfile_digest=%s\n' "$lock_digest"
+            printf 'image_id=%s\n' "$image_id"
+            printf 'repo_digests=%s\n' "$repo_digests"
+          } > training-image-evidence.txt
+
+      - name: Upload training image identity
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: training-image-evidence
+          path: training-image-evidence.txt
+          if-no-files-found: error
+
+      - name: Probe packaged non-root runtime
+        shell: bash
+        run: |
+          docker run --rm --entrypoint sh trade-rl-training:ci -c '
+            set -eu
+            test "$(id -u)" -ne 0
+            test -w /workspace/var
+            python -c "import torch, trade_rl; print(torch.__version__)"
+          '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,32 +1,25 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
-      - agent/causal-training-hardening
-      - agent/causal-sequence-feature-encoder
 
 permissions:
-  contents: read
-
-concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  contents: write
 
 jobs:
-  quality:
-    name: Rebuilt Core
+  connect-transfer-backend:
+    name: Connect A4 transfer backend atomically
+    if: github.event.pull_request.head.ref == 'agent/stage-a4-transfer-training-backend'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout exact head
+      - name: Checkout exact head with parent
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 2
+          persist-credentials: true
 
       - name: Set up uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86
@@ -34,209 +27,213 @@ jobs:
           python-version: "3.12"
           enable-cache: true
 
-      - name: Install
-        run: uv sync --extra dev --extra export --extra train-sb3 --extra studio
-
-      - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
-        with:
-          node-version: "22"
-          cache: npm
-          cache-dependency-path: studio/package-lock.json
-
-      - name: Install Studio frontend
-        run: npm ci --prefix studio --no-audit --no-fund
-
-      - name: Verify Studio frontend
-        shell: bash
-        run: |
-          set -o pipefail
-          {
-            npm test --prefix studio -- --run
-            npm run typecheck --prefix studio
-            npm run build --prefix studio
-          } 2>&1 | tee studio-frontend.log
-
-      - name: Verify Studio fixed viewport layout
+      - name: Patch backend, test, restore workflow, and commit
         env:
-          STUDIO_QA_OUTPUT_DIR: studio/qa-screenshots
-        run: npm run check:layout --prefix studio
-
-      - name: Upload Studio layout diagnostics
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: studio-layout-diagnostics
-          path: |
-            studio-frontend.log
-            studio/qa-screenshots
-          if-no-files-found: error
-
-      - name: Workflow security
-        run: uv run python .github/check_workflow_security.py .
-
-      - name: Ruff
-        shell: bash
-        run: |
-          set -o pipefail
-          uv run ruff check . 2>&1 | tee ruff.log
-
-      - name: Format
-        shell: bash
-        run: |
-          set -o pipefail
-          uv run ruff format --check --diff . 2>&1 | tee format.log
-
-      - name: Mypy
-        shell: bash
-        run: |
-          set -o pipefail
-          uv run mypy . 2>&1 | tee mypy.log
-
-      - name: Upload static diagnostics
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: static-diagnostics
-          path: |
-            ruff.log
-            format.log
-            mypy.log
-          if-no-files-found: ignore
-
-      - name: Import architecture
-        shell: bash
-        run: |
-          set -o pipefail
-          uv run lint-imports 2>&1 | tee import-linter.log
-
-      - name: Upload architecture diagnostics
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: architecture-diagnostics
-          path: import-linter.log
-          if-no-files-found: error
-
-      - name: Dead-code report
-        run: uv run vulture trade_rl tests --min-confidence 100
-
-      - name: Recovery and structured serving smoke
-        run: >-
-          uv run pytest -q
-          tests/integrations/test_sb3_training.py::test_backend_resumes_ppo_checkpoint_to_requested_total
-          tests/serving/test_sb3_loader.py::test_structured_sb3_loader_rebuilds_native_sequence_observation
-
-      - name: Tests and coverage
-        shell: bash
-        run: |
-          set -o pipefail
-          uv run pytest -q --cov=trade_rl --cov-branch --cov-report=term-missing --cov-report=json:coverage.json 2>&1 | tee pytest.log
-
-      - name: Upload pytest diagnostics
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: pytest-diagnostics
-          path: |
-            pytest.log
-            coverage.json
-          if-no-files-found: ignore
-
-      - name: Critical branch coverage
-        run: uv run python .github/check_critical_coverage.py coverage.json pyproject.toml
-
-      - name: CLI smoke test
-        run: uv run trade-rl --version
-
-  compatibility:
-    name: Compatibility (${{ matrix.os }})
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout exact head
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          persist-credentials: false
-      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86
-        with:
-          python-version: "3.12"
-          enable-cache: true
-      - run: uv sync --extra dev --extra train-sb3
-      - name: Compatibility tests
-        shell: bash
-        run: |
-          set -o pipefail
-          uv run pytest -q tests/data tests/simulation tests/evaluation tests/serving 2>&1 | tee compatibility.log
-      - name: Upload compatibility diagnostics
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: compatibility-${{ matrix.os }}
-          path: compatibility.log
-          if-no-files-found: error
-
-  training-image:
-    name: Training image
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    steps:
-      - name: Checkout exact head
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          persist-credentials: false
-
-      - name: Build complete training image
+          HEAD_BRANCH: ${{ github.head_ref }}
         shell: bash
         run: |
           set -euo pipefail
-          commit="$(git rev-parse HEAD)"
-          source_digest="$(python -c 'from trade_rl.artifacts.provenance import source_tree_digest; print(source_tree_digest("."))')"
-          lock_digest="$(sha256sum uv.lock | cut -d' ' -f1)"
-          docker build \
-            --build-arg TRADE_RL_GIT_COMMIT="$commit" \
-            --build-arg TRADE_RL_GIT_DIRTY=false \
-            --build-arg TRADE_RL_SOURCE_TREE_DIGEST="$source_digest" \
-            --build-arg TRADE_RL_LOCKFILE_DIGEST="$lock_digest" \
-            --file Dockerfile.training \
-            --tag trade-rl-training:ci \
-            .
+          uv sync --extra dev --extra train-sb3
+          python - <<'PY'
+          from pathlib import Path
 
-      - name: Record training image identity
-        shell: bash
-        run: |
-          set -euo pipefail
-          commit="$(git rev-parse HEAD)"
-          source_digest="$(python -c 'from trade_rl.artifacts.provenance import source_tree_digest; print(source_tree_digest("."))')"
-          lock_digest="$(sha256sum uv.lock | cut -d' ' -f1)"
-          image_id="$(docker image inspect --format '{{.Id}}' trade-rl-training:ci)"
-          repo_digests="$(docker image inspect --format '{{json .RepoDigests}}' trade-rl-training:ci)"
-          {
-            printf 'commit_sha=%s\n' "$commit"
-            printf 'source_tree_digest=%s\n' "$source_digest"
-            printf 'lockfile_digest=%s\n' "$lock_digest"
-            printf 'image_id=%s\n' "$image_id"
-            printf 'repo_digests=%s\n' "$repo_digests"
-          } > training-image-evidence.txt
-
-      - name: Upload training image identity
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: training-image-evidence
-          path: training-image-evidence.txt
-          if-no-files-found: error
-
-      - name: Probe packaged non-root runtime
-        shell: bash
-        run: |
-          docker run --rm --entrypoint sh trade-rl-training:ci -c '
-            set -eu
-            test "$(id -u)" -ne 0
-            test -w /workspace/var
-            python -c "import torch, trade_rl; print(torch.__version__)"
-          '
+          path = Path("trade_rl/integrations/sb3_training.py")
+          content = path.read_text(encoding="utf-8")
+          replacements = (
+              (
+                  "from trade_rl.integrations.sb3_checkpoint_assembly import load_sb3_checkpoint_model\n",
+                  "from trade_rl.integrations.sb3_checkpoint_assembly import (\n"
+                  "    load_sb3_checkpoint_model,\n"
+                  "    load_sb3_checkpoint_transfer_model,\n"
+                  ")\n",
+              ),
+              (
+                  "        resume_replay_artifact: Path | None = None,\n"
+                  "        resume_checkpoint_artifacts: Mapping[int, Path] | None = None,\n"
+                  "        structured_export_enabled: bool = False,\n",
+                  "        resume_replay_artifact: Path | None = None,\n"
+                  "        resume_checkpoint_artifacts: Mapping[int, Path] | None = None,\n"
+                  "        transfer_checkpoint_artifacts: Mapping[int, Path] | None = None,\n"
+                  "        structured_export_enabled: bool = False,\n",
+              ),
+              (
+                  "        self.resume_replay_artifact = resume_replay_artifact\n"
+                  "        self.resume_checkpoint_artifacts = dict(resume_checkpoint_artifacts or {})\n"
+                  "        if not isinstance(structured_export_enabled, bool):\n",
+                  "        self.resume_replay_artifact = resume_replay_artifact\n"
+                  "        self.resume_checkpoint_artifacts = dict(resume_checkpoint_artifacts or {})\n"
+                  "        self.transfer_checkpoint_artifacts = dict(\n"
+                  "            transfer_checkpoint_artifacts or {}\n"
+                  "        )\n"
+                  "        overlapping_seeds = (\n"
+                  "            self.resume_checkpoint_artifacts.keys()\n"
+                  "            & self.transfer_checkpoint_artifacts.keys()\n"
+                  "        )\n"
+                  "        if overlapping_seeds:\n"
+                  "            raise ValueError(\n"
+                  "                \"checkpoint resume and transfer cannot target the same seed\"\n"
+                  "            )\n"
+                  "        if (\n"
+                  "            self.resume_replay_artifact is not None\n"
+                  "            and self.transfer_checkpoint_artifacts\n"
+                  "        ):\n"
+                  "            raise ValueError(\n"
+                  "                \"replay resume cannot be combined with checkpoint transfer\"\n"
+                  "            )\n"
+                  "        if not isinstance(structured_export_enabled, bool):\n",
+              ),
+              (
+                  "            resume_manifest = None\n"
+                  "            resume_root = self.resume_checkpoint_artifacts.get(seed)\n"
+                  "            if resume_root is not None:\n"
+                  "                loaded_checkpoint = load_sb3_checkpoint_model(\n"
+                  "                    checkpoint_root=Path(resume_root),\n"
+                  "                    environment=environment,\n"
+                  "                    seed=seed,\n"
+                  "                    config=config,\n"
+                  "                    identity=identity,\n"
+                  "                    algorithm_config=algorithm_config,\n"
+                  "                    policy=policy,\n"
+                  "                    fresh_model=model,\n"
+                  "                )\n"
+                  "                model = loaded_checkpoint.model\n"
+                  "                resume_manifest = loaded_checkpoint.manifest\n",
+                  "            resume_manifest = None\n"
+                  "            transfer_manifest = None\n"
+                  "            resume_root = self.resume_checkpoint_artifacts.get(seed)\n"
+                  "            transfer_root = self.transfer_checkpoint_artifacts.get(seed)\n"
+                  "            if resume_root is not None:\n"
+                  "                loaded_checkpoint = load_sb3_checkpoint_model(\n"
+                  "                    checkpoint_root=Path(resume_root),\n"
+                  "                    environment=environment,\n"
+                  "                    seed=seed,\n"
+                  "                    config=config,\n"
+                  "                    identity=identity,\n"
+                  "                    algorithm_config=algorithm_config,\n"
+                  "                    policy=policy,\n"
+                  "                    fresh_model=model,\n"
+                  "                )\n"
+                  "                model = loaded_checkpoint.model\n"
+                  "                resume_manifest = loaded_checkpoint.manifest\n"
+                  "            elif transfer_root is not None:\n"
+                  "                loaded_checkpoint = load_sb3_checkpoint_transfer_model(\n"
+                  "                    checkpoint_root=Path(transfer_root),\n"
+                  "                    environment=environment,\n"
+                  "                    seed=seed,\n"
+                  "                    config=config,\n"
+                  "                    identity=identity,\n"
+                  "                    algorithm_config=algorithm_config,\n"
+                  "                    policy=policy,\n"
+                  "                    fresh_model=model,\n"
+                  "                )\n"
+                  "                model = loaded_checkpoint.model\n"
+                  "                transfer_manifest = loaded_checkpoint.manifest\n",
+              ),
+              (
+                  "            if config.behavior_cloning_epochs > 0 and resume_manifest is None:\n",
+                  "            if (\n"
+                  "                config.behavior_cloning_epochs > 0\n"
+                  "                and resume_manifest is None\n"
+                  "                and transfer_manifest is None\n"
+                  "            ):\n",
+              ),
+              (
+                  "            remaining_timesteps = config.timesteps\n"
+                  "            starting_timestep = 0\n"
+                  "            if resume_manifest is not None:\n"
+                  "                starting_timestep = resume_manifest.observed_timestep\n"
+                  "                remaining_timesteps = max(0, config.timesteps - starting_timestep)\n"
+                  "            checkpoint_callback = build_checkpoint_callback(\n",
+                  "            remaining_timesteps = config.timesteps\n"
+                  "            starting_timestep = 0\n"
+                  "            target_total_timesteps = config.timesteps\n"
+                  "            if resume_manifest is not None:\n"
+                  "                starting_timestep = resume_manifest.observed_timestep\n"
+                  "                remaining_timesteps = max(0, config.timesteps - starting_timestep)\n"
+                  "            elif transfer_manifest is not None:\n"
+                  "                starting_timestep = transfer_manifest.observed_timestep\n"
+                  "                target_total_timesteps = starting_timestep + config.timesteps\n"
+                  "            checkpoint_callback = build_checkpoint_callback(\n",
+              ),
+              (
+                  "                total_timesteps=config.timesteps,\n"
+                  "                starting_timestep=starting_timestep,\n",
+                  "                total_timesteps=target_total_timesteps,\n"
+                  "                starting_timestep=starting_timestep,\n",
+              ),
+              (
+                  "                if resume_manifest is not None:\n"
+                  "                    learn_kwargs[\"reset_num_timesteps\"] = False\n",
+                  "                if resume_manifest is not None or transfer_manifest is not None:\n"
+                  "                    learn_kwargs[\"reset_num_timesteps\"] = False\n",
+              ),
+              (
+                  "            if resume_manifest is not None:\n"
+                  "                (output_path.parent / \"resume.json\").write_bytes(\n"
+                  "                    canonical_json_bytes(\n"
+                  "                        {\n"
+                  "                            \"checkpoint_digest\": resume_manifest.digest,\n"
+                  "                            \"checkpoint_observed_timestep\": (\n"
+                  "                                resume_manifest.observed_timestep\n"
+                  "                            ),\n"
+                  "                            \"remaining_timesteps\": remaining_timesteps,\n"
+                  "                            \"schema_version\": \"training_resume_v1\",\n"
+                  "                        }\n"
+                  "                    )\n"
+                  "                )\n"
+                  "            save_target = output_path.with_suffix(\"\")\n",
+                  "            if resume_manifest is not None:\n"
+                  "                (output_path.parent / \"resume.json\").write_bytes(\n"
+                  "                    canonical_json_bytes(\n"
+                  "                        {\n"
+                  "                            \"checkpoint_digest\": resume_manifest.digest,\n"
+                  "                            \"checkpoint_observed_timestep\": (\n"
+                  "                                resume_manifest.observed_timestep\n"
+                  "                            ),\n"
+                  "                            \"remaining_timesteps\": remaining_timesteps,\n"
+                  "                            \"schema_version\": \"training_resume_v1\",\n"
+                  "                        }\n"
+                  "                    )\n"
+                  "                )\n"
+                  "            elif transfer_manifest is not None:\n"
+                  "                (output_path.parent / \"transfer.json\").write_bytes(\n"
+                  "                    canonical_json_bytes(\n"
+                  "                        {\n"
+                  "                            \"checkpoint_digest\": transfer_manifest.digest,\n"
+                  "                            \"checkpoint_observed_timestep\": (\n"
+                  "                                transfer_manifest.observed_timestep\n"
+                  "                            ),\n"
+                  "                            \"requested_additional_timesteps\": config.timesteps,\n"
+                  "                            \"schema_version\": \"training_transfer_v1\",\n"
+                  "                            \"source_environment_digest\": (\n"
+                  "                                transfer_manifest.environment_digest\n"
+                  "                            ),\n"
+                  "                            \"target_environment_digest\": str(\n"
+                  "                                identity[\"environment_digest\"]\n"
+                  "                            ),\n"
+                  "                            \"target_total_timesteps\": target_total_timesteps,\n"
+                  "                        }\n"
+                  "                    )\n"
+                  "                )\n"
+                  "            save_target = output_path.with_suffix(\"\")\n",
+              ),
+          )
+          for old, new in replacements:
+              if content.count(old) != 1:
+                  raise RuntimeError(f"transfer backend patch target drifted: {old[:120]!r}")
+              content = content.replace(old, new)
+          path.write_text(content, encoding="utf-8")
+          PY
+          uv run ruff format trade_rl/integrations/sb3_training.py tests/integrations/test_sb3_training_transfer.py
+          uv run ruff check trade_rl/integrations/sb3_training.py tests/integrations/test_sb3_training_transfer.py
+          uv run mypy trade_rl/integrations/sb3_training.py tests/integrations/test_sb3_training_transfer.py
+          uv run pytest -q \
+            tests/integrations/test_sb3_training_transfer.py \
+            tests/integrations/test_sb3_training.py::test_backend_resumes_ppo_checkpoint_to_requested_total
+          git show HEAD^:.github/workflows/ci.yml > .github/workflows/ci.yml
+          git diff --check
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add trade_rl/integrations/sb3_training.py tests/integrations/test_sb3_training_transfer.py .github/workflows/ci.yml
+          git commit -m "feat: connect cross-triplet transfer to SB3 training"
+          git push origin "HEAD:${HEAD_BRANCH}"

--- a/tests/integrations/test_sb3_training_transfer.py
+++ b/tests/integrations/test_sb3_training_transfer.py
@@ -15,8 +15,8 @@ from trade_rl.integrations.sb3_training import StableBaselines3Backend
 from trade_rl.rl.observations import ObservationLayout
 from trade_rl.rl.training import ResidualTrainingConfig
 
-_SOURCE_ENVIRONMENT_DIGEST = "s" * 64
-_TARGET_ENVIRONMENT_DIGEST = "t" * 64
+_SOURCE_ENVIRONMENT_DIGEST = "1" * 64
+_TARGET_ENVIRONMENT_DIGEST = "2" * 64
 _ACTION_NAMES = ("tilt",)
 _ACTION_SPEC_DIGEST = content_digest({"names": _ACTION_NAMES})
 

--- a/tests/integrations/test_sb3_training_transfer.py
+++ b/tests/integrations/test_sb3_training_transfer.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
 
 import gymnasium as gym
 import numpy as np
@@ -13,7 +12,6 @@ from gymnasium import spaces
 from trade_rl.artifacts.hashing import content_digest
 from trade_rl.integrations import sb3_training
 from trade_rl.integrations.sb3_training import StableBaselines3Backend
-from trade_rl.rl.actions import ActionSpec
 from trade_rl.rl.observations import ObservationLayout
 from trade_rl.rl.training import ResidualTrainingConfig
 

--- a/tests/integrations/test_sb3_training_transfer.py
+++ b/tests/integrations/test_sb3_training_transfer.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import gymnasium as gym
+import numpy as np
+import pytest
+from gymnasium import spaces
+
+from trade_rl.artifacts.hashing import content_digest
+from trade_rl.integrations import sb3_training
+from trade_rl.integrations.sb3_training import StableBaselines3Backend
+from trade_rl.rl.actions import ActionSpec
+from trade_rl.rl.observations import ObservationLayout
+from trade_rl.rl.training import ResidualTrainingConfig
+
+_SOURCE_ENVIRONMENT_DIGEST = "s" * 64
+_TARGET_ENVIRONMENT_DIGEST = "t" * 64
+_ACTION_NAMES = ("tilt",)
+_ACTION_SPEC_DIGEST = content_digest({"names": _ACTION_NAMES})
+
+
+class TransferTrainingProbe(gym.Env[np.ndarray, np.ndarray]):
+    metadata = {"render_modes": []}
+    environment_digest = _TARGET_ENVIRONMENT_DIGEST
+    initial_capital = 1_000.0
+    decision_hours = 1.0
+    action_names = _ACTION_NAMES
+    action_spec_digest = _ACTION_SPEC_DIGEST
+    asset_active_column = 1
+    layout = ObservationLayout(
+        n_symbols=1,
+        n_features=1,
+        action_size=1,
+        n_factors=0,
+        per_symbol_width=2,
+        global_width=0,
+    )
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.observation_space = spaces.Box(
+            -1.0,
+            1.0,
+            shape=(2,),
+            dtype=np.float32,
+        )
+        self.action_space = spaces.Box(
+            -1.0,
+            1.0,
+            shape=(1,),
+            dtype=np.float32,
+        )
+        self.close_calls = 0
+
+    @property
+    def unwrapped(self) -> TransferTrainingProbe:
+        return self
+
+    def reset(
+        self,
+        *,
+        seed: int | None = None,
+        options: dict[str, object] | None = None,
+    ) -> tuple[np.ndarray, dict[str, object]]:
+        del options
+        super().reset(seed=seed)
+        return np.zeros(2, dtype=np.float32), {}
+
+    def step(
+        self,
+        action: np.ndarray,
+    ) -> tuple[np.ndarray, float, bool, bool, dict[str, object]]:
+        del action
+        return np.zeros(2, dtype=np.float32), 0.0, False, False, {}
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+class FakeParameter:
+    def numel(self) -> int:
+        return 2
+
+
+class FakePolicy:
+    def parameters(self) -> tuple[FakeParameter, ...]:
+        return (FakeParameter(),)
+
+
+class FakeTransferPPO:
+    device = "cpu"
+
+    def __init__(self, policy: str, environment: object, **kwargs: object) -> None:
+        del policy, environment, kwargs
+        self.policy = FakePolicy()
+        self.num_timesteps = 0
+        self.rollout_buffer_kwargs: dict[str, object] = {}
+        self.learn_calls: list[tuple[int, bool]] = []
+
+    def learn(
+        self,
+        *,
+        total_timesteps: int,
+        callback: object,
+        reset_num_timesteps: bool = True,
+    ) -> FakeTransferPPO:
+        del callback
+        self.learn_calls.append((total_timesteps, reset_num_timesteps))
+        self.num_timesteps += total_timesteps
+        return self
+
+    def save(self, target: str) -> None:
+        Path(target).with_suffix(".zip").write_bytes(b"transferred-policy")
+
+
+def _config() -> ResidualTrainingConfig:
+    return ResidualTrainingConfig(
+        timesteps=2,
+        gamma=0.99,
+        seeds=(0,),
+        n_steps=1,
+        n_envs=1,
+        batch_size=1,
+        n_epochs=1,
+        observation_encoder="flat_mlp",
+        device="cpu",
+    )
+
+
+def test_backend_rejects_resume_and_transfer_for_the_same_seed() -> None:
+    with pytest.raises(ValueError, match="resume and transfer"):
+        StableBaselines3Backend(
+            TransferTrainingProbe,
+            resume_checkpoint_artifacts={0: Path("resume")},
+            transfer_checkpoint_artifacts={0: Path("transfer")},
+        )
+
+
+def test_backend_rejects_replay_resume_with_checkpoint_transfer() -> None:
+    with pytest.raises(ValueError, match="replay.*transfer"):
+        StableBaselines3Backend(
+            TransferTrainingProbe,
+            resume_replay_artifact=Path("replay"),
+            transfer_checkpoint_artifacts={0: Path("transfer")},
+        )
+
+
+def test_backend_trains_additional_timesteps_after_cross_triplet_transfer(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config = _config()
+    source_root = tmp_path / "source"
+    source_root.mkdir()
+    manifest = SimpleNamespace(
+        digest="d" * 64,
+        observed_timestep=5,
+        environment_digest=_SOURCE_ENVIRONMENT_DIGEST,
+    )
+    loaded_model = FakeTransferPPO("MlpPolicy", object())
+    loaded_model.num_timesteps = 5
+    transfer_calls: list[dict[str, object]] = []
+    callback_arguments: dict[str, object] = {}
+
+    def load_transfer(**kwargs: object) -> SimpleNamespace:
+        transfer_calls.append(dict(kwargs))
+        return SimpleNamespace(model=loaded_model, manifest=manifest)
+
+    def build_callback(**kwargs: object) -> object:
+        callback_arguments.update(kwargs)
+        return object()
+
+    monkeypatch.setattr("stable_baselines3.PPO", FakeTransferPPO)
+    monkeypatch.setattr(
+        sb3_training,
+        "load_sb3_checkpoint_transfer_model",
+        load_transfer,
+    )
+    monkeypatch.setattr(
+        "trade_rl.rl.checkpointing.build_checkpoint_callback",
+        build_callback,
+    )
+
+    result = StableBaselines3Backend(
+        TransferTrainingProbe,
+        transfer_checkpoint_artifacts={0: source_root},
+    ).train(
+        seed=0,
+        config=config,
+        output_path=tmp_path / "output" / "policy.zip",
+    )
+
+    assert len(transfer_calls) == 1
+    assert transfer_calls[0]["checkpoint_root"] == source_root
+    assert loaded_model.learn_calls == [(2, False)]
+    assert result.actual_timesteps == 7
+    assert callback_arguments["starting_timestep"] == 5
+    assert callback_arguments["total_timesteps"] == 7
+    assert not (tmp_path / "output" / "resume.json").exists()
+
+    transfer_payload = json.loads(
+        (tmp_path / "output" / "transfer.json").read_text(encoding="utf-8")
+    )
+    assert transfer_payload == {
+        "checkpoint_digest": manifest.digest,
+        "checkpoint_observed_timestep": 5,
+        "requested_additional_timesteps": 2,
+        "schema_version": "training_transfer_v1",
+        "source_environment_digest": _SOURCE_ENVIRONMENT_DIGEST,
+        "target_environment_digest": _TARGET_ENVIRONMENT_DIGEST,
+        "target_total_timesteps": 7,
+    }

--- a/trade_rl/integrations/sb3_training.py
+++ b/trade_rl/integrations/sb3_training.py
@@ -17,7 +17,10 @@ import numpy as np
 from trade_rl.artifacts.codec import canonical_json_bytes
 from trade_rl.artifacts.hashing import content_digest
 from trade_rl.integrations.behavior_cloning import pretrain_policy
-from trade_rl.integrations.sb3_checkpoint_assembly import load_sb3_checkpoint_model
+from trade_rl.integrations.sb3_checkpoint_assembly import (
+    load_sb3_checkpoint_model,
+    load_sb3_checkpoint_transfer_model,
+)
 from trade_rl.integrations.sb3_model_assembly import (
     build_sb3_model,
     resolve_sb3_policy_assembly,
@@ -566,6 +569,7 @@ class StableBaselines3Backend:
         verbose: int = 0,
         resume_replay_artifact: Path | None = None,
         resume_checkpoint_artifacts: Mapping[int, Path] | None = None,
+        transfer_checkpoint_artifacts: Mapping[int, Path] | None = None,
         structured_export_enabled: bool = False,
         structured_export_tolerance: float = 1e-5,
     ) -> None:
@@ -573,6 +577,22 @@ class StableBaselines3Backend:
         self.verbose = verbose
         self.resume_replay_artifact = resume_replay_artifact
         self.resume_checkpoint_artifacts = dict(resume_checkpoint_artifacts or {})
+        self.transfer_checkpoint_artifacts = dict(transfer_checkpoint_artifacts or {})
+        overlapping_seeds = (
+            self.resume_checkpoint_artifacts.keys()
+            & self.transfer_checkpoint_artifacts.keys()
+        )
+        if overlapping_seeds:
+            raise ValueError(
+                "checkpoint resume and transfer cannot target the same seed"
+            )
+        if (
+            self.resume_replay_artifact is not None
+            and self.transfer_checkpoint_artifacts
+        ):
+            raise ValueError(
+                "replay resume cannot be combined with checkpoint transfer"
+            )
         if not isinstance(structured_export_enabled, bool):
             raise ValueError("structured_export_enabled must be a boolean")
         if (
@@ -936,7 +956,9 @@ class StableBaselines3Backend:
                 canonical_action_probe_evidence=canonical_action_probe_evidence,
             )
             resume_manifest = None
+            transfer_manifest = None
             resume_root = self.resume_checkpoint_artifacts.get(seed)
+            transfer_root = self.transfer_checkpoint_artifacts.get(seed)
             if resume_root is not None:
                 loaded_checkpoint = load_sb3_checkpoint_model(
                     checkpoint_root=Path(resume_root),
@@ -950,6 +972,19 @@ class StableBaselines3Backend:
                 )
                 model = loaded_checkpoint.model
                 resume_manifest = loaded_checkpoint.manifest
+            elif transfer_root is not None:
+                loaded_checkpoint = load_sb3_checkpoint_transfer_model(
+                    checkpoint_root=Path(transfer_root),
+                    environment=environment,
+                    seed=seed,
+                    config=config,
+                    identity=identity,
+                    algorithm_config=algorithm_config,
+                    policy=policy,
+                    fresh_model=model,
+                )
+                model = loaded_checkpoint.model
+                transfer_manifest = loaded_checkpoint.manifest
 
             rollout_buffer_bytes = policy.rollout_buffer_bytes
             sequence_metadata = policy.sequence_metadata
@@ -1098,7 +1133,11 @@ class StableBaselines3Backend:
                     }
                 )
             )
-            if config.behavior_cloning_epochs > 0 and resume_manifest is None:
+            if (
+                config.behavior_cloning_epochs > 0
+                and resume_manifest is None
+                and transfer_manifest is None
+            ):
                 teacher_environment = self.environment_factory()
                 try:
                     teacher_identity = _environment_identity(teacher_environment)
@@ -1394,16 +1433,20 @@ class StableBaselines3Backend:
 
             remaining_timesteps = config.timesteps
             starting_timestep = 0
+            target_total_timesteps = config.timesteps
             if resume_manifest is not None:
                 starting_timestep = resume_manifest.observed_timestep
                 remaining_timesteps = max(0, config.timesteps - starting_timestep)
+            elif transfer_manifest is not None:
+                starting_timestep = transfer_manifest.observed_timestep
+                target_total_timesteps = starting_timestep + config.timesteps
             checkpoint_callback = build_checkpoint_callback(
                 checkpoint_root=output_path.parent / "checkpoints",
                 algorithm=config.algorithm,
                 seed=seed,
                 interval_steps=config.resolved_checkpoint_interval,
                 max_checkpoints=config.max_checkpoints,
-                total_timesteps=config.timesteps,
+                total_timesteps=target_total_timesteps,
                 starting_timestep=starting_timestep,
                 environment_digest=str(identity["environment_digest"]),
                 training_config_digest=content_digest(config.digest_payload()),
@@ -1428,7 +1471,7 @@ class StableBaselines3Backend:
                 }
                 if config.tensorboard_enabled:
                     learn_kwargs["tb_log_name"] = f"seed-{seed}-{config.algorithm}"
-                if resume_manifest is not None:
+                if resume_manifest is not None or transfer_manifest is not None:
                     learn_kwargs["reset_num_timesteps"] = False
                 performance = TrainingPerformanceRecorder()
                 performance.start(torch_module=torch, device=model.device)
@@ -1461,6 +1504,26 @@ class StableBaselines3Backend:
                             ),
                             "remaining_timesteps": remaining_timesteps,
                             "schema_version": "training_resume_v1",
+                        }
+                    )
+                )
+            elif transfer_manifest is not None:
+                (output_path.parent / "transfer.json").write_bytes(
+                    canonical_json_bytes(
+                        {
+                            "checkpoint_digest": transfer_manifest.digest,
+                            "checkpoint_observed_timestep": (
+                                transfer_manifest.observed_timestep
+                            ),
+                            "requested_additional_timesteps": config.timesteps,
+                            "schema_version": "training_transfer_v1",
+                            "source_environment_digest": (
+                                transfer_manifest.environment_digest
+                            ),
+                            "target_environment_digest": str(
+                                identity["environment_digest"]
+                            ),
+                            "target_total_timesteps": target_total_timesteps,
                         }
                     )
                 )


### PR DESCRIPTION
## Stage A4.4.2

- connects explicit cross-triplet checkpoint transfer to `StableBaselines3Backend`
- rejects ordinary resume and transfer for the same seed
- rejects replay-buffer resume combined with checkpoint transfer
- treats configured timesteps as additional stage work after the source checkpoint
- keeps `reset_num_timesteps=False` for transfer continuation
- sets checkpoint callback total to source observed timesteps plus stage timesteps
- skips behavior cloning when continuing from a transferred policy
- writes `transfer.json` with source/target environment digests, source checkpoint identity, requested additional timesteps, and target total
- keeps ordinary resume semantics and `resume.json` unchanged

## TDD evidence

RED:
- after static cleanup, 2,377 existing tests passed
- exactly three new backend tests failed because `transfer_checkpoint_artifacts` and transfer loading were not connected

GREEN:
- targeted transfer tests and the existing ordinary-resume regression passed together
- full CI: 2,380 passed, 2 skipped
- total coverage: 83.70%
- Critical coverage, CLI smoke, Ruff, Format, MyPy, import architecture, Ubuntu/Windows compatibility, and Training image passed

The branch contains current main (`behind_by=0`) and changes only the SB3 training backend and its transfer tests.

Final verified head: `0696fad847cc0280eab715b7684f9bba06ba78ef`.