### PR TITLE
Bind runtime provenance to observed Git identity

### DIFF
--- a/tests/artifacts/test_provenance.py
+++ b/tests/artifacts/test_provenance.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -20,6 +21,25 @@ def _source_tree(root: Path, *, marker: str = "same") -> None:
     (root / "uv.toml").write_text('required-version = "==0.10.0"\n', encoding="utf-8")
     (root / "trade_rl" / "module.py").write_text(marker, encoding="utf-8")
     (root / "examples" / "runner.py").write_text("runner", encoding="utf-8")
+
+
+def _git(root: Path, *args: str) -> str:
+    return subprocess.run(
+        ("git", "-C", str(root), *args),
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _committed_source_tree(root: Path) -> str:
+    _source_tree(root)
+    _git(root, "init")
+    _git(root, "config", "user.email", "provenance@example.invalid")
+    _git(root, "config", "user.name", "Provenance Test")
+    _git(root, "add", ".")
+    _git(root, "commit", "-m", "initial source")
+    return _git(root, "rev-parse", "HEAD")
 
 
 def _capture(root: Path, **overrides: object):
@@ -99,3 +119,38 @@ def test_runtime_provenance_binds_container_image_digest(tmp_path: Path) -> None
 
     assert first.image_digest == "1" * 64
     assert first.digest != second.digest
+
+
+def test_runtime_provenance_rejects_declared_commit_that_differs_from_checkout(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "repo"
+    observed_commit = _committed_source_tree(root)
+    declared_commit = "b" * 40
+    assert observed_commit != declared_commit
+
+    with pytest.raises(ValueError, match="git commit does not match checkout"):
+        _capture(root, git_commit=declared_commit, git_dirty=False)
+
+
+def test_runtime_provenance_rejects_declared_clean_state_for_dirty_checkout(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "repo"
+    observed_commit = _committed_source_tree(root)
+    (root / "trade_rl" / "module.py").write_text("dirty", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="git dirty state does not match checkout"):
+        _capture(root, git_commit=observed_commit, git_dirty=False)
+
+
+def test_runtime_provenance_accepts_declared_identity_matching_checkout(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "repo"
+    observed_commit = _committed_source_tree(root)
+
+    provenance = _capture(root, git_commit=observed_commit, git_dirty=False)
+
+    assert provenance.git_commit == observed_commit
+    assert provenance.git_dirty is False

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _bind_research_to_serving_declared_git_identity(
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[None]:
+    """Keep the serving E2E focused on its signed pipeline, not host checkout data."""
+
+    if request.node.name != "test_research_training_to_attested_runtime_prediction":
+        yield
+        return
+
+    def matching_git_identity(_root: Path, *args: str) -> str | None:
+        if args == ("rev-parse", "HEAD"):
+            return "a" * 40
+        if args == ("status", "--porcelain"):
+            return ""
+        raise AssertionError(f"unexpected Git provenance query: {args!r}")
+
+    monkeypatch.setattr("trade_rl.artifacts.provenance._git", matching_git_identity)
+    yield

--- a/tests/workflows/test_training_run.py
+++ b/tests/workflows/test_training_run.py
@@ -150,7 +150,7 @@ def test_execute_training_run_trains_serializes_and_publishes(tmp_path: Path) ->
     assert pointer == {"path": "runs/tiny-run", "run_id": "tiny-run"}
 
 
-def test_execute_training_run_uses_explicit_provenance_without_git_lookup(
+def test_execute_training_run_uses_declared_provenance_when_git_is_unavailable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     dataset_root = tmp_path / "dataset"
@@ -162,10 +162,7 @@ def test_execute_training_run_uses_explicit_provenance_without_git_lookup(
     config["git_dirty"] = False
     config_path.write_text(json.dumps(config), encoding="utf-8")
 
-    def fail_git_lookup(_root: Path, *_args: str) -> str | None:
-        raise AssertionError("explicit packaged provenance must avoid Git lookup")
-
-    monkeypatch.setattr("trade_rl.artifacts.provenance._git", fail_git_lookup)
+    monkeypatch.setattr("trade_rl.artifacts.provenance._git", lambda *_args: None)
 
     result = execute_training_run(
         config_path=config_path,

--- a/trade_rl/artifacts/provenance.py
+++ b/trade_rl/artifacts/provenance.py
@@ -79,6 +79,38 @@ def _git(root: Path, *args: str) -> str | None:
     return completed.stdout.strip()
 
 
+def _resolve_git_identity(
+    repository: Path,
+    *,
+    declared_commit: str | None,
+    declared_dirty: bool | None,
+) -> tuple[str, bool]:
+    observed_commit = _git(repository, "rev-parse", "HEAD")
+    observed_status = _git(repository, "status", "--porcelain")
+    if observed_commit is not None or observed_status is not None:
+        if observed_commit is None or observed_status is None:
+            raise ValueError("git checkout identity could not be determined completely")
+        resolved_commit = observed_commit.lower()
+        if not _GIT_SHA_RE.fullmatch(resolved_commit):
+            raise ValueError("git checkout returned an invalid commit")
+        resolved_dirty = bool(observed_status)
+        if (
+            declared_commit is not None
+            and declared_commit.lower() != resolved_commit
+        ):
+            raise ValueError("declared git commit does not match checkout")
+        if declared_dirty is not None and declared_dirty != resolved_dirty:
+            raise ValueError("declared git dirty state does not match checkout")
+        return resolved_commit, resolved_dirty
+
+    resolved_commit = (declared_commit or "").lower()
+    if not _GIT_SHA_RE.fullmatch(resolved_commit):
+        raise ValueError("a valid git commit is required for runtime provenance")
+    if declared_dirty is None:
+        raise ValueError("git dirty state could not be determined")
+    return resolved_commit, declared_dirty
+
+
 @dataclass(frozen=True, slots=True)
 class RuntimeProvenance:
     digest: str
@@ -160,17 +192,11 @@ def capture_runtime_provenance(
     """Capture and verify source, dependency, image, and runtime provenance."""
 
     repository = Path(root)
-    resolved_commit = (
-        git_commit or _git(repository, "rev-parse", "HEAD") or ""
-    ).lower()
-    if not _GIT_SHA_RE.fullmatch(resolved_commit):
-        raise ValueError("a valid git commit is required for runtime provenance")
-    resolved_dirty = git_dirty
-    if resolved_dirty is None:
-        status = _git(repository, "status", "--porcelain")
-        if status is None:
-            raise ValueError("git dirty state could not be determined")
-        resolved_dirty = bool(status)
+    resolved_commit, resolved_dirty = _resolve_git_identity(
+        repository,
+        declared_commit=git_commit,
+        declared_dirty=git_dirty,
+    )
 
     lock_path = repository / "uv.lock"
     lock_digest = _sha256_file(lock_path) if lock_path.is_file() else None

--- a/trade_rl/artifacts/provenance.py
+++ b/trade_rl/artifacts/provenance.py
@@ -94,10 +94,7 @@ def _resolve_git_identity(
         if not _GIT_SHA_RE.fullmatch(resolved_commit):
             raise ValueError("git checkout returned an invalid commit")
         resolved_dirty = bool(observed_status)
-        if (
-            declared_commit is not None
-            and declared_commit.lower() != resolved_commit
-        ):
+        if declared_commit is not None and declared_commit.lower() != resolved_commit:
             raise ValueError("declared git commit does not match checkout")
         if declared_dirty is not None and declared_dirty != resolved_dirty:
             raise ValueError("declared git dirty state does not match checkout")


### PR DESCRIPTION
## Summary

- observe the actual Git commit and working-tree state whenever a Git checkout is available
- reject a caller-declared commit that differs from `git rev-parse HEAD`
- reject a caller-declared clean/dirty state that differs from `git status --porcelain`
- preserve the packaged-image fallback where `.git` is unavailable and signed build-time values must be supplied explicitly
- update the training and research-to-serving regressions to distinguish real-checkout verification from packaged-source fallback

## TDD

The first test-only head produced exactly the intended failures: declared commit mismatch and declared dirty-state mismatch were both accepted by the previous implementation. Production code was added only after those failures were observed.

## Verification

Exact head: `a2eaf4d2342069039ffcbf66887a57ef905ac429`

- CI: success
- PostgreSQL Catalog: success
- Python: 2,729 passed, 4 skipped
- total branch-aware coverage: 82.77% (required 80%)
- critical branch coverage: all targets passed
- Ruff and format: success
- MyPy: 327 source files, 0 issues
- Import Linter: 10 contracts kept, 0 broken
- dead-code report: success
- recovery and structured-serving smoke: success
- package and uv identity: success
- Ubuntu and Windows compatibility: success
- complete training image, identity record, and non-root probe: success
- Studio: 65 tests, typecheck, production build, and fixed-layout checks succeeded
- unresolved review threads: 0
- current main comparison: ahead 5, behind 0

## Scope

No training algorithm, evaluation metric, execution model, policy behavior, action semantics, release authorization, or Studio behavior changes.