### PR TITLE
Connect triplet stages to PostgreSQL training

### DIFF
--- a/tests/workflows/test_binance_symbol_triplet_stage_runner.py
+++ b/tests/workflows/test_binance_symbol_triplet_stage_runner.py
@@ -117,7 +117,9 @@ def test_runner_builds_current_postgres_stage_and_calls_training_once(
         return sentinel
 
     monkeypatch.setattr(module, "build_postgres_market_dataset", build_dataset)
-    monkeypatch.setattr(module, "execute_symbol_triplet_stage_training", execute_training)
+    monkeypatch.setattr(
+        module, "execute_symbol_triplet_stage_training", execute_training
+    )
 
     result = module.execute_binance_symbol_triplet_postgres_stage(**kwargs)
 
@@ -165,7 +167,9 @@ def test_runner_resumes_existing_bound_dataset_without_rebuilding(
     plan = _plan()
     kwargs = _run_kwargs(tmp_path, plan)
     monkeypatch.setattr(module, "_training_seeds", lambda _: (0, 1))
-    monkeypatch.setattr(module, "execute_symbol_triplet_stage_training", lambda **_: "ok")
+    monkeypatch.setattr(
+        module, "execute_symbol_triplet_stage_training", lambda **_: "ok"
+    )
     monkeypatch.setattr(
         module,
         "build_postgres_market_dataset",

--- a/tests/workflows/test_binance_symbol_triplet_stage_runner.py
+++ b/tests/workflows/test_binance_symbol_triplet_stage_runner.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+import pytest
+
+from trade_rl.data.market import MarketDataset
+from trade_rl.workflows.symbol_triplet_manifest import build_symbol_triplet_manifest
+from trade_rl.workflows.symbol_triplet_training_cursor import (
+    SymbolTripletTrainingCursor,
+    build_symbol_triplet_training_plan,
+    initial_symbol_triplet_training_cursor,
+    write_symbol_triplet_training_cursor,
+)
+
+_SYMBOLS = (
+    "BTCUSDT",
+    "ETHUSDT",
+    "BNBUSDT",
+    "SOLUSDT",
+    "XRPUSDT",
+    "ADAUSDT",
+    "DOGEUSDT",
+    "LINKUSDT",
+    "LTCUSDT",
+    "BCHUSDT",
+    "DOTUSDT",
+    "AVAXUSDT",
+    "UNIUSDT",
+    "TRXUSDT",
+    "ETCUSDT",
+)
+_SLOT_SYMBOLS = ("SLOT0", "SLOT1", "SLOT2")
+
+
+def _plan():
+    manifest = build_symbol_triplet_manifest(_SYMBOLS, seed=31)
+    return build_symbol_triplet_training_plan(
+        manifest,
+        cycles=1,
+        slot_symbols=_SLOT_SYMBOLS,
+    )
+
+
+def _dataset(identity: str) -> MarketDataset:
+    n_bars = 8
+    timestamps = np.datetime64("2026-01-01T00:00:00", "ns") + np.arange(
+        n_bars
+    ) * np.timedelta64(15, "m")
+    close = np.stack(
+        [100.0 + np.arange(n_bars, dtype=np.float64) + offset for offset in range(3)],
+        axis=1,
+    )
+    return MarketDataset(
+        dataset_id="0" * 64,
+        symbols=_SLOT_SYMBOLS,
+        timestamps=timestamps,
+        features=np.zeros((n_bars, 3, 1), dtype=np.float32),
+        global_features=np.zeros((n_bars, 1), dtype=np.float32),
+        open=close,
+        high=close + 1.0,
+        low=close - 1.0,
+        close=close,
+        volume=np.full((n_bars, 3), 1_000_000.0),
+        funding_rate=np.zeros((n_bars, 3)),
+        tradable=np.ones((n_bars, 3), dtype=np.bool_),
+        feature_available=np.ones((n_bars, 3, 1), dtype=np.bool_),
+        feature_names=("feature",),
+        global_feature_names=("regime",),
+        periods_per_year=35_040,
+    ).with_content_identity({"identity": identity})
+
+
+def _run_kwargs(tmp_path: Path, plan: Any) -> dict[str, Any]:
+    cursor_path = write_symbol_triplet_training_cursor(
+        tmp_path / "cursor.json",
+        initial_symbol_triplet_training_cursor(plan),
+    )
+    base_config_path = tmp_path / "base-config.json"
+    base_config_path.write_text("{}\n", encoding="utf-8")
+    return {
+        "connection": object(),
+        "plan": plan,
+        "cursor_path": cursor_path,
+        "base_config_path": base_config_path,
+        "work_root": tmp_path / "triplet-training",
+        "symbol_vocabulary": _SYMBOLS,
+        "start_time": datetime(2024, 12, 1, tzinfo=UTC),
+        "end_time": datetime(2026, 7, 1, tzinfo=UTC),
+        "metadata": {symbol: {} for symbol in _SYMBOLS},
+        "metadata_evidence_digest": "a" * 64,
+    }
+
+
+def test_runner_builds_current_postgres_stage_and_calls_training_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import trade_rl.workflows.binance_symbol_triplet_stage_runner as module
+
+    plan = _plan()
+    kwargs = _run_kwargs(tmp_path, plan)
+    calls: list[dict[str, Any]] = []
+    sentinel = object()
+
+    monkeypatch.setattr(module, "_training_seeds", lambda _: (0, 1))
+
+    def build_dataset(connection: object, **builder_kwargs: Any) -> MarketDataset:
+        calls.append({"connection": connection, **builder_kwargs})
+        return _dataset("stage-0")
+
+    def execute_training(**executor_kwargs: Any) -> object:
+        calls.append({"executor": executor_kwargs})
+        return sentinel
+
+    monkeypatch.setattr(module, "build_postgres_market_dataset", build_dataset)
+    monkeypatch.setattr(module, "execute_symbol_triplet_stage_training", execute_training)
+
+    result = module.execute_binance_symbol_triplet_postgres_stage(**kwargs)
+
+    assert result is sentinel
+    request = module.current_binance_symbol_triplet_stage_request(
+        plan,
+        kwargs["cursor_path"],
+        kwargs["base_config_path"],
+        kwargs["work_root"],
+    )
+    assert request is not None
+    builder_call = calls[0]
+    assert builder_call["symbols"] == request.symbols
+    assert builder_call["slot_symbols"] == request.slot_symbols
+    assert builder_call["symbol_vocabulary"] == _SYMBOLS
+    assert builder_call["symbol_triplet_provenance"] == {
+        "cycle_index": request.cycle_index,
+        "plan_digest": request.plan_digest,
+        "request_digest": request.digest,
+        "schema_version": "binance_symbol_triplet_stage_provenance_v1",
+        "selected_symbols": request.symbols,
+        "slot_symbols": request.slot_symbols,
+        "stage_id": request.stage_id,
+        "stage_index": request.stage_index,
+        "train_split_slot": request.train_split_slot,
+    }
+    stage_root = module.binance_symbol_triplet_stage_root(kwargs["work_root"], request)
+    assert (stage_root / "dataset" / "manifest.json").is_file()
+    assert (stage_root / "dataset-binding.json").is_file()
+    executor_call = calls[1]["executor"]
+    assert executor_call["dataset_path"] == stage_root / "dataset"
+    assert executor_call["dataset_binding_path"] == stage_root / "dataset-binding.json"
+    assert executor_call["stage_config_path"] == stage_root / "training-config.json"
+    assert executor_call["completion_path"] == stage_root / "completion.json"
+    assert executor_call["previous_completion_path"] is None
+    assert executor_call["run_id"].startswith("binance-triplet-stage-0000-")
+
+
+def test_runner_resumes_existing_bound_dataset_without_rebuilding(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import trade_rl.workflows.binance_symbol_triplet_stage_runner as module
+
+    plan = _plan()
+    kwargs = _run_kwargs(tmp_path, plan)
+    monkeypatch.setattr(module, "_training_seeds", lambda _: (0, 1))
+    monkeypatch.setattr(module, "execute_symbol_triplet_stage_training", lambda **_: "ok")
+    monkeypatch.setattr(
+        module,
+        "build_postgres_market_dataset",
+        lambda *_args, **_kwargs: _dataset("stable"),
+    )
+
+    assert module.execute_binance_symbol_triplet_postgres_stage(**kwargs) == "ok"
+    monkeypatch.setattr(
+        module,
+        "build_postgres_market_dataset",
+        lambda *_args, **_kwargs: pytest.fail("bound dataset must be reused"),
+    )
+
+    assert module.execute_binance_symbol_triplet_postgres_stage(**kwargs) == "ok"
+
+
+def test_runner_rejects_orphan_dataset_without_advancing_cursor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import trade_rl.workflows.binance_symbol_triplet_stage_runner as module
+    from trade_rl.data import publish_market_dataset_artifact
+
+    plan = _plan()
+    kwargs = _run_kwargs(tmp_path, plan)
+    monkeypatch.setattr(module, "_training_seeds", lambda _: (0, 1))
+    request = module.current_binance_symbol_triplet_stage_request(
+        plan,
+        kwargs["cursor_path"],
+        kwargs["base_config_path"],
+        kwargs["work_root"],
+    )
+    assert request is not None
+    stage_root = module.binance_symbol_triplet_stage_root(kwargs["work_root"], request)
+    publish_market_dataset_artifact(stage_root / "dataset", _dataset("orphan"))
+    before = Path(kwargs["cursor_path"]).read_bytes()
+
+    with pytest.raises(FileExistsError, match="binding"):
+        module.execute_binance_symbol_triplet_postgres_stage(**kwargs)
+
+    assert Path(kwargs["cursor_path"]).read_bytes() == before
+    assert not (stage_root / "completion.json").exists()
+
+
+def test_runner_returns_none_for_completed_plan_without_touching_database(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import trade_rl.workflows.binance_symbol_triplet_stage_runner as module
+
+    plan = _plan()
+    kwargs = _run_kwargs(tmp_path, plan)
+    complete = SymbolTripletTrainingCursor(
+        plan_digest=plan.digest,
+        stage_count=plan.stage_count,
+        next_stage_index=plan.stage_count,
+        last_completed_stage_id=plan.stages[-1].stage_id,
+    )
+    write_symbol_triplet_training_cursor(kwargs["cursor_path"], complete)
+    monkeypatch.setattr(
+        module,
+        "_training_seeds",
+        lambda _: pytest.fail("completed plan must not load training config"),
+    )
+    monkeypatch.setattr(
+        module,
+        "build_postgres_market_dataset",
+        lambda *_args, **_kwargs: pytest.fail("completed plan must not build data"),
+    )
+
+    assert module.execute_binance_symbol_triplet_postgres_stage(**kwargs) is None

--- a/tests/workflows/test_binance_symbol_triplet_stage_runner.py
+++ b/tests/workflows/test_binance_symbol_triplet_stage_runner.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Any
 
 import numpy as np

--- a/trade_rl/workflows/binance_symbol_triplet_stage_runner.py
+++ b/trade_rl/workflows/binance_symbol_triplet_stage_runner.py
@@ -1,0 +1,235 @@
+"""Run one Binance USDS-M symbol-triplet stage from PostgreSQL evidence."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from pathlib import Path
+
+from trade_rl.data import publish_market_dataset_artifact
+from trade_rl.data.contracts import InstrumentExecutionRule
+from trade_rl.domain.common import require_sha256
+from trade_rl.integrations.postgres_indicator_artifacts import (
+    IndicatorArtifactConnection,
+)
+from trade_rl.integrations.postgres_market_dataset import (
+    build_postgres_market_dataset,
+)
+from trade_rl.workflows.symbol_triplet_stage_orchestrator import (
+    SymbolTripletStageRequest,
+    build_symbol_triplet_stage_request,
+    load_symbol_triplet_stage_completion,
+)
+from trade_rl.workflows.symbol_triplet_stage_training import (
+    SymbolTripletStageTrainingResult,
+    build_symbol_triplet_stage_dataset_binding,
+    execute_symbol_triplet_stage_training,
+    load_symbol_triplet_stage_dataset_binding,
+    write_symbol_triplet_stage_dataset_binding,
+)
+from trade_rl.workflows.symbol_triplet_training_cursor import (
+    SymbolTripletTrainingPlan,
+    SymbolTripletTrainingStage,
+    current_symbol_triplet_training_stage,
+    load_symbol_triplet_training_cursor,
+)
+from trade_rl.workflows.training_run import (
+    TrainingRunConfig,
+    normalize_training_run_config,
+)
+
+_PROVENANCE_SCHEMA = "binance_symbol_triplet_stage_provenance_v1"
+
+
+def _training_seeds(path: str | Path) -> tuple[int, ...]:
+    config = normalize_training_run_config(TrainingRunConfig.from_json(Path(path)))
+    return tuple(config.training.seeds)
+
+
+def binance_symbol_triplet_stage_root(
+    work_root: str | Path,
+    stage: SymbolTripletStageRequest | SymbolTripletTrainingStage,
+) -> Path:
+    """Return the deterministic immutable root for one Plan stage."""
+
+    root = Path(work_root).resolve()
+    return root / "stages" / f"stage-{stage.stage_index:04d}-{stage.stage_id[:16]}"
+
+
+def _previous_completion_path(
+    plan: SymbolTripletTrainingPlan,
+    work_root: str | Path,
+    *,
+    stage_index: int,
+) -> Path | None:
+    if stage_index == 0:
+        return None
+    previous_stage = plan.stages[stage_index - 1]
+    return binance_symbol_triplet_stage_root(work_root, previous_stage) / "completion.json"
+
+
+def current_binance_symbol_triplet_stage_request(
+    plan: SymbolTripletTrainingPlan,
+    cursor_path: str | Path,
+    base_config_path: str | Path,
+    work_root: str | Path,
+) -> SymbolTripletStageRequest | None:
+    """Resolve the current request and only the immediately prior completion."""
+
+    cursor = load_symbol_triplet_training_cursor(cursor_path, plan=plan)
+    stage = current_symbol_triplet_training_stage(plan, cursor)
+    if stage is None:
+        return None
+    previous_path = _previous_completion_path(
+        plan,
+        work_root,
+        stage_index=stage.stage_index,
+    )
+    previous_completion = (
+        None
+        if previous_path is None
+        else load_symbol_triplet_stage_completion(previous_path, plan=plan)
+    )
+    return build_symbol_triplet_stage_request(
+        plan,
+        cursor,
+        training_seeds=_training_seeds(base_config_path),
+        previous_completion=previous_completion,
+    )
+
+
+def _stage_provenance(request: SymbolTripletStageRequest) -> dict[str, object]:
+    return {
+        "cycle_index": request.cycle_index,
+        "plan_digest": request.plan_digest,
+        "request_digest": request.digest,
+        "schema_version": _PROVENANCE_SCHEMA,
+        "selected_symbols": request.symbols,
+        "slot_symbols": request.slot_symbols,
+        "stage_id": request.stage_id,
+        "stage_index": request.stage_index,
+        "train_split_slot": request.train_split_slot,
+    }
+
+
+def _prepare_bound_dataset(
+    *,
+    connection: IndicatorArtifactConnection,
+    request: SymbolTripletStageRequest,
+    dataset_path: Path,
+    binding_path: Path,
+    symbol_vocabulary: Sequence[str],
+    start_time: datetime,
+    end_time: datetime,
+    metadata: Mapping[str, Mapping[str, object]],
+    metadata_evidence_digest: str,
+    execution_rule_histories: Mapping[str, Sequence[InstrumentExecutionRule]] | None,
+) -> None:
+    dataset_exists = dataset_path.exists()
+    binding_exists = binding_path.exists()
+    if dataset_exists:
+        if not dataset_path.is_dir() or not binding_path.is_file():
+            raise FileExistsError(
+                "symbol-triplet stage dataset exists without an immutable binding"
+            )
+        load_symbol_triplet_stage_dataset_binding(
+            binding_path,
+            request=request,
+            dataset_path=dataset_path,
+        )
+        return
+    if binding_exists:
+        raise FileExistsError(
+            "symbol-triplet stage binding exists without its dataset artifact"
+        )
+
+    dataset = build_postgres_market_dataset(
+        connection,
+        symbols=request.symbols,
+        symbol_vocabulary=symbol_vocabulary,
+        slot_symbols=request.slot_symbols,
+        start_time=start_time,
+        end_time=end_time,
+        metadata=metadata,
+        metadata_evidence_digest=metadata_evidence_digest,
+        execution_rule_histories=execution_rule_histories,
+        symbol_triplet_provenance=_stage_provenance(request),
+    )
+    if dataset.symbols != request.slot_symbols:
+        raise ValueError("PostgreSQL stage dataset slot symbols differ from the request")
+    publish_market_dataset_artifact(dataset_path, dataset)
+    binding = build_symbol_triplet_stage_dataset_binding(
+        request,
+        dataset_path=dataset_path,
+        selected_symbols=request.symbols,
+    )
+    write_symbol_triplet_stage_dataset_binding(binding_path, binding)
+
+
+def execute_binance_symbol_triplet_postgres_stage(
+    *,
+    connection: IndicatorArtifactConnection,
+    plan: SymbolTripletTrainingPlan,
+    cursor_path: str | Path,
+    base_config_path: str | Path,
+    work_root: str | Path,
+    symbol_vocabulary: Sequence[str],
+    start_time: datetime,
+    end_time: datetime,
+    metadata: Mapping[str, Mapping[str, object]],
+    metadata_evidence_digest: str,
+    execution_rule_histories: Mapping[str, Sequence[InstrumentExecutionRule]]
+    | None = None,
+) -> SymbolTripletStageTrainingResult | None:
+    """Build/reuse the current PostgreSQL dataset and execute one training stage."""
+
+    require_sha256(metadata_evidence_digest, field="metadata_evidence_digest")
+    request = current_binance_symbol_triplet_stage_request(
+        plan,
+        cursor_path,
+        base_config_path,
+        work_root,
+    )
+    if request is None:
+        return None
+
+    stage_root = binance_symbol_triplet_stage_root(work_root, request)
+    dataset_path = stage_root / "dataset"
+    binding_path = stage_root / "dataset-binding.json"
+    _prepare_bound_dataset(
+        connection=connection,
+        request=request,
+        dataset_path=dataset_path,
+        binding_path=binding_path,
+        symbol_vocabulary=symbol_vocabulary,
+        start_time=start_time,
+        end_time=end_time,
+        metadata=metadata,
+        metadata_evidence_digest=metadata_evidence_digest,
+        execution_rule_histories=execution_rule_histories,
+    )
+    previous_completion_path = _previous_completion_path(
+        plan,
+        work_root,
+        stage_index=request.stage_index,
+    )
+    run_id = f"binance-triplet-stage-{request.stage_index:04d}-{request.stage_id[:16]}"
+    return execute_symbol_triplet_stage_training(
+        plan=plan,
+        cursor_path=Path(cursor_path),
+        previous_completion_path=previous_completion_path,
+        dataset_path=dataset_path,
+        dataset_binding_path=binding_path,
+        base_config_path=Path(base_config_path),
+        stage_config_path=stage_root / "training-config.json",
+        store_root=stage_root / "artifacts",
+        run_id=run_id,
+        completion_path=stage_root / "completion.json",
+    )
+
+
+__all__ = [
+    "binance_symbol_triplet_stage_root",
+    "current_binance_symbol_triplet_stage_request",
+    "execute_binance_symbol_triplet_postgres_stage",
+]

--- a/trade_rl/workflows/binance_symbol_triplet_stage_runner.py
+++ b/trade_rl/workflows/binance_symbol_triplet_stage_runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from datetime import datetime
 from pathlib import Path
+from typing import Final
 
 from trade_rl.data import publish_market_dataset_artifact
 from trade_rl.data.contracts import InstrumentExecutionRule
@@ -38,7 +39,7 @@ from trade_rl.workflows.training_run import (
     normalize_training_run_config,
 )
 
-_PROVENANCE_SCHEMA = "binance_symbol_triplet_stage_provenance_v1"
+_PROVENANCE_SCHEMA: Final = "binance_symbol_triplet_stage_provenance_v1"
 
 
 def _training_seeds(path: str | Path) -> tuple[int, ...]:

--- a/trade_rl/workflows/binance_symbol_triplet_stage_runner.py
+++ b/trade_rl/workflows/binance_symbol_triplet_stage_runner.py
@@ -65,7 +65,9 @@ def _previous_completion_path(
     if stage_index == 0:
         return None
     previous_stage = plan.stages[stage_index - 1]
-    return binance_symbol_triplet_stage_root(work_root, previous_stage) / "completion.json"
+    return (
+        binance_symbol_triplet_stage_root(work_root, previous_stage) / "completion.json"
+    )
 
 
 def current_binance_symbol_triplet_stage_request(
@@ -156,7 +158,9 @@ def _prepare_bound_dataset(
         symbol_triplet_provenance=_stage_provenance(request),
     )
     if dataset.symbols != request.slot_symbols:
-        raise ValueError("PostgreSQL stage dataset slot symbols differ from the request")
+        raise ValueError(
+            "PostgreSQL stage dataset slot symbols differ from the request"
+        )
     publish_market_dataset_artifact(dataset_path, dataset)
     binding = build_symbol_triplet_stage_dataset_binding(
         request,


### PR DESCRIPTION
## Stage A4.4.3c2

Connects the merged Plan/Cursor stage contracts to the actual Binance USDS-M PostgreSQL market-dataset builder without modifying the selected-final training path.

### Contract
- resolves only the current Plan/Cursor stage and the immediately previous completion
- passes the selected Binance symbols explicitly to PostgreSQL; no fixed train-slot or mutable global symbol state
- emits generic `SLOT0/SLOT1/SLOT2` datasets with stage/plan/request provenance bound into dataset identity
- stores each stage under a deterministic immutable root
- reuses an existing dataset only when its immutable binding validates
- rejects orphan dataset or binding artifacts fail-closed
- completed plans return before loading configuration or touching PostgreSQL
- delegates training and cursor advancement to the validated A4.4.3c1 executor

### TDD evidence
RED:
- tests initially targeted a nonexistent `binance_symbol_triplet_stage_runner` module

GREEN:
- head: `2eda3c72633bbcc509789720f4069cb64ea773c3`
- CI: success
- PostgreSQL Catalog: success
- pytest: `2400 passed, 2 skipped`
- coverage: `83.62%`
- Ruff, Format, MyPy, import architecture, critical branch coverage, CLI smoke, both OS compatibility, and Training image: success
- scope: 2 new files
- main comparison: `behind_by=0`