### PR TITLE
Fix Studio review follow-up races

### DIFF
--- a/studio/src/live/MarketReplayChart.test.tsx
+++ b/studio/src/live/MarketReplayChart.test.tsx
@@ -48,4 +48,18 @@ describe('MarketReplayChart', () => {
     expect(container.querySelector('.live-marker--sell')).not.toBeNull()
     expect(container.querySelector('.live-marker--buy')).toBeNull()
   })
+
+  it('does not invent a primary asset direction when only another asset changes', () => {
+    const record = {
+      ...positionRecord(),
+      weightsBefore: [0.1, 0.1],
+      weightsAfter: [0.1, 0.2],
+    }
+    const { container } = render(
+      <MarketReplayChart records={[record]} cursorSequence={1} compressed={false} />,
+    )
+
+    expect(container.querySelector('.live-marker--buy')).toBeNull()
+    expect(container.querySelector('.live-marker--sell')).toBeNull()
+  })
 })

--- a/studio/src/live/MarketReplayChart.tsx
+++ b/studio/src/live/MarketReplayChart.tsx
@@ -71,17 +71,18 @@ export function MarketReplayChart({ records, cursorSequence, compressed }: Marke
           const bodyTop = y(Math.max(open, close))
           const bodyHeight = Math.max(1.5, Math.abs(y(open) - y(close)))
           const delta = weightDelta(record)
+          const direction = delta > 0 ? 'buy' : delta < 0 ? 'sell' : null
           const markerY = delta >= 0 ? y(recordLow) + 18 : y(recordHigh) - 18
           return (
             <g key={`${record.sequence}-${record.environmentId}`}>
               <line x1={candleX} x2={candleX} y1={y(recordHigh)} y2={y(recordLow)} className={rising ? 'live-candle live-candle--up' : 'live-candle live-candle--down'} />
               <rect x={candleX - candleWidth / 2} y={bodyTop} width={candleWidth} height={bodyHeight} rx="1" className={rising ? 'live-candle live-candle--up' : 'live-candle live-candle--down'} />
-              {record.eventType === 'position' ? (
+              {record.eventType === 'position' && direction !== null ? (
                 <path
-                  d={delta >= 0
+                  d={direction === 'buy'
                     ? `M ${candleX} ${markerY - 8} L ${candleX - 7} ${markerY + 5} L ${candleX + 7} ${markerY + 5} Z`
                     : `M ${candleX} ${markerY + 8} L ${candleX - 7} ${markerY - 5} L ${candleX + 7} ${markerY - 5} Z`}
-                  className={delta >= 0 ? 'live-marker live-marker--buy' : 'live-marker live-marker--sell'}
+                  className={`live-marker live-marker--${direction}`}
                 />
               ) : null}
               {record.eventType === 'risk' ? <circle cx={candleX} cy={markerY} r="5" className="live-marker live-marker--risk" /> : null}

--- a/studio/src/pages/RunCenterPage.tsx
+++ b/studio/src/pages/RunCenterPage.tsx
@@ -14,18 +14,25 @@ export function RunCenterPage({ api = studioApi }: RunCenterPageProps) {
   const [lines, setLines] = useState<string[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const selectedIdRef = useRef(selectedId)
   const logRequest = useRef(0)
+
+  function selectJob(jobId: string | null) {
+    selectedIdRef.current = jobId
+    setSelectedId(jobId)
+    replaceParams({ job: jobId })
+  }
 
   async function refreshJobs() {
     setLoading(true); setError(null)
     try {
       const response = await api.loadJobs()
       setJobs(response.items)
-      const next = selectedId && response.items.some((item) => item.id === selectedId)
-        ? selectedId
+      const current = selectedIdRef.current
+      const next = current && response.items.some((item) => item.id === current)
+        ? current
         : response.items[0]?.id ?? null
-      setSelectedId(next)
-      replaceParams({ job: next })
+      selectJob(next)
       if (next) {
         await loadLog(next)
       } else {
@@ -38,7 +45,7 @@ export function RunCenterPage({ api = studioApi }: RunCenterPageProps) {
 
   async function loadLog(jobId: string) {
     const sequence = ++logRequest.current
-    setSelectedId(jobId); replaceParams({ job: jobId }); setError(null)
+    selectJob(jobId); setError(null)
     try {
       const response = await api.loadJobLog(jobId)
       if (sequence === logRequest.current) setLines(response.lines)

--- a/studio/src/pages/RuntimePages.test.tsx
+++ b/studio/src/pages/RuntimePages.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { StudioApi } from '../api/studioApi'
-import type { ConfigSummary, DatasetSummary, JobSummary } from '../data/types'
+import type { ConfigSummary, DatasetSummary, JobListResponse, JobSummary } from '../data/types'
 import { DataLabPage } from './DataLabPage'
 import { ExperimentsPage } from './ExperimentsPage'
 import { RunCenterPage } from './RunCenterPage'
@@ -57,6 +57,20 @@ const job: JobSummary = {
   exitCode: null,
   cancellable: true,
   error: null,
+}
+
+const job2: JobSummary = {
+  ...job,
+  id: 'job-2',
+  runId: 'run-2',
+  pid: 456,
+  pidStartToken: '100',
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((next) => { resolve = next })
+  return { promise, resolve }
 }
 
 function api(overrides: Partial<StudioApi> = {}): StudioApi {
@@ -124,5 +138,35 @@ describe('RunCenterPage', () => {
 
     await waitFor(() => expect(runtimeApi.cancelJob).toHaveBeenCalledWith('job-1'))
     expect(await screen.findAllByText('cancelled')).toHaveLength(3)
+  })
+
+  it('preserves a newer job selection when a jobs refresh completes', async () => {
+    window.history.replaceState({}, '', '/?job=job-1')
+    const user = userEvent.setup()
+    const refreshRequest = deferred<JobListResponse>()
+    const loadJobs = vi.fn()
+      .mockResolvedValueOnce({ items: [job, job2], total: 2 })
+      .mockReturnValueOnce(refreshRequest.promise)
+    const loadJobLog = vi.fn(async (jobId: string) => ({
+      jobId,
+      lines: [`${jobId} log`],
+      truncated: false,
+    }))
+    const runtimeApi = api({ loadJobs, loadJobLog })
+    render(<RunCenterPage api={runtimeApi} />)
+
+    await waitFor(() => expect(loadJobLog).toHaveBeenCalledWith('job-1'))
+    await user.click(screen.getByRole('button', { name: '再読込' }))
+    await waitFor(() => expect(loadJobs).toHaveBeenCalledTimes(2))
+    await user.click(screen.getByRole('button', { name: /job-2 running/i }))
+    expect(await screen.findByLabelText('job log')).toHaveTextContent('job-2 log')
+
+    await act(async () => {
+      refreshRequest.resolve({ items: [job, job2], total: 2 })
+    })
+    await waitFor(() => expect(screen.getByRole('button', { name: '再読込' })).toBeEnabled())
+
+    expect(screen.getByRole('button', { name: /job-2 running/i })).toHaveClass('runtime-row--selected')
+    expect(screen.getByLabelText('job log')).toHaveTextContent('job-2 log')
   })
 })


### PR DESCRIPTION
## Summary

Fix two post-merge review findings from PR #314:

- suppress BUY/SELL markers when the displayed primary asset weight delta is zero, even when another asset caused the `position` event
- preserve the newest Run Center job selection and log when an in-flight jobs refresh completes

## Regression coverage

- covers a multi-asset position event where the primary asset is unchanged and verifies that no directional marker is invented
- uses a deferred jobs response to verify that refresh completion cannot overwrite a newer user selection

## TDD evidence

RED was verified on `a4efc6af375c4c742cbf05e9ca79fce54011dbe0` in CI run #4947:

- the two newly added regression tests failed for the expected reasons
- the existing 45 Studio tests passed

GREEN was verified on `77e10276b980d6ac4940d774c9a4a05b3bda0b0a` in CI run #4952.

## Verification

- Studio: 15 test files, 47 tests passed
- TypeScript typecheck: passed
- Vite production build: passed
- fixed viewport layout checks: passed
- Python: 2,513 passed, 2 skipped
- total coverage: 83.43% (required 80%)
- Ruff, format, MyPy, workflow security, dead-code, serving smoke, CLI smoke: passed
- import architecture: 10 contracts kept, 0 broken
- critical branch coverage ratchet: passed
- Windows and Ubuntu compatibility jobs: passed
- complete training image build and non-root runtime probe: passed

## Scope

The diff is limited to two Studio production files and their two regression test files.