### PR TITLE
Add executable triplet stage command

### DIFF
--- a/examples/binance-multitimeframe/run_symbol_triplet_training_stage.py
+++ b/examples/binance-multitimeframe/run_symbol_triplet_training_stage.py
@@ -1,0 +1,89 @@
+"""Execute exactly one resumable Binance symbol-triplet training stage."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Sequence
+
+from trade_rl.workflows.binance_metadata_modes import BinanceMetadataMode
+from trade_rl.workflows.binance_symbol_triplet_stage_command import (
+    execute_binance_symbol_triplet_stage_command,
+)
+
+_RESULT_SCHEMA = "binance_symbol_triplet_stage_command_result_v1"
+
+
+def _parse_utc(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(f"invalid ISO-8601 datetime: {value}") from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError("datetime must include an explicit timezone")
+    return parsed.astimezone(UTC)
+
+
+def _result_payload(result: Any | None) -> dict[str, object]:
+    if result is None:
+        return {
+            "schema_version": _RESULT_SCHEMA,
+            "status": "complete",
+        }
+    return {
+        "completion_digest": result.completion.digest,
+        "next_stage_index": result.cursor.next_stage_index,
+        "run_id": result.training.run_id,
+        "schema_version": _RESULT_SCHEMA,
+        "stage_id": result.request.stage_id,
+        "stage_index": result.request.stage_index,
+        "status": result.training.status,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Execute the current immutable Binance USDS-M symbol-triplet stage, "
+            "then advance its Plan/Cursor only after validated final checkpoints."
+        )
+    )
+    parser.add_argument("--manifest-path", type=Path, required=True)
+    parser.add_argument("--plan-path", type=Path, required=True)
+    parser.add_argument("--cursor-path", type=Path, required=True)
+    parser.add_argument("--base-config-path", type=Path, required=True)
+    parser.add_argument("--work-root", type=Path, required=True)
+    parser.add_argument("--cache-root", type=Path, required=True)
+    parser.add_argument(
+        "--metadata-mode",
+        choices=tuple(mode.value for mode in BinanceMetadataMode),
+        required=True,
+    )
+    parser.add_argument("--start-time", type=_parse_utc, required=True)
+    parser.add_argument("--end-time", type=_parse_utc, required=True)
+    parser.add_argument("--conservative-static-path", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _parser().parse_args(argv)
+    result = execute_binance_symbol_triplet_stage_command(
+        manifest_path=arguments.manifest_path,
+        plan_path=arguments.plan_path,
+        cursor_path=arguments.cursor_path,
+        base_config_path=arguments.base_config_path,
+        work_root=arguments.work_root,
+        cache_root=arguments.cache_root,
+        metadata_mode=arguments.metadata_mode,
+        start_time=arguments.start_time,
+        end_time=arguments.end_time,
+        conservative_static_path=arguments.conservative_static_path,
+    )
+    print(json.dumps(_result_payload(result), ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/binance-multitimeframe/run_symbol_triplet_training_stage.py
+++ b/examples/binance-multitimeframe/run_symbol_triplet_training_stage.py
@@ -6,7 +6,7 @@ import argparse
 import json
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any, Callable, Sequence
 
 from trade_rl.workflows.binance_metadata_modes import BinanceMetadataMode
 from trade_rl.workflows.binance_symbol_triplet_stage_command import (
@@ -67,9 +67,13 @@ def _parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    execute: Callable[..., Any] = execute_binance_symbol_triplet_stage_command,
+) -> int:
     arguments = _parser().parse_args(argv)
-    result = execute_binance_symbol_triplet_stage_command(
+    result = execute(
         manifest_path=arguments.manifest_path,
         plan_path=arguments.plan_path,
         cursor_path=arguments.cursor_path,

--- a/tests/examples/test_symbol_triplet_training_stage_command.py
+++ b/tests/examples/test_symbol_triplet_training_stage_command.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+import runpy
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+_SCRIPT = Path("examples/binance-multitimeframe/run_symbol_triplet_training_stage.py")
+
+
+def _namespace() -> dict[str, Any]:
+    return runpy.run_path(str(_SCRIPT))
+
+
+def test_parse_utc_requires_an_explicit_timezone() -> None:
+    namespace = _namespace()
+
+    with pytest.raises(ValueError, match="timezone"):
+        namespace["_parse_utc"]("2026-01-01T00:00:00")
+
+    assert namespace["_parse_utc"]("2026-01-01T09:00:00+09:00").isoformat() == (
+        "2026-01-01T00:00:00+00:00"
+    )
+
+
+def test_result_payload_distinguishes_complete_and_published_stage() -> None:
+    namespace = _namespace()
+
+    assert namespace["_result_payload"](None) == {
+        "schema_version": "binance_symbol_triplet_stage_command_result_v1",
+        "status": "complete",
+    }
+
+    result = SimpleNamespace(
+        request=SimpleNamespace(stage_id="a" * 64, stage_index=7),
+        completion=SimpleNamespace(digest="b" * 64),
+        cursor=SimpleNamespace(next_stage_index=8),
+        training=SimpleNamespace(run_id="run-7", status="published"),
+    )
+    assert namespace["_result_payload"](result) == {
+        "completion_digest": "b" * 64,
+        "next_stage_index": 8,
+        "run_id": "run-7",
+        "schema_version": "binance_symbol_triplet_stage_command_result_v1",
+        "stage_id": "a" * 64,
+        "stage_index": 7,
+        "status": "published",
+    }
+
+
+def test_main_passes_paths_and_prints_one_json_object(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    namespace = _namespace()
+    observed: dict[str, Any] = {}
+
+    def execute(**kwargs: Any) -> None:
+        observed.update(kwargs)
+        return None
+
+    namespace["execute_binance_symbol_triplet_stage_command"] = execute
+    exit_code = namespace["main"](
+        [
+            "--manifest-path",
+            str(tmp_path / "manifest.json"),
+            "--plan-path",
+            str(tmp_path / "plan.json"),
+            "--cursor-path",
+            str(tmp_path / "cursor.json"),
+            "--base-config-path",
+            str(tmp_path / "training.json"),
+            "--work-root",
+            str(tmp_path / "work"),
+            "--cache-root",
+            str(tmp_path / "cache"),
+            "--metadata-mode",
+            "frozen_snapshot",
+            "--start-time",
+            "2024-12-01T00:00:00Z",
+            "--end-time",
+            "2026-07-01T00:00:00Z",
+        ]
+    )
+
+    assert exit_code == 0
+    assert observed["metadata_mode"] == "frozen_snapshot"
+    assert observed["manifest_path"] == tmp_path / "manifest.json"
+    assert observed["start_time"].isoformat() == "2024-12-01T00:00:00+00:00"
+    assert json.loads(capsys.readouterr().out) == {
+        "schema_version": "binance_symbol_triplet_stage_command_result_v1",
+        "status": "complete",
+    }

--- a/tests/examples/test_symbol_triplet_training_stage_command.py
+++ b/tests/examples/test_symbol_triplet_training_stage_command.py
@@ -52,7 +52,6 @@ def test_result_payload_distinguishes_complete_and_published_stage() -> None:
 
 
 def test_main_passes_paths_and_prints_one_json_object(
-    monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
     tmp_path: Path,
 ) -> None:
@@ -63,7 +62,6 @@ def test_main_passes_paths_and_prints_one_json_object(
         observed.update(kwargs)
         return None
 
-    namespace["execute_binance_symbol_triplet_stage_command"] = execute
     exit_code = namespace["main"](
         [
             "--manifest-path",
@@ -84,7 +82,8 @@ def test_main_passes_paths_and_prints_one_json_object(
             "2024-12-01T00:00:00Z",
             "--end-time",
             "2026-07-01T00:00:00Z",
-        ]
+        ],
+        execute=execute,
     )
 
     assert exit_code == 0

--- a/tests/workflows/test_binance_symbol_triplet_stage_command.py
+++ b/tests/workflows/test_binance_symbol_triplet_stage_command.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from trade_rl.workflows.binance_metadata_modes import (
+    BinanceMetadataMode,
+    BinanceMetadataResolution,
+)
+from trade_rl.workflows.symbol_triplet_manifest import build_symbol_triplet_manifest
+from trade_rl.workflows.symbol_triplet_stage_orchestrator import (
+    build_symbol_triplet_stage_request,
+)
+from trade_rl.workflows.symbol_triplet_training_cursor import (
+    build_symbol_triplet_training_plan,
+    initial_symbol_triplet_training_cursor,
+)
+
+_SYMBOLS = (
+    "BTCUSDT",
+    "ETHUSDT",
+    "BNBUSDT",
+    "SOLUSDT",
+    "XRPUSDT",
+    "ADAUSDT",
+    "DOGEUSDT",
+    "LINKUSDT",
+    "LTCUSDT",
+    "BCHUSDT",
+    "DOTUSDT",
+    "AVAXUSDT",
+    "UNIUSDT",
+    "TRXUSDT",
+    "ETCUSDT",
+)
+_START = datetime(2024, 12, 1, tzinfo=UTC)
+_END = datetime(2026, 7, 1, tzinfo=UTC)
+
+
+def _request():
+    manifest = build_symbol_triplet_manifest(_SYMBOLS, seed=31)
+    plan = build_symbol_triplet_training_plan(
+        manifest,
+        cycles=1,
+        slot_symbols=("SLOT0", "SLOT1", "SLOT2"),
+    )
+    request = build_symbol_triplet_stage_request(
+        plan,
+        initial_symbol_triplet_training_cursor(plan),
+        training_seeds=(0, 1),
+        previous_completion=None,
+    )
+    assert request is not None
+    return request
+
+
+def _resolution(symbols: tuple[str, ...]) -> BinanceMetadataResolution:
+    metadata = {
+        symbol: {
+            "listed_at": "2020-01-01T00:00:00+00:00",
+            "tick_size": 0.1,
+            "lot_size": 0.001,
+            "minimum_notional": 5.0,
+        }
+        for symbol in symbols
+    }
+    identity = {
+        "schema_version": "test_metadata_v1",
+        "symbols": symbols,
+    }
+    return BinanceMetadataResolution(
+        mode=BinanceMetadataMode.FROZEN_SNAPSHOT,
+        metadata=metadata,
+        execution_rule_histories=None,
+        identity_evidence=identity,
+        evidence_digest="a" * 64,
+        source_uri="test://metadata",
+        raw_payload=b"{}",
+    )
+
+
+def test_metadata_resolution_uses_only_current_request_symbols(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import trade_rl.workflows.binance_symbol_triplet_stage_command as module
+
+    request = _request()
+    observed: dict[str, Any] = {}
+
+    def resolve_frozen(**kwargs: Any) -> BinanceMetadataResolution:
+        observed.update(kwargs)
+        return _resolution(request.symbols)
+
+    monkeypatch.setattr(module, "resolve_frozen_snapshot", resolve_frozen)
+
+    result = module.resolve_binance_symbol_triplet_stage_metadata(
+        request,
+        mode=BinanceMetadataMode.FROZEN_SNAPSHOT,
+        transport=object(),
+        start_time=_START,
+        end_time=_END,
+    )
+
+    assert result.metadata.keys() == set(request.symbols)
+    assert observed["symbols"] == request.symbols
+    assert observed["start_time"] == _START
+    assert observed["end_time"] == _END
+
+
+def test_completed_plan_returns_before_metadata_and_database(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import trade_rl.workflows.binance_symbol_triplet_stage_command as module
+
+    monkeypatch.setattr(module, "load_symbol_triplet_manifest", lambda _: object())
+    monkeypatch.setattr(
+        module,
+        "load_symbol_triplet_training_plan",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        module,
+        "current_binance_symbol_triplet_stage_request",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        module,
+        "_resolve_metadata_for_request",
+        lambda *_args, **_kwargs: pytest.fail("completed plan must not resolve metadata"),
+    )
+    monkeypatch.setattr(
+        module,
+        "_postgres_connection",
+        lambda *_args, **_kwargs: pytest.fail("completed plan must not touch database"),
+    )
+
+    assert (
+        module.execute_binance_symbol_triplet_stage_command(
+            manifest_path=tmp_path / "manifest.json",
+            plan_path=tmp_path / "plan.json",
+            cursor_path=tmp_path / "cursor.json",
+            base_config_path=tmp_path / "config.json",
+            work_root=tmp_path / "work",
+            cache_root=tmp_path / "cache",
+            metadata_mode=BinanceMetadataMode.HISTORICAL_SIGNED,
+            start_time=_START,
+            end_time=_END,
+        )
+        is None
+    )
+
+
+def test_active_command_persists_metadata_and_executes_postgres_stage(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import trade_rl.workflows.binance_symbol_triplet_stage_command as module
+
+    request = _request()
+    resolution = _resolution(request.symbols)
+    sentinel = object()
+    observed: dict[str, Any] = {}
+
+    monkeypatch.setattr(module, "load_symbol_triplet_manifest", lambda _: object())
+    monkeypatch.setattr(
+        module,
+        "load_symbol_triplet_training_plan",
+        lambda *_args, **_kwargs: "plan",
+    )
+    monkeypatch.setattr(
+        module,
+        "current_binance_symbol_triplet_stage_request",
+        lambda *_args, **_kwargs: request,
+    )
+    monkeypatch.setattr(
+        module,
+        "_resolve_metadata_for_request",
+        lambda *_args, **_kwargs: resolution,
+    )
+
+    @contextmanager
+    def connection(_database_url: str):
+        yield "connection"
+
+    monkeypatch.setattr(module, "_postgres_connection", connection)
+
+    def execute(**kwargs: Any) -> object:
+        observed.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(module, "execute_binance_symbol_triplet_postgres_stage", execute)
+    monkeypatch.setenv("TRADE_RL_DATABASE_URL", "postgresql://example.invalid/trade_rl")
+
+    result = module.execute_binance_symbol_triplet_stage_command(
+        manifest_path=tmp_path / "manifest.json",
+        plan_path=tmp_path / "plan.json",
+        cursor_path=tmp_path / "cursor.json",
+        base_config_path=tmp_path / "config.json",
+        work_root=tmp_path / "work",
+        cache_root=tmp_path / "cache",
+        metadata_mode=BinanceMetadataMode.FROZEN_SNAPSHOT,
+        start_time=_START,
+        end_time=_END,
+    )
+
+    assert result is sentinel
+    assert observed["connection"] == "connection"
+    assert observed["plan"] == "plan"
+    assert observed["metadata"] == resolution.metadata
+    assert observed["metadata_evidence_digest"] == resolution.evidence_digest
+    metadata_root = (
+        module.binance_symbol_triplet_stage_root(tmp_path / "work", request)
+        / "metadata"
+    )
+    assert (metadata_root / "exchange-info.json").is_file()
+    assert (metadata_root / "exchange-info.raw.json").read_bytes() == b"{}"
+
+
+def test_metadata_artifact_reuse_rejects_drift(tmp_path: Path) -> None:
+    import trade_rl.workflows.binance_symbol_triplet_stage_command as module
+
+    resolution = _resolution(_request().symbols)
+    root = tmp_path / "metadata"
+
+    module.write_or_validate_binance_metadata_resolution(root, resolution)
+    module.write_or_validate_binance_metadata_resolution(root, resolution)
+    (root / "exchange-info.json").write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="metadata evidence"):
+        module.write_or_validate_binance_metadata_resolution(root, resolution)
+
+
+def test_missing_database_url_fails_after_metadata_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import trade_rl.workflows.binance_symbol_triplet_stage_command as module
+
+    request = _request()
+    monkeypatch.setattr(module, "load_symbol_triplet_manifest", lambda _: object())
+    monkeypatch.setattr(
+        module,
+        "load_symbol_triplet_training_plan",
+        lambda *_args, **_kwargs: SimpleNamespace(),
+    )
+    monkeypatch.setattr(
+        module,
+        "current_binance_symbol_triplet_stage_request",
+        lambda *_args, **_kwargs: request,
+    )
+    monkeypatch.setattr(
+        module,
+        "_resolve_metadata_for_request",
+        lambda *_args, **_kwargs: _resolution(request.symbols),
+    )
+    monkeypatch.delenv("TRADE_RL_DATABASE_URL", raising=False)
+
+    with pytest.raises(ValueError, match="TRADE_RL_DATABASE_URL"):
+        module.execute_binance_symbol_triplet_stage_command(
+            manifest_path=tmp_path / "manifest.json",
+            plan_path=tmp_path / "plan.json",
+            cursor_path=tmp_path / "cursor.json",
+            base_config_path=tmp_path / "config.json",
+            work_root=tmp_path / "work",
+            cache_root=tmp_path / "cache",
+            metadata_mode=BinanceMetadataMode.FROZEN_SNAPSHOT,
+            start_time=_START,
+            end_time=_END,
+        )

--- a/tests/workflows/test_binance_symbol_triplet_stage_command.py
+++ b/tests/workflows/test_binance_symbol_triplet_stage_command.py
@@ -132,7 +132,9 @@ def test_completed_plan_returns_before_metadata_and_database(
     monkeypatch.setattr(
         module,
         "_resolve_metadata_for_request",
-        lambda *_args, **_kwargs: pytest.fail("completed plan must not resolve metadata"),
+        lambda *_args, **_kwargs: pytest.fail(
+            "completed plan must not resolve metadata"
+        ),
     )
     monkeypatch.setattr(
         module,
@@ -194,7 +196,9 @@ def test_active_command_persists_metadata_and_executes_postgres_stage(
         observed.update(kwargs)
         return sentinel
 
-    monkeypatch.setattr(module, "execute_binance_symbol_triplet_postgres_stage", execute)
+    monkeypatch.setattr(
+        module, "execute_binance_symbol_triplet_postgres_stage", execute
+    )
     monkeypatch.setenv("TRADE_RL_DATABASE_URL", "postgresql://example.invalid/trade_rl")
 
     result = module.execute_binance_symbol_triplet_stage_command(

--- a/trade_rl/workflows/binance_symbol_triplet_stage_command.py
+++ b/trade_rl/workflows/binance_symbol_triplet_stage_command.py
@@ -1,0 +1,279 @@
+"""Operator command for one resumable Binance symbol-triplet training stage."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, cast
+
+from trade_rl.artifacts.codec import canonical_json_bytes
+from trade_rl.integrations.binance import BinanceMarket, BinancePublicTransport
+from trade_rl.release.asymmetric import load_public_verification_keys
+from trade_rl.workflows.binance_metadata_modes import (
+    BinanceMetadataMode,
+    BinanceMetadataResolution,
+    VerifiedBinanceRuleHistory,
+    load_verified_binance_rule_history,
+    resolution_from_historical_signed,
+    resolve_conservative_static,
+    resolve_frozen_snapshot,
+)
+from trade_rl.workflows.binance_symbol_triplet_stage_runner import (
+    binance_symbol_triplet_stage_root,
+    current_binance_symbol_triplet_stage_request,
+    execute_binance_symbol_triplet_postgres_stage,
+)
+from trade_rl.workflows.symbol_triplet_manifest import (
+    SymbolTripletManifest,
+    load_symbol_triplet_manifest,
+)
+from trade_rl.workflows.symbol_triplet_stage_orchestrator import (
+    SymbolTripletStageRequest,
+)
+from trade_rl.workflows.symbol_triplet_training_cursor import (
+    SymbolTripletTrainingPlan,
+    load_symbol_triplet_training_plan,
+)
+
+
+def _json_object(path: Path, *, field: str) -> dict[str, object]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"{field} must be valid JSON: {path}") from error
+    if not isinstance(payload, dict):
+        raise ValueError(f"{field} must be a JSON object: {path}")
+    return dict(payload)
+
+
+def _required_file_from_environment(name: str) -> Path:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        raise ValueError(f"{name} is required")
+    path = Path(raw)
+    if not path.is_file():
+        raise FileNotFoundError(f"{name} file is missing: {path}")
+    return path
+
+
+def _verified_history_from_environment() -> VerifiedBinanceRuleHistory:
+    history_path = _required_file_from_environment("TRADE_RL_BINANCE_RULE_HISTORY")
+    public_keys_path = _required_file_from_environment("TRADE_RL_METADATA_PUBLIC_KEYS")
+    trusted_keys = load_public_verification_keys(public_keys_path)
+    return load_verified_binance_rule_history(
+        _json_object(history_path, field="signed Binance rule history"),
+        trusted_keys=trusted_keys,
+        trusted_now=datetime.now(UTC),
+    )
+
+
+def _validate_resolution_scope(
+    request: SymbolTripletStageRequest,
+    resolution: BinanceMetadataResolution,
+) -> BinanceMetadataResolution:
+    missing_metadata = tuple(
+        symbol for symbol in request.symbols if symbol not in resolution.metadata
+    )
+    if missing_metadata:
+        raise ValueError(
+            "Binance metadata resolution is missing current stage symbols: "
+            + ", ".join(missing_metadata)
+        )
+    histories = resolution.execution_rule_histories
+    if histories is not None:
+        missing_histories = tuple(
+            symbol for symbol in request.symbols if symbol not in histories
+        )
+        if missing_histories:
+            raise ValueError(
+                "Binance execution-rule history is missing current stage symbols: "
+                + ", ".join(missing_histories)
+            )
+    return resolution
+
+
+def resolve_binance_symbol_triplet_stage_metadata(
+    request: SymbolTripletStageRequest,
+    *,
+    mode: BinanceMetadataMode | str,
+    transport: Any,
+    start_time: datetime,
+    end_time: datetime,
+    conservative_static_path: Path | None = None,
+    verified_history: VerifiedBinanceRuleHistory | None = None,
+) -> BinanceMetadataResolution:
+    """Resolve metadata for the current stage without consulting a fixed slot."""
+
+    resolved_mode = BinanceMetadataMode(mode)
+    if resolved_mode is BinanceMetadataMode.HISTORICAL_SIGNED:
+        if verified_history is None:
+            raise ValueError("historical_signed metadata requires verified history")
+        resolution = resolution_from_historical_signed(
+            verified_history,
+            start_time=start_time,
+            end_time=end_time,
+        )
+    elif resolved_mode is BinanceMetadataMode.FROZEN_SNAPSHOT:
+        resolution = resolve_frozen_snapshot(
+            transport=transport,
+            market=BinanceMarket.USDS_M,
+            symbols=request.symbols,
+            start_time=start_time,
+            end_time=end_time,
+        )
+    else:
+        if conservative_static_path is None:
+            raise ValueError(
+                "conservative_static metadata requires conservative_static_path"
+            )
+        resolution = resolve_conservative_static(
+            path=conservative_static_path,
+            symbols=request.symbols,
+            start_time=start_time,
+            end_time=end_time,
+        )
+    return _validate_resolution_scope(request, resolution)
+
+
+def _resolve_metadata_for_request(
+    request: SymbolTripletStageRequest,
+    *,
+    mode: BinanceMetadataMode | str,
+    cache_root: Path,
+    start_time: datetime,
+    end_time: datetime,
+    conservative_static_path: Path | None,
+) -> BinanceMetadataResolution:
+    resolved_mode = BinanceMetadataMode(mode)
+    verified_history = (
+        _verified_history_from_environment()
+        if resolved_mode is BinanceMetadataMode.HISTORICAL_SIGNED
+        else None
+    )
+    transport = BinancePublicTransport(cache_root=cache_root)
+    return resolve_binance_symbol_triplet_stage_metadata(
+        request,
+        mode=resolved_mode,
+        transport=transport,
+        start_time=start_time,
+        end_time=end_time,
+        conservative_static_path=conservative_static_path,
+        verified_history=verified_history,
+    )
+
+
+def write_or_validate_binance_metadata_resolution(
+    root: str | Path,
+    resolution: BinanceMetadataResolution,
+) -> Path:
+    """Write metadata evidence once or require exact byte-for-byte reuse."""
+
+    resolved_root = Path(root)
+    report_path = resolved_root / "exchange-info.json"
+    raw_path = resolved_root / "exchange-info.raw.json"
+    expected_report = canonical_json_bytes(resolution.report_payload()) + b"\n"
+    expected_raw = resolution.raw_payload
+
+    if not report_path.exists() and not raw_path.exists():
+        resolution.write_artifacts(resolved_root)
+        return report_path
+    if not report_path.is_file() or report_path.read_bytes() != expected_report:
+        raise ValueError("Binance metadata evidence report differs from the stage binding")
+    if expected_raw is None:
+        if raw_path.exists():
+            raise ValueError("Binance metadata evidence has an unexpected raw payload")
+    elif not raw_path.is_file() or raw_path.read_bytes() != expected_raw:
+        raise ValueError("Binance metadata evidence raw payload differs from the stage binding")
+    return report_path
+
+
+@contextmanager
+def _postgres_connection(database_url: str) -> Iterator[Any]:
+    try:
+        import psycopg
+    except ImportError as error:  # pragma: no cover - optional dependency boundary
+        raise RuntimeError("PostgreSQL symbol-triplet training requires psycopg") from error
+    with psycopg.connect(database_url) as connection:
+        yield connection
+
+
+def _manifest_universe(
+    manifest: SymbolTripletManifest | object,
+    request: SymbolTripletStageRequest,
+) -> tuple[str, ...]:
+    raw = getattr(manifest, "universe", request.symbols)
+    universe = tuple(cast(Any, raw))
+    if not universe or any(not isinstance(symbol, str) or not symbol for symbol in universe):
+        raise ValueError("symbol-triplet manifest universe is invalid")
+    return universe
+
+
+def execute_binance_symbol_triplet_stage_command(
+    *,
+    manifest_path: str | Path,
+    plan_path: str | Path,
+    cursor_path: str | Path,
+    base_config_path: str | Path,
+    work_root: str | Path,
+    cache_root: str | Path,
+    metadata_mode: BinanceMetadataMode | str,
+    start_time: datetime,
+    end_time: datetime,
+    conservative_static_path: str | Path | None = None,
+    database_url: str | None = None,
+) -> object | None:
+    """Execute exactly one active Plan/Cursor stage and return its result."""
+
+    manifest = load_symbol_triplet_manifest(manifest_path)
+    plan = load_symbol_triplet_training_plan(plan_path, manifest=manifest)
+    request = current_binance_symbol_triplet_stage_request(
+        plan,
+        cursor_path,
+        base_config_path,
+        work_root,
+    )
+    if request is None:
+        return None
+
+    resolved_static_path = (
+        None if conservative_static_path is None else Path(conservative_static_path)
+    )
+    resolution = _resolve_metadata_for_request(
+        request,
+        mode=metadata_mode,
+        cache_root=Path(cache_root),
+        start_time=start_time,
+        end_time=end_time,
+        conservative_static_path=resolved_static_path,
+    )
+    metadata_root = binance_symbol_triplet_stage_root(work_root, request) / "metadata"
+    write_or_validate_binance_metadata_resolution(metadata_root, resolution)
+
+    resolved_database_url = (database_url or os.environ.get("TRADE_RL_DATABASE_URL", "")).strip()
+    if not resolved_database_url:
+        raise ValueError("TRADE_RL_DATABASE_URL is required for PostgreSQL market data")
+    with _postgres_connection(resolved_database_url) as connection:
+        return execute_binance_symbol_triplet_postgres_stage(
+            connection=connection,
+            plan=cast(SymbolTripletTrainingPlan, plan),
+            cursor_path=cursor_path,
+            base_config_path=base_config_path,
+            work_root=work_root,
+            symbol_vocabulary=_manifest_universe(manifest, request),
+            start_time=start_time,
+            end_time=end_time,
+            metadata=cast(Mapping[str, Mapping[str, object]], resolution.metadata),
+            metadata_evidence_digest=resolution.evidence_digest,
+            execution_rule_histories=resolution.execution_rule_histories,
+        )
+
+
+__all__ = [
+    "execute_binance_symbol_triplet_stage_command",
+    "resolve_binance_symbol_triplet_stage_metadata",
+    "write_or_validate_binance_metadata_resolution",
+]

--- a/trade_rl/workflows/binance_symbol_triplet_stage_command.py
+++ b/trade_rl/workflows/binance_symbol_triplet_stage_command.py
@@ -182,12 +182,16 @@ def write_or_validate_binance_metadata_resolution(
         resolution.write_artifacts(resolved_root)
         return report_path
     if not report_path.is_file() or report_path.read_bytes() != expected_report:
-        raise ValueError("Binance metadata evidence report differs from the stage binding")
+        raise ValueError(
+            "Binance metadata evidence report differs from the stage binding"
+        )
     if expected_raw is None:
         if raw_path.exists():
             raise ValueError("Binance metadata evidence has an unexpected raw payload")
     elif not raw_path.is_file() or raw_path.read_bytes() != expected_raw:
-        raise ValueError("Binance metadata evidence raw payload differs from the stage binding")
+        raise ValueError(
+            "Binance metadata evidence raw payload differs from the stage binding"
+        )
     return report_path
 
 
@@ -196,7 +200,9 @@ def _postgres_connection(database_url: str) -> Iterator[Any]:
     try:
         import psycopg
     except ImportError as error:  # pragma: no cover - optional dependency boundary
-        raise RuntimeError("PostgreSQL symbol-triplet training requires psycopg") from error
+        raise RuntimeError(
+            "PostgreSQL symbol-triplet training requires psycopg"
+        ) from error
     with psycopg.connect(database_url) as connection:
         yield connection
 
@@ -207,7 +213,9 @@ def _manifest_universe(
 ) -> tuple[str, ...]:
     raw = getattr(manifest, "universe", request.symbols)
     universe = tuple(cast(Any, raw))
-    if not universe or any(not isinstance(symbol, str) or not symbol for symbol in universe):
+    if not universe or any(
+        not isinstance(symbol, str) or not symbol for symbol in universe
+    ):
         raise ValueError("symbol-triplet manifest universe is invalid")
     return universe
 
@@ -253,7 +261,9 @@ def execute_binance_symbol_triplet_stage_command(
     metadata_root = binance_symbol_triplet_stage_root(work_root, request) / "metadata"
     write_or_validate_binance_metadata_resolution(metadata_root, resolution)
 
-    resolved_database_url = (database_url or os.environ.get("TRADE_RL_DATABASE_URL", "")).strip()
+    resolved_database_url = (
+        database_url or os.environ.get("TRADE_RL_DATABASE_URL", "")
+    ).strip()
     if not resolved_database_url:
         raise ValueError("TRADE_RL_DATABASE_URL is required for PostgreSQL market data")
     with _postgres_connection(resolved_database_url) as connection:


### PR DESCRIPTION
## Stage A4.4.3c3

Add the operator-facing one-stage command for resumable Binance symbol-triplet training.

### Contracts

- Load and validate the immutable Manifest and Training Plan before resolving work.
- Resolve the current request from the persisted Cursor and prior stage evidence.
- Return immediately for a completed Plan without touching Binance metadata or PostgreSQL.
- Resolve Binance execution metadata for the active stage using `historical_signed`, `frozen_snapshot`, or `conservative_static` mode.
- Persist metadata evidence once and require byte-for-byte reuse on retries.
- Require PostgreSQL only after an active stage and its metadata evidence have been resolved.
- Delegate dataset construction and training publication to the merged Plan/Cursor-aware PostgreSQL stage runner.
- Provide a direct CLI with timezone-aware UTC parsing and one canonical JSON result object.
- Keep the legacy fixed `TRADE_RL_SYMBOL_TRIPLET_TRAIN_SLOT` path out of this command.

### TDD evidence

- RED: the original CLI test exposed the invalid `runpy` dictionary injection boundary.
- RED: the corrected contract failed only because `main()` did not accept an explicit executor (`1 failed, 2407 passed, 2 skipped`).
- GREEN: `main(..., execute=...)` now supports explicit test injection while normal CLI execution remains bound to the canonical command.

### Final verification — head `28009c02827b55f19b5f23a0390c38b79c4f2e28`

- Ruff: passed
- Ruff format: passed
- MyPy: passed
- Import architecture: passed
- Recovery and structured serving smoke: passed
- Full pytest: `2408 passed, 2 skipped`
- Coverage: `83.54%`
- Critical branch coverage: passed
- CLI smoke: passed
- Ubuntu compatibility: passed
- Windows compatibility: passed
- Training image build/runtime probe: passed
- PostgreSQL Catalog compose, migration, unit, and integration checks: passed
- Main comparison: `behind_by=0`
- Changed files: 4
