### PR TITLE
ci: prune merged v4 branches

### DIFF
--- a/.github/workflows/one-shot-prune-merged-branches-v4.yml
+++ b/.github/workflows/one-shot-prune-merged-branches-v4.yml
@@ -1,0 +1,40 @@
+name: One-shot prune merged branches v4
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prune:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      CLEANUP_BRANCH: ${{ github.event.pull_request.head.ref }}
+    steps:
+      - name: Delete integrated branches
+        run: |
+          set -euo pipefail
+          for branch in \
+            agent/training-config-v4-explicitness \
+            fix/current-documentation-contract-20260801
+          do
+            if gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${branch}" >/dev/null 2>&1; then
+              gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/${branch}"
+            fi
+          done
+      - name: Close cleanup pull request
+        run: |
+          gh pr close "${PR_NUMBER}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --comment "Merged branches were removed. This maintenance PR is intentionally not merged."
+      - name: Delete cleanup branch
+        run: |
+          gh api --method DELETE \
+            "repos/${GITHUB_REPOSITORY}/git/refs/heads/${CLEANUP_BRANCH}"


### PR DESCRIPTION
One-shot maintenance PR. It deletes the two branches already integrated through PR #344 and PR #343, closes itself without merging, and deletes its own cleanup branch. Do not merge.