### PR TITLE
Harden serving publication integrity

### DIFF
--- a/tests/workflows/test_release_packaging_integrity.py
+++ b/tests/workflows/test_release_packaging_integrity.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import hashlib
+import os
+from datetime import timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import trade_rl.workflows.release_packaging as release_packaging
+from tests.serving.conftest import _rebuild_v3_training_run
+from tests.serving.test_package import (
+    PUBLIC_KEY,
+    _confirmation,
+    _training_run,
+)
+from trade_rl.artifacts.run_manifest import RunFile, TrainingRunManifest
+from trade_rl.rl.sequence_observations import SEQUENCE_OBSERVATION_SCHEMA
+from trade_rl.workflows.release_packaging import package_selected_training_run
+
+
+def _complete_training_run(
+    root: Path,
+    **kwargs: Any,
+) -> TrainingRunManifest:
+    return _rebuild_v3_training_run(_training_run, root, **kwargs)
+
+
+def _package(
+    tmp_path: Path,
+    training_root: Path,
+    training: TrainingRunManifest,
+) -> None:
+    confirmation_path = tmp_path / "confirmation.json"
+    _confirmation(confirmation_path, training)
+    package_selected_training_run(
+        training_root=training_root,
+        confirmation_path=confirmation_path,
+        output_root=tmp_path / "bundle",
+        signal_digest="a" * 64,
+        selection_digest="b" * 64,
+        trusted_confirmation_keys={PUBLIC_KEY.key_id: PUBLIC_KEY},
+        trusted_now=training.completed_at + timedelta(days=30),
+    )
+
+
+def _run_file(path: str, content: bytes, *, size_delta: int = 0) -> RunFile:
+    return RunFile(
+        path=path,
+        digest=hashlib.sha256(content).hexdigest(),
+        size_bytes=len(content) + size_delta,
+    )
+
+
+def test_sequence_publication_requires_structured_policy_loader(
+    tmp_path: Path,
+) -> None:
+    training_root = tmp_path / "training"
+    training = _complete_training_run(
+        training_root,
+        run_kind="research_selected_final",
+        observation_schema=SEQUENCE_OBSERVATION_SCHEMA,
+        architecture_digest="9" * 64,
+        include_structured_loader=False,
+    )
+
+    with pytest.raises(ValueError, match="structured policy loader"):
+        _package(tmp_path, training_root, training)
+
+    assert not (tmp_path / "bundle").exists()
+
+
+def test_sequence_publication_rejects_loader_action_size_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    training_root = tmp_path / "training"
+    training = _complete_training_run(
+        training_root,
+        run_kind="research_selected_final",
+        observation_schema=SEQUENCE_OBSERVATION_SCHEMA,
+        architecture_digest="9" * 64,
+        include_structured_loader=True,
+    )
+    monkeypatch.setattr(
+        "trade_rl.serving.policy_loader.load_structured_policy_loader_manifest",
+        lambda _: {"architecture_digest": "9" * 64, "action_size": 999},
+    )
+
+    with pytest.raises(ValueError, match="action size"):
+        _package(tmp_path, training_root, training)
+
+    assert not (tmp_path / "bundle").exists()
+
+
+def test_publication_rejects_artifact_changed_after_manifest_validation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    training_root = tmp_path / "training"
+    training = _complete_training_run(
+        training_root,
+        run_kind="research_selected_final",
+    )
+    original_validate = release_packaging.validate_training_run_directory
+
+    def validate_then_mutate(path: Path) -> TrainingRunManifest:
+        manifest = original_validate(path)
+        (path / "policy.zip").write_bytes(b"changed-after-validation")
+        return manifest
+
+    monkeypatch.setattr(
+        release_packaging,
+        "validate_training_run_directory",
+        validate_then_mutate,
+    )
+
+    with pytest.raises(ValueError, match="source artifact identity changed"):
+        _package(tmp_path, training_root, training)
+
+    assert not (tmp_path / "bundle").exists()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires privileges")
+def test_verified_copy_rejects_symlink_source(tmp_path: Path) -> None:
+    training_root = tmp_path / "training"
+    training_root.mkdir()
+    outside = tmp_path / "outside.bin"
+    content = b"outside"
+    outside.write_bytes(content)
+    (training_root / "artifact.bin").symlink_to(outside)
+
+    with pytest.raises(ValueError, match="source artifact identity changed"):
+        release_packaging._copy_verified_run_file(
+            training_root=training_root,
+            stage=tmp_path / "stage",
+            item=_run_file("artifact.bin", content),
+        )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink creation requires privileges")
+def test_verified_copy_rejects_parent_symlink_escape(tmp_path: Path) -> None:
+    training_root = tmp_path / "training"
+    training_root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    content = b"outside"
+    (outside / "artifact.bin").write_bytes(content)
+    (training_root / "linked").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="escapes training root"):
+        release_packaging._copy_verified_run_file(
+            training_root=training_root,
+            stage=tmp_path / "stage",
+            item=_run_file("linked/artifact.bin", content),
+        )
+
+
+def test_verified_copy_rejects_missing_source(tmp_path: Path) -> None:
+    training_root = tmp_path / "training"
+    training_root.mkdir()
+
+    with pytest.raises(ValueError, match="source artifact identity changed"):
+        release_packaging._copy_verified_run_file(
+            training_root=training_root,
+            stage=tmp_path / "stage",
+            item=_run_file("missing.bin", b"missing"),
+        )
+
+
+def test_verified_copy_rejects_source_size_mismatch(tmp_path: Path) -> None:
+    training_root = tmp_path / "training"
+    training_root.mkdir()
+    content = b"artifact"
+    (training_root / "artifact.bin").write_bytes(content)
+
+    with pytest.raises(ValueError, match="source artifact identity changed"):
+        release_packaging._copy_verified_run_file(
+            training_root=training_root,
+            stage=tmp_path / "stage",
+            item=_run_file("artifact.bin", content, size_delta=1),
+        )
+
+
+def test_verified_copy_rejects_destination_digest_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    training_root = tmp_path / "training"
+    training_root.mkdir()
+    content = b"artifact"
+    (training_root / "artifact.bin").write_bytes(content)
+    monkeypatch.setattr(release_packaging, "_file_digest", lambda _: "f" * 64)
+
+    with pytest.raises(ValueError, match="destination artifact identity mismatch"):
+        release_packaging._copy_verified_run_file(
+            training_root=training_root,
+            stage=tmp_path / "stage",
+            item=_run_file("artifact.bin", content),
+        )
+
+    assert not (tmp_path / "stage" / "artifact.bin").exists()
+    assert not (tmp_path / "stage" / ".artifact.bin.tmp").exists()

--- a/trade_rl/workflows/release_packaging.py
+++ b/trade_rl/workflows/release_packaging.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import shutil
@@ -9,7 +10,7 @@ from collections.abc import Mapping
 from datetime import datetime
 from pathlib import Path
 
-from trade_rl.artifacts.run_manifest import validate_training_run_directory
+from trade_rl.artifacts.run_manifest import RunFile, validate_training_run_directory
 from trade_rl.data.metadata_promotion import (
     METADATA_PROMOTION_FILE_NAME,
     load_metadata_promotion_evidence,
@@ -72,6 +73,64 @@ def _number(value: object, *, field: str) -> float:
 
 def _execution_cost(training_root: Path) -> ExecutionCostConfig:
     return load_training_execution_cost(training_root / "environment.json")
+
+
+def _file_digest(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _copy_verified_run_file(
+    *,
+    training_root: Path,
+    stage: Path,
+    item: RunFile,
+) -> str:
+    resolved_root = training_root.resolve()
+    source = training_root / item.path
+    if source.is_symlink():
+        raise ValueError(f"source artifact identity changed: {item.path}")
+    resolved_source = source.resolve()
+    if (
+        resolved_root != resolved_source
+        and resolved_root not in resolved_source.parents
+    ):
+        raise ValueError("source artifact path escapes training root")
+    if not source.is_file():
+        raise ValueError(f"source artifact identity changed: {item.path}")
+
+    destination = stage / item.path
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_name(f".{destination.name}.tmp")
+    temporary.unlink(missing_ok=True)
+    digest = hashlib.sha256()
+    copied_size = 0
+    try:
+        with source.open("rb") as source_handle, temporary.open("xb") as output_handle:
+            if os.fstat(source_handle.fileno()).st_size != item.size_bytes:
+                raise ValueError(f"source artifact identity changed: {item.path}")
+            for chunk in iter(lambda: source_handle.read(1024 * 1024), b""):
+                copied_size += len(chunk)
+                digest.update(chunk)
+                output_handle.write(chunk)
+            output_handle.flush()
+            os.fsync(output_handle.fileno())
+        if copied_size != item.size_bytes or digest.hexdigest() != item.digest:
+            raise ValueError(f"source artifact identity changed: {item.path}")
+        destination_identity_matches = (
+            temporary.stat().st_size == item.size_bytes
+            and _file_digest(temporary) == item.digest
+        )
+        if not destination_identity_matches:
+            raise ValueError(f"destination artifact identity mismatch: {item.path}")
+        os.replace(temporary, destination)
+        return item.path
+    except Exception:
+        temporary.unlink(missing_ok=True)
+        raise
 
 
 def package_selected_training_run(
@@ -195,13 +254,14 @@ def package_selected_training_run(
         shutil.rmtree(stage)
     stage.mkdir(parents=True)
     try:
-        artifact_paths: list[str] = []
-        for item in manifest.files:
-            source = training_root / item.path
-            destination = stage / item.path
-            destination.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(source, destination)
-            artifact_paths.append(item.path)
+        artifact_paths = [
+            _copy_verified_run_file(
+                training_root=training_root,
+                stage=stage,
+                item=item,
+            )
+            for item in manifest.files
+        ]
         shutil.copy2(training_root / "run.json", stage / "training-run.json")
         artifact_paths.append("training-run.json")
         shutil.copy2(confirmation_path, stage / "confirmation-evidence.json")
@@ -248,18 +308,29 @@ def package_selected_training_run(
                 load_structured_policy_loader_manifest,
             )
 
-            structured_loader_path = stage / STRUCTURED_POLICY_LOADER_NAME
-            if structured_loader_path.is_file():
-                structured_loader = load_structured_policy_loader_manifest(
-                    structured_loader_path
+            manifest_paths = {item.path for item in manifest.files}
+            if STRUCTURED_POLICY_LOADER_NAME not in manifest_paths:
+                raise ValueError(
+                    "structured policy loader is missing from training manifest"
                 )
-                raw_architecture_digest = structured_loader.get("architecture_digest")
-                if not isinstance(raw_architecture_digest, str):
-                    raise ValueError("structured loader architecture digest is missing")
-                if architecture_digest != raw_architecture_digest:
-                    raise ValueError(
-                        "structured loader architecture differs from ensemble"
-                    )
+            structured_loader_path = stage / STRUCTURED_POLICY_LOADER_NAME
+            if not structured_loader_path.is_file():
+                raise ValueError(
+                    "structured policy loader is missing from staged bundle"
+                )
+            structured_loader = load_structured_policy_loader_manifest(
+                structured_loader_path
+            )
+            raw_architecture_digest = structured_loader.get("architecture_digest")
+            if not isinstance(raw_architecture_digest, str):
+                raise ValueError("structured loader architecture digest is missing")
+            if architecture_digest != raw_architecture_digest:
+                raise ValueError("structured loader architecture differs from ensemble")
+            raw_action_size = structured_loader.get("action_size")
+            if raw_action_size is not None and raw_action_size != action_spec.size:
+                raise ValueError(
+                    "structured loader action size differs from training action contract"
+                )
         bundle_manifest = ServingBundleManifest.build(
             root=stage,
             dataset_id=manifest.dataset_id,


### PR DESCRIPTION
## Summary

- verify every manifest-bound training artifact by size and SHA-256 while copying into serving staging
- reject symlinks, parent-directory root escapes, missing files, source mutation, and destination corruption
- require structured-policy loader closure for sequence policies
- reject structured loader architecture or action-size mismatches before publication
- preserve atomic staging cleanup and immutable output behavior

## TDD evidence

The initial regression-only head failed exactly the three intended cases:

- missing structured policy loader
- structured loader action-size mismatch
- artifact changed after manifest validation

Result: `3 failed, 2691 passed, 2 skipped`.

The implementation then passed the full suite, while the critical coverage ratchet correctly rejected newly untested failure branches. Focused tests were added for symlinks, parent-directory root escape, missing sources, source size mismatch, and destination digest mismatch without lowering any coverage threshold.

## Final verification

Verified on unchanged final head `bfc54e57d8422abea4faaa31186a575165197882`, based directly on main after PR #328:

- CI: success, run `30681065601`
- PostgreSQL Catalog: success, run `30681065599`
- Ruff: success
- Ruff format: 823 files formatted
- MyPy: 325 source files, 0 issues
- Import Linter: 10 contracts kept, 0 broken
- Studio: 45 tests passed; typecheck, production build, and fixed-layout checks passed
- Recovery and structured-serving smoke: 2 passed
- Python: `2706 passed, 4 skipped`
- Total branch-aware coverage: `82.73%` (required 80%)
- `release_packaging.py`: 95% statement coverage
- Critical branch coverage: `release_packaging.py 91.67% >= 90%`
- Ubuntu and Windows compatibility: success
- Complete training image and packaged non-root runtime probe: success
- Unresolved review threads: 0

## Scope

No training algorithm, evaluation metric, policy output, Studio UI, Stage A authorization, serving bundle schema, or release approval behavior changes.