### PR TITLE
Fix Dashboard drill-through and visual evidence

### DIFF
--- a/studio/scripts/check-no-page-scroll.mjs
+++ b/studio/scripts/check-no-page-scroll.mjs
@@ -18,7 +18,9 @@ const [css, rawJs] = await Promise.all([
 ])
 const js = rawJs.replaceAll('</script>', '<\\/script>')
 const html = `<!doctype html><html lang="ja"><head><base href="http://127.0.0.1:4173/"><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><style>${css}</style></head><body><div id="root"></div><script type="module">${js}</script></body></html>`
-const outputDir = process.env.STUDIO_QA_OUTPUT_DIR ?? '/mnt/data'
+const outputDir = process.env.STUDIO_QA_OUTPUT_DIR
+  ? path.resolve(studioRoot, '..', process.env.STUDIO_QA_OUTPUT_DIR)
+  : '/mnt/data'
 await mkdir(outputDir, { recursive: true })
 
 const dataset = {

--- a/studio/src/dashboard/dashboardCockpitModel.ts
+++ b/studio/src/dashboard/dashboardCockpitModel.ts
@@ -177,7 +177,7 @@ function buildDecisions(overview: StudioOverview, latest: RunSummary | null): Da
   if (dataset === null) {
     addDecision(decisions, seen, { id: 'dataset:no-valid', stage: 'data', severity: 'warning', title: 'Datasetがありません', explanation: '学習前に検証済みDatasetを登録してください。', occurredAt: null, age: null, action: { label: 'Data Labを開く', workspace: 'data', params: {} } })
   } else if (dataset.status === 'INVALID') {
-    addDecision(decisions, seen, { id: `dataset:${dataset.id}:invalid`, stage: 'data', severity: 'critical', title: `Dataset ${dataset.name} が無効です`, explanation: dataset.validationError ?? 'Dataset validation failed.', occurredAt: null, age: dataset.updated, action: { label: 'Data Labで確認', workspace: 'data', params: { dataset: dataset.id } } })
+    addDecision(decisions, seen, { id: `dataset:${dataset.id}:invalid`, stage: 'data', severity: 'critical', title: `Dataset ${dataset.name} が無効です`, explanation: dataset.validationError ?? 'Dataset validation failed.', occurredAt: dataset.updated, age: null, action: { label: 'Data Labで確認', workspace: 'data', params: { dataset: dataset.id } } })
   }
 
   for (const job of overview.activeJobs) {

--- a/studio/src/dashboard/dashboardDatasetTimestamp.test.ts
+++ b/studio/src/dashboard/dashboardDatasetTimestamp.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import type { StudioOverview } from '../data/types'
+import { buildDashboardCockpitModel } from './dashboardCockpitModel'
+
+const updatedAt = '2026-08-06T00:00:00Z'
+
+const overview: StudioOverview = {
+  system: { gpuName: 'GPU', cudaReady: true, pythonVersion: '3.12', metrics: [] },
+  latestDataset: {
+    id: 'dataset-invalid',
+    datasetId: 'd'.repeat(64),
+    name: 'broken-market',
+    relativePath: 'datasets/broken-market',
+    market: 'spot',
+    symbols: ['BTCUSDT'],
+    timeframes: ['1h'],
+    range: '2026',
+    status: 'INVALID',
+    featureCount: 1,
+    barCount: 1,
+    symbolCount: 1,
+    updated: updatedAt,
+    validationError: 'broken',
+  },
+  activeJobs: [],
+  runs: [],
+  alerts: [],
+  evidence: {
+    runResourceId: null,
+    status: 'UNAVAILABLE',
+    requiredCount: 0,
+    verifiedCount: 0,
+    blockerCount: 0,
+    updatedAt: null,
+  },
+  equity: [],
+  stability: [],
+  assessment: { status: 'NO-GO', reasons: ['approval missing'] },
+}
+
+describe('Dashboard Dataset timestamps', () => {
+  it('keeps an authoritative timestamp out of the human age field', () => {
+    const model = buildDashboardCockpitModel(overview)
+    const decision = model.decisions.find((item) => item.id === 'dataset:dataset-invalid:invalid')
+
+    expect(decision?.occurredAt).toBe(updatedAt)
+    expect(decision?.age).toBeNull()
+  })
+})

--- a/studio/src/pages/DataLabPage.deepLink.test.tsx
+++ b/studio/src/pages/DataLabPage.deepLink.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { StudioApi } from '../api/studioApi'
+import type { DatasetSummary } from '../data/types'
+import { DataLabPage } from './DataLabPage'
+
+const firstDataset: DatasetSummary = {
+  id: 'dataset-111111111111111111111111',
+  datasetId: 'd'.repeat(64),
+  name: 'btc-eth',
+  relativePath: 'artifacts/datasets/btc-eth',
+  market: 'continuous_24_7',
+  symbols: ['BTCUSDT', 'ETHUSDT'],
+  timeframes: ['15m', '1h'],
+  range: '2026-01-01 → 2026-02-01',
+  status: 'VALID',
+  featureCount: 226,
+  barCount: 744,
+  symbolCount: 2,
+  updated: '2026-07-19T00:00:00+00:00',
+  validationError: null,
+}
+
+const requestedDataset: DatasetSummary = {
+  ...firstDataset,
+  id: 'dataset-222222222222222222222222',
+  datasetId: 'e'.repeat(64),
+  name: 'sol-market',
+  relativePath: 'artifacts/datasets/sol-market',
+  symbols: ['SOLUSDT'],
+  symbolCount: 1,
+}
+
+function api(): StudioApi {
+  return {
+    loadDatasets: vi.fn().mockResolvedValue({
+      items: [firstDataset, requestedDataset],
+      total: 2,
+      invalid: 0,
+    }),
+  } as unknown as StudioApi
+}
+
+beforeEach(() => {
+  window.history.replaceState({}, '', '/')
+})
+
+describe('DataLabPage Dashboard drill-through', () => {
+  it('selects the Dataset resource requested by the URL', async () => {
+    window.history.replaceState({}, '', `/?page=data&dataset=${requestedDataset.id}`)
+
+    render(<DataLabPage api={api()} />)
+
+    const requested = await screen.findByRole('button', { name: /sol-market valid/i })
+    await waitFor(() => expect(requested).toHaveClass('runtime-row--selected'))
+    expect(screen.getAllByText('SOLUSDT').length).toBeGreaterThan(0)
+  })
+})

--- a/studio/src/pages/DataLabPage.tsx
+++ b/studio/src/pages/DataLabPage.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from 'react'
 
 import { studioApi, type StudioApi } from '../api/studioApi'
 import type { DatasetSummary } from '../data/types'
+import { readParam, replaceParams } from '../state/urlState'
 
 interface DataLabPageProps {
   api?: StudioApi
@@ -17,7 +18,7 @@ function formatUpdated(value: string): string {
 
 export function DataLabPage({ api = studioApi }: DataLabPageProps) {
   const [datasets, setDatasets] = useState<DatasetSummary[]>([])
-  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [selectedId, setSelectedId] = useState<string | null>(() => readParam(window.location.search, 'dataset'))
   const [page, setPage] = useState(0)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -28,12 +29,14 @@ export function DataLabPage({ api = studioApi }: DataLabPageProps) {
     try {
       const response = await api.loadDatasets()
       setDatasets(response.items)
-      setSelectedId((current) =>
-        current && response.items.some((item) => item.id === current)
-          ? current
-          : response.items[0]?.id ?? null,
-      )
-      setPage((current) => Math.min(current, Math.max(Math.ceil(response.items.length / PAGE_SIZE) - 1, 0)))
+      const nextSelectedId = selectedId && response.items.some((item) => item.id === selectedId)
+        ? selectedId
+        : response.items[0]?.id ?? null
+      setSelectedId(nextSelectedId)
+      const selectedIndex = nextSelectedId === null
+        ? -1
+        : response.items.findIndex((item) => item.id === nextSelectedId)
+      setPage(selectedIndex < 0 ? 0 : Math.floor(selectedIndex / PAGE_SIZE))
     } catch (reason) {
       setError(reason instanceof Error ? reason.message : 'データセットを取得できませんでした。')
     } finally {
@@ -82,7 +85,10 @@ export function DataLabPage({ api = studioApi }: DataLabPageProps) {
                 type="button"
                 key={dataset.id}
                 className={`runtime-row${dataset.id === selectedId ? ' runtime-row--selected' : ''}`}
-                onClick={() => setSelectedId(dataset.id)}
+                onClick={() => {
+                  setSelectedId(dataset.id)
+                  replaceParams({ dataset: dataset.id })
+                }}
                 aria-label={`${dataset.name} ${dataset.status}`}
               >
                 <Database size={16} aria-hidden="true" />


### PR DESCRIPTION
## What changed

Follow-up to merged PR #358:

- Data Lab now consumes `?dataset=<resource-id>` from Dashboard actions
- a requested Dataset remains selected after loading and its containing page is opened
- manual Dataset selection keeps the URL state synchronized
- invalid Dataset `updated` timestamps are preserved as authoritative `occurredAt` values instead of being mislabeled as a human-readable age
- Dashboard screenshots now resolve `STUDIO_QA_OUTPUT_DIR` relative to the repository root and are included in the standard layout artifact

## TDD evidence

RED run **#5830** failed only on the two intended regressions:

1. Data Lab selected the first Dataset instead of the URL-requested Dataset.
2. Dataset decisions stored the timestamp in `age` instead of `occurredAt`.

GREEN run **#5833** on exact head `bbb72c0` completed successfully:

- Studio Vitest: **110 passed** across 27 files
- dedicated Dataset drill-through regression: passed
- dedicated Dataset timestamp regression: passed
- TypeScript typecheck: passed
- Vite production build: passed
- Chromium layout checks passed at 1536×1024, 1440×900, and 1180×800
- Dashboard screenshots are present in `studio-layout-diagnostics`
- Ruff and format checks: passed
- MyPy: no issues in 352 source files
- import architecture: 12 contracts kept, 0 broken
- Python: **2,914 passed**, 6 skipped
- total coverage: **82.34%** against the 80% requirement
- critical branch coverage ratchet: passed
- Ubuntu and Windows compatibility: passed
- training image build and non-root runtime probe: passed

## Scope

This PR changes five files only. It does not modify Live Training, Lightweight Charts, or the Entry → Reduce → Exit / Entry → Open Trade lifecycle background-band contract.