### PR TITLE
Unify package and uv toolchain identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,8 +146,17 @@ jobs:
       - name: Critical branch coverage
         run: uv run python .github/check_critical_coverage.py coverage.json pyproject.toml
 
-      - name: CLI smoke test
-        run: uv run trade-rl --version
+      - name: Package and uv identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected="$(uv run python -c 'from importlib.metadata import version; print(version("trade-rl"))')"
+          module="$(uv run python -c 'import trade_rl; print(trade_rl.__version__)')"
+          cli="$(uv run trade-rl --version)"
+          uv_version="$(python -c 'import tomllib; print(tomllib.load(open("uv.toml", "rb"))["required-version"].removeprefix("=="))')"
+          test "$module" = "$expected"
+          test "$cli" = "trade-rl $expected"
+          test "$(uv --version)" = "uv $uv_version"
 
   compatibility:
     name: Compatibility (${{ matrix.os }})

--- a/Dockerfile.training
+++ b/Dockerfile.training
@@ -26,9 +26,13 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     UV_PROJECT_ENVIRONMENT=/opt/trade-rl-venv \
     PATH="/opt/trade-rl-venv/bin:${PATH}"
 
+COPY uv.toml /tmp/trade-rl-uv.toml
 RUN groupadd --system trainer \
     && useradd --system --gid trainer --create-home trainer \
-    && pip install --no-cache-dir uv==0.10.0
+    && UV_VERSION="$(python -c 'import tomllib; print(tomllib.load(open("/tmp/trade-rl-uv.toml", "rb"))["required-version"].removeprefix("=="))')" \
+    && pip install --no-cache-dir "uv==${UV_VERSION}" \
+    && test "$(uv --version)" = "uv ${UV_VERSION}" \
+    && rm /tmp/trade-rl-uv.toml
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
@@ -36,7 +40,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && apt-get install -y --no-install-recommends build-essential
 
 WORKDIR /workspace
-COPY pyproject.toml uv.lock README.md ./
+COPY pyproject.toml uv.lock uv.toml README.md ./
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --extra train-sb3 --extra postgres --no-dev --no-install-project \
     && mkdir -p \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trade-rl"
-version = "0.3.0"
+dynamic = ["version"]
 description = "Baseline-anchored residual reinforcement learning for portfolio research"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
@@ -53,6 +53,9 @@ export = [
 
 [project.scripts]
 trade-rl = "trade_rl.cli:main"
+
+[tool.setuptools.dynamic]
+version = {attr = "trade_rl._version.__version__"}
 
 [tool.setuptools.packages.find]
 where = ["."]
@@ -119,6 +122,7 @@ branch = true
 show_missing = true
 skip_covered = true
 fail_under = 80
+
 [tool.trade_rl.critical_coverage]
 metric = "branch"
 target = 90.0

--- a/tests/artifacts/test_provenance.py
+++ b/tests/artifacts/test_provenance.py
@@ -17,9 +17,7 @@ def _source_tree(root: Path, *, marker: str = "same") -> None:
         "[project]\nname='trade-rl'\n", encoding="utf-8"
     )
     (root / "uv.lock").write_text("same-lock", encoding="utf-8")
-    (root / "uv.toml").write_text(
-        'required-version = "==0.10.0"\n', encoding="utf-8"
-    )
+    (root / "uv.toml").write_text('required-version = "==0.10.0"\n', encoding="utf-8")
     (root / "trade_rl" / "module.py").write_text(marker, encoding="utf-8")
     (root / "examples" / "runner.py").write_text("runner", encoding="utf-8")
 

--- a/tests/artifacts/test_provenance.py
+++ b/tests/artifacts/test_provenance.py
@@ -17,6 +17,9 @@ def _source_tree(root: Path, *, marker: str = "same") -> None:
         "[project]\nname='trade-rl'\n", encoding="utf-8"
     )
     (root / "uv.lock").write_text("same-lock", encoding="utf-8")
+    (root / "uv.toml").write_text(
+        'required-version = "==0.10.0"\n', encoding="utf-8"
+    )
     (root / "trade_rl" / "module.py").write_text(marker, encoding="utf-8")
     (root / "examples" / "runner.py").write_text("runner", encoding="utf-8")
 

--- a/tests/test_package_toolchain_identity.py
+++ b/tests/test_package_toolchain_identity.py
@@ -6,6 +6,7 @@ from importlib.metadata import version
 from pathlib import Path
 
 import trade_rl
+from trade_rl.artifacts.provenance import source_tree_digest
 from trade_rl.cli import main as cli_main
 
 _ROOT = Path(__file__).resolve().parents[1]
@@ -47,3 +48,19 @@ def test_setup_uv_workflows_resolve_version_from_repository_config() -> None:
         text = path.read_text(encoding="utf-8")
         assert text.index("actions/checkout@") < text.index("astral-sh/setup-uv@"), path
         assert "version: latest" not in text, path
+
+
+def test_uv_toolchain_version_is_bound_to_source_identity(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    (root / "trade_rl").mkdir(parents=True)
+    (root / "examples").mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='trade-rl'\n")
+    (root / "uv.lock").write_text("lock")
+    (root / "uv.toml").write_text('required-version = "==0.10.0"\n')
+    (root / "trade_rl" / "module.py").write_text("module")
+    (root / "examples" / "runner.py").write_text("runner")
+    before = source_tree_digest(root)
+
+    (root / "uv.toml").write_text('required-version = "==0.10.1"\n')
+
+    assert source_tree_digest(root) != before

--- a/tests/test_package_toolchain_identity.py
+++ b/tests/test_package_toolchain_identity.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import io
+import tomllib
+from importlib.metadata import version
+from pathlib import Path
+
+import trade_rl
+from trade_rl.cli import main as cli_main
+
+_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_runtime_version_matches_installed_package_metadata() -> None:
+    assert trade_rl.__version__ == version("trade-rl")
+
+
+def test_cli_version_matches_installed_package_metadata() -> None:
+    output = io.StringIO()
+
+    assert cli_main(["--version"], stdout=output) == 0
+    assert output.getvalue() == f"trade-rl {version('trade-rl')}\n"
+
+
+def test_uv_toolchain_has_one_required_version_source() -> None:
+    uv_config = _ROOT / "uv.toml"
+    assert uv_config.is_file()
+    payload = tomllib.loads(uv_config.read_text(encoding="utf-8"))
+    required = payload.get("required-version")
+    assert required == "==0.10.0"
+
+    dockerfile = (_ROOT / "Dockerfile.training").read_text(encoding="utf-8")
+    assert "COPY uv.toml /tmp/trade-rl-uv.toml" in dockerfile
+    assert 'tomllib.load(open("/tmp/trade-rl-uv.toml", "rb"))' in dockerfile
+    assert "pip install --no-cache-dir uv==0.10.0" not in dockerfile
+
+
+def test_setup_uv_workflows_resolve_version_from_repository_config() -> None:
+    workflows = sorted((_ROOT / ".github" / "workflows").glob("*.yml"))
+    setup_workflows = tuple(
+        path
+        for path in workflows
+        if "astral-sh/setup-uv@" in path.read_text(encoding="utf-8")
+    )
+    assert setup_workflows
+    for path in setup_workflows:
+        text = path.read_text(encoding="utf-8")
+        assert text.index("actions/checkout@") < text.index("astral-sh/setup-uv@"), path
+        assert "version: latest" not in text, path

--- a/tests/test_package_toolchain_identity.py
+++ b/tests/test_package_toolchain_identity.py
@@ -23,6 +23,16 @@ def test_cli_version_matches_installed_package_metadata() -> None:
     assert output.getvalue() == f"trade-rl {version('trade-rl')}\n"
 
 
+def test_package_metadata_uses_canonical_version_module() -> None:
+    payload = tomllib.loads((_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    project = payload["project"]
+    assert "version" not in project
+    assert "version" in project["dynamic"]
+    assert payload["tool"]["setuptools"]["dynamic"]["version"] == {
+        "attr": "trade_rl._version.__version__"
+    }
+
+
 def test_uv_toolchain_has_one_required_version_source() -> None:
     uv_config = _ROOT / "uv.toml"
     assert uv_config.is_file()

--- a/tests/workflows/test_walk_forward_manifest_provenance.py
+++ b/tests/workflows/test_walk_forward_manifest_provenance.py
@@ -117,6 +117,7 @@ def _provenance(tmp_path: Path):
         "[project]\nname='trade-rl'\n", encoding="utf-8"
     )
     (root / "uv.lock").write_text("test-lock", encoding="utf-8")
+    (root / "uv.toml").write_text('required-version = "==0.10.0"\n', encoding="utf-8")
     (root / "trade_rl" / "module.py").write_text("test", encoding="utf-8")
     (root / "examples" / "runner.py").write_text("test", encoding="utf-8")
     return capture_runtime_provenance(

--- a/trade_rl/__init__.py
+++ b/trade_rl/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-__all__ = ["__version__"]
+from trade_rl._version import __version__
 
-__version__ = "0.2.0"
+__all__ = ["__version__"]

--- a/trade_rl/_version.py
+++ b/trade_rl/_version.py
@@ -1,0 +1,7 @@
+"""Single source for the installed trade-rl package version."""
+
+from __future__ import annotations
+
+__version__ = "0.3.0"
+
+__all__ = ["__version__"]

--- a/trade_rl/artifacts/provenance.py
+++ b/trade_rl/artifacts/provenance.py
@@ -17,7 +17,7 @@ from trade_rl.artifacts.hashing import content_digest
 from trade_rl.domain.common import require_sha256
 
 _GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
-_SOURCE_ROOTS = ("pyproject.toml", "uv.lock", "trade_rl", "examples")
+_SOURCE_ROOTS = ("pyproject.toml", "uv.lock", "uv.toml", "trade_rl", "examples")
 
 
 def _sha256_file(path: Path) -> str:

--- a/uv.toml
+++ b/uv.toml
@@ -1,0 +1,1 @@
+required-version = "==0.10.0"


### PR DESCRIPTION
## Summary

- make `trade_rl._version` the single package-version source
- bind installed package metadata, `trade_rl.__version__`, and `trade-rl --version` to the same value
- add repository-owned `uv.toml` with `==0.10.0`
- make GitHub Actions and the training image resolve uv from the same contract
- include the uv toolchain contract in source identity
- add package/CLI/toolchain consistency regression coverage

## TDD

The initial tests failed on the existing `0.3.0` package metadata versus `0.2.0` CLI drift and on the absence of a repository uv-version contract. The production changes were added only after those failures were observed.

## Verification

Exact head: `e317f22bd3a4a8338de49ce4873f1697eac5783f`

- CI: success
- PostgreSQL Catalog: success
- Ruff and format: success
- MyPy: success
- Import Linter and dead-code report: success
- full Python tests and branch coverage: success
- critical branch coverage: success
- package and uv identity check: success
- Ubuntu and Windows compatibility: success
- complete training image and non-root runtime probe: success
- Studio tests, typecheck, production build, and fixed-layout checks: success
- unresolved review threads: 0

## Scope

No training algorithm, policy behavior, evaluation metric, execution model, serving action semantics, or Studio feature behavior changes.