### PR TITLE
Fix maintained documentation contract drift

### DIFF
--- a/START.md
+++ b/START.md
@@ -92,7 +92,7 @@ var/quickstart/artifacts/
 ```
 
 - `run.json`: 宣言済みFile、Size、SHA-256を束ねる最終Manifest
-- `training-config.json`: 解決済み`training_run_config_v2`
+- `training-config.json`: 解決済み`training_run_config_v3`
 - `environment.json`: Action、Observation、Reward、Risk、Execution identity
 - `policy.zip`: Stable-Baselines3のRecovery形式
 - `training-telemetry.jsonl`: Studio用の診断Stream
@@ -118,17 +118,17 @@ npm run dev --prefix studio
 
 `http://127.0.0.1:5173`を開きます。Live TrainingのBUY／SELL表示はWeight変化であり、取引所注文ではありません。
 
-## 6. `training_run_config_v2`を使う
+## 6. `training_run_config_v3`を使う
 
 Top-levelの`schema_version`は必ず次の値です。
 
 ```json
 {
-  "schema_version": "training_run_config_v2"
+  "schema_version": "training_run_config_v3"
 }
 ```
 
-旧`training_run_config_v1`は自動移行されず、明示的に拒否されます。
+旧Schemaは自動移行されず、明示的に拒否されます。
 
 ### Encoderを選ぶ
 
@@ -234,9 +234,9 @@ uv sync --extra dev --extra train-sb3
 
 新しい`--run-id`を指定してください。Published runは上書きしません。
 
-### `migrate training_run_config_v1`
+### Training config schemaの移行が必要
 
-設定の`schema_version`をv2へ変更し、旧Encoder Booleanを`observation_encoder`へ置き換えてください。
+設定の`schema_version`を`training_run_config_v3`へ変更し、旧Encoder Booleanを`observation_encoder`へ置き換えてください。必要なv3 Fieldは[設定リファレンス](docs/CONFIGURATION.md)で確認してください。
 
 ### `dataset digest mismatch`
 

--- a/docs/RESEARCH_STATUS.md
+++ b/docs/RESEARCH_STATUS.md
@@ -1,10 +1,13 @@
 # Research Status
 
-## Current status — 2026-07-28
+## Current status
 
 ```text
 RepositoryIntegrity: VERIFIED_BY_MAIN_CI
 ResearchWorkflows: AVAILABLE
+StageAZeroShotSoftware: IMPLEMENTED_AND_CI_VERIFIED
+StageAEmpiricalEvaluation: NOT_COMPLETED
+StageBSpotFuturesGeneralization: NOT_IMPLEMENTED
 HierarchicalSequenceV2: IMPLEMENTED_AND_CPU_VERIFIED
 StatefulOHLCExecution: AVAILABLE_WITH_OHLCV_LIMITATIONS
 TradeRLStudio: AVAILABLE_FOR_DIAGNOSTIC_REPLAY_WITH_EPISODE_ISOLATION
@@ -15,6 +18,8 @@ ProfitabilityClaim: NONE
 ```
 
 この表は能力境界です。実装済み、CI検証済み、研究上有効、収益性あり、Production認可済みは別の状態です。
+
+Stage Aのソフトウェア契約とCLIは実装・CI検証済みですが、維持対象の実データ、複数Seed・Fold、対象GPUによる実証評価は完了していません。Stage BのSpotとUSDⓈ-M先物を横断する一般化は未実装です。
 
 ## 現在のModel契約
 

--- a/docs/operations/docker-gpu-full-training.md
+++ b/docs/operations/docker-gpu-full-training.md
@@ -30,7 +30,7 @@ Containerは次をFail closedで確認します。
 - CUDA deviceとPyTorch CUDA
 - Source/lock provenance
 - DatasetとMetadata evidence
-- `training_run_config_v2`
+- `training_run_config_v3`
 - ParameterとRollout buffer上限
 - BC、PPO-family、Checkpoint、Resume
 - Evaluation、Execution sensitivity、Research gate

--- a/tests/test_current_documentation_contract.py
+++ b/tests/test_current_documentation_contract.py
@@ -111,6 +111,28 @@ def test_current_schema_contracts_are_documented() -> None:
     assert "Gated Cross-Asset Attention" in architecture
 
 
+def test_operator_runbooks_use_current_training_schema() -> None:
+    for path in (
+        ROOT / "START.md",
+        ROOT / "docs" / "operations" / "docker-gpu-full-training.md",
+    ):
+        text = _text(path)
+        assert "training_run_config_v3" in text
+        assert "training_run_config_v2" not in text
+
+
+def test_research_status_has_timeless_heading_and_explicit_stage_boundaries() -> None:
+    research_status = _text(ROOT / "docs" / "RESEARCH_STATUS.md")
+    assert "## Current status\n" in research_status
+    assert "## Current status —" not in research_status
+    for boundary in (
+        "StageAZeroShotSoftware: IMPLEMENTED_AND_CI_VERIFIED",
+        "StageAEmpiricalEvaluation: NOT_COMPLETED",
+        "StageBSpotFuturesGeneralization: NOT_IMPLEMENTED",
+    ):
+        assert boundary in research_status
+
+
 def test_legacy_settings_are_only_documented_as_rejected_inputs() -> None:
     configuration = _text(ROOT / "docs" / "CONFIGURATION.md")
     for legacy in (


### PR DESCRIPTION
## What

- update `START.md` and the Docker GPU runbook from the stale v2 training schema to `training_run_config_v3`
- remove the date-stamped research-status heading
- explicitly distinguish Stage A software completion, Stage A empirical evaluation, and Stage B implementation status
- add maintained-documentation regression tests so these contracts cannot silently drift again

## Why

The runtime and maintained examples already require `training_run_config_v3`, but two operator-facing runbooks still instructed users to use v2. The research-status document also mixed implemented software with incomplete empirical validation and did not state the Stage B boundary explicitly.

## TDD

RED was verified on exact test-only head `74fae244fef6ea045b78b5c2fa8be3b027f9bcde` in CI run `30695966534`:

- exactly the two new documentation-contract tests failed
- `2730 passed, 5 skipped`
- total branch-aware coverage remained `82.77%`
- Ruff, format, MyPy, Import Linter, Studio, Ubuntu, Windows, and the complete training image passed

## Verification

Verified on unchanged final head `8fe94e7ead85fb2e637d08cf44c6c356c1bbbf0a` in CI run `30696342144`:

- CI: success
- Python: `2732 passed, 5 skipped`
- total branch-aware coverage: `82.77%` (required `80%`)
- critical branch coverage: all file and group ratchets passed
- Ruff: success
- Ruff format: `831 files already formatted`
- MyPy: `327 source files`, no issues
- Import Linter: `10 contracts kept, 0 broken`
- dead-code report: success
- recovery and structured-serving smoke: `2 passed`
- Studio: `65 tests`, typecheck, production build, and fixed-layout checks passed
- Ubuntu and Windows compatibility: success
- complete training image, identity recording, and non-root runtime probe: success
- branch comparison: ahead `4`, behind `0`

## Scope

Documentation and documentation-contract tests only. No training, evaluation, execution, serving, Studio, configuration parser, or runtime behavior changes.

## Remaining boundary

This PR does not perform the Stage A full empirical run, target-GPU evidence collection, Stage B implementation, direct exchange routing, or Production authorization.

GitHub Actions emits an existing Node 20 action-runtime deprecation warning while forcing those pinned actions onto Node 24. It did not fail this PR and is not changed here because it is outside the documentation-only scope.