### PR TITLE
Harden Studio process supervision

### DIFF
--- a/tests/studio/test_jobs.py
+++ b/tests/studio/test_jobs.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+import trade_rl.studio.jobs as studio_jobs
 from trade_rl.studio.contracts import ConfigSummary, DatasetSummary, TrainingJobRequest
 from trade_rl.studio.errors import IdentityConflict, JobOwnershipLost, ResourceNotFound
 from trade_rl.studio.jobs import JobSupervisor
@@ -215,3 +217,58 @@ def test_cancel_owned_process_persists_cancelled_state(tmp_path: Path) -> None:
     assert factory.process.terminated is True
     assert cancelled.status == "cancelled"
     assert cancelled.completed_at is not None
+
+
+def test_pid_identity_fails_closed_without_start_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(studio_jobs, "_pid_alive", lambda pid: True)
+
+    assert studio_jobs._pid_matches(1234, None) is False
+
+
+def test_process_group_options_isolate_workers_on_supported_platforms() -> None:
+    assert studio_jobs._process_group_options("posix") == {"start_new_session": True}
+    assert studio_jobs._process_group_options("nt") == {
+        "creationflags": studio_jobs._WINDOWS_NEW_PROCESS_GROUP
+    }
+
+
+def test_cancel_uses_process_tree_terminator(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    catalog = FakeCatalog(tmp_path)
+    factory = FakeFactory()
+    supervisor = JobSupervisor(
+        settings(tmp_path), catalog=catalog, process_factory=factory
+    )
+    job = supervisor.submit_training(request(catalog))
+    calls: list[int] = []
+
+    def terminate_tree(process: FakeProcess) -> int:
+        calls.append(process.pid)
+        process.exit_code = -15
+        return -15
+
+    monkeypatch.setattr(
+        studio_jobs,
+        "_terminate_process_tree",
+        terminate_tree,
+        raising=False,
+    )
+
+    cancelled = supervisor.cancel(job.id)
+
+    assert calls == [factory.process.pid]
+    assert factory.process.terminated is False
+    assert cancelled.status == "cancelled"
+    assert cancelled.exit_code == -15
+
+
+def test_process_group_options_match_current_platform() -> None:
+    options = studio_jobs._process_group_options(os.name)
+    if os.name == "nt":
+        assert options == {"creationflags": studio_jobs._WINDOWS_NEW_PROCESS_GROUP}
+    else:
+        assert options == {"start_new_session": True}

--- a/trade_rl/studio/jobs.py
+++ b/trade_rl/studio/jobs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import re
+import signal
 import subprocess
 import sys
 import uuid
@@ -11,7 +12,7 @@ from collections import deque
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Protocol, cast
+from typing import Any, Final, Protocol, cast
 
 from trade_rl.artifacts.run_manifest import validate_training_run_directory
 from trade_rl.studio.contracts import JobSummary, TrainingJobRequest
@@ -25,6 +26,12 @@ from trade_rl.studio.settings import StudioSettings
 
 _RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 _TERMINAL_STATES = {"succeeded", "failed", "cancelled"}
+_WINDOWS_NEW_PROCESS_GROUP: Final = getattr(
+    subprocess,
+    "CREATE_NEW_PROCESS_GROUP",
+    0x00000200,
+)
+_PROCESS_STOP_TIMEOUT_SECONDS: Final = 5.0
 
 
 class ProcessHandle(Protocol):
@@ -52,6 +59,14 @@ def _utc_now() -> str:
     return datetime.now(UTC).isoformat()
 
 
+def _process_group_options(platform_name: str) -> dict[str, object]:
+    """Return the subprocess options that isolate one complete worker tree."""
+
+    if platform_name == "nt":
+        return {"creationflags": _WINDOWS_NEW_PROCESS_GROUP}
+    return {"start_new_session": True}
+
+
 def _default_process_factory(
     command: tuple[str, ...], *, cwd: Path, log_path: Path
 ) -> ProcessHandle:
@@ -63,7 +78,7 @@ def _default_process_factory(
             stdin=subprocess.DEVNULL,
             stdout=log_handle,
             stderr=subprocess.STDOUT,
-            start_new_session=os.name != "nt",
+            **_process_group_options(os.name),
         )
     return cast(ProcessHandle, process)
 
@@ -90,12 +105,64 @@ def _pid_alive(pid: int | None) -> bool:
 
 
 def _pid_matches(pid: int | None, token: str | None) -> bool:
-    if not _pid_alive(pid):
+    if not _pid_alive(pid) or pid is None or token is None:
         return False
-    if pid is None or token is None:
-        return True
     current = _pid_start_token(pid)
     return current is not None and current == token
+
+
+def _wait_or_none(process: ProcessHandle) -> int | None:
+    try:
+        return process.wait(timeout=_PROCESS_STOP_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired:
+        return None
+
+
+def _terminate_posix_process_tree(process: ProcessHandle) -> int:
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        process.terminate()
+    exit_code = _wait_or_none(process)
+    if exit_code is not None:
+        return exit_code
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        process.kill()
+    return process.wait(timeout=_PROCESS_STOP_TIMEOUT_SECONDS)
+
+
+def _run_taskkill(pid: int, *, force: bool) -> None:
+    command = ["taskkill", "/PID", str(pid), "/T"]
+    if force:
+        command.append("/F")
+    completed = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            "failed to terminate Studio worker process tree: "
+            f"{completed.stderr.strip() or completed.stdout.strip()}"
+        )
+
+
+def _terminate_windows_process_tree(process: ProcessHandle) -> int:
+    _run_taskkill(process.pid, force=False)
+    exit_code = _wait_or_none(process)
+    if exit_code is not None:
+        return exit_code
+    _run_taskkill(process.pid, force=True)
+    return process.wait(timeout=_PROCESS_STOP_TIMEOUT_SECONDS)
+
+
+def _terminate_process_tree(process: ProcessHandle) -> int:
+    if os.name == "nt":
+        return _terminate_windows_process_tree(process)
+    return _terminate_posix_process_tree(process)
 
 
 class JobSupervisor:
@@ -362,12 +429,7 @@ class JobSupervisor:
             expected={"queued", "running"},
             updates={"status": "cancelling", "cancellable": False},
         )
-        process.terminate()
-        try:
-            exit_code = process.wait(timeout=5.0)
-        except subprocess.TimeoutExpired:
-            process.kill()
-            exit_code = process.wait(timeout=5.0)
+        exit_code = _terminate_process_tree(process)
         self._processes.pop(job_id, None)
         return self._finish(
             cancelling,

--- a/trade_rl/studio/jobs.py
+++ b/trade_rl/studio/jobs.py
@@ -72,14 +72,24 @@ def _default_process_factory(
 ) -> ProcessHandle:
     log_path.parent.mkdir(parents=True, exist_ok=True)
     with log_path.open("ab", buffering=0) as log_handle:
-        process = subprocess.Popen(
-            command,
-            cwd=cwd,
-            stdin=subprocess.DEVNULL,
-            stdout=log_handle,
-            stderr=subprocess.STDOUT,
-            **_process_group_options(os.name),
-        )
+        if os.name == "nt":
+            process = subprocess.Popen(
+                command,
+                cwd=cwd,
+                stdin=subprocess.DEVNULL,
+                stdout=log_handle,
+                stderr=subprocess.STDOUT,
+                creationflags=_WINDOWS_NEW_PROCESS_GROUP,
+            )
+        else:
+            process = subprocess.Popen(
+                command,
+                cwd=cwd,
+                stdin=subprocess.DEVNULL,
+                stdout=log_handle,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
     return cast(ProcessHandle, process)
 
 


### PR DESCRIPTION
## Summary

- isolate Studio training workers into complete process groups/trees
- terminate child processes together with the parent during cancellation
- use POSIX session groups with SIGTERM then SIGKILL fallback
- use Windows process-tree termination with `taskkill /T` and forced fallback
- fail closed when a detached PID cannot be matched to an immutable process-start token
- prevent PID reuse from being mistaken for the original worker

## TDD

Focused regressions were committed first for POSIX process-group creation, Windows process-group flags, complete tree termination, and missing PID-token rejection. They failed against the prior implementation before production code was added.

## Verification

Exact head: `ff8b94214e55e3c731b1552606cdbf5bdf66c75c`

- CI: success
- Ruff and format: success
- MyPy: success
- Import Linter and dead-code report: success
- recovery and structured-serving smoke: success
- full Python tests and branch coverage: success
- critical branch coverage: success
- package and uv identity: success
- Ubuntu and Windows compatibility: success
- complete training image and non-root runtime probe: success
- Studio frontend tests, typecheck, production build, and fixed-layout checks: success
- unresolved review threads: 0

## Scope

The change is limited to the Studio Python process supervisor and its dedicated tests. It does not alter the Studio chart frontend, training algorithm, policy behavior, execution, evaluation, or serving contracts.