### PR TITLE
Restore Dashboard URL history selection

### DIFF
--- a/studio/src/pages/DashboardPage.test.tsx
+++ b/studio/src/pages/DashboardPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -26,6 +26,19 @@ describe('DashboardPage', () => {
     expect(new URL(window.location.href).searchParams.get('stage')).toBe('data')
   })
 
+  it('restores the committed selection when Dashboard URL state changes through popstate', async () => {
+    render(<DashboardPage overview={demoOverview} />)
+    const pipeline = screen.getByRole('list', { name: '研究準備ステージ' })
+    const evidenceStage = within(pipeline).getByRole('button', { name: /Evidence/i })
+
+    act(() => {
+      window.history.pushState(null, '', '/?workspace=dashboard&stage=evidence')
+      window.dispatchEvent(new PopStateEvent('popstate'))
+    })
+
+    await waitFor(() => expect(evidenceStage).toHaveAttribute('aria-pressed', 'true'))
+  })
+
   it('opens Environment with E and restores trigger focus after closing', async () => {
     const user = userEvent.setup()
     render(<DashboardPage overview={demoOverview} />)
@@ -33,6 +46,12 @@ describe('DashboardPage', () => {
     expect(screen.getByRole('dialog', { name: 'Environment' })).toBeInTheDocument()
     await user.click(screen.getByRole('button', { name: 'Environmentを閉じる' }))
     await waitFor(() => expect(screen.getByRole('button', { name: /Environment/ })).toHaveFocus())
+  })
+
+  it('does not intercept modified browser or operating-system shortcuts', () => {
+    render(<DashboardPage overview={demoOverview} />)
+    fireEvent.keyDown(window, { key: 'e', ctrlKey: true })
+    expect(screen.queryByRole('dialog', { name: 'Environment' })).not.toBeInTheDocument()
   })
 
   it('drills through using the action contract', async () => {

--- a/studio/src/pages/DashboardPage.tsx
+++ b/studio/src/pages/DashboardPage.tsx
@@ -55,6 +55,18 @@ export function DashboardPage({ overview, freshness = 'LIVE', sourceError = null
   }, [])
 
   useEffect(() => {
+    const restoreSelection = () => {
+      const selection = readDashboardSelection(window.location.search)
+      setCommittedStage(selection.stage)
+      setCommittedDecisionId(selection.decision)
+      setPreviewStage(null)
+      setPreviewDecisionId(null)
+    }
+    window.addEventListener('popstate', restoreSelection)
+    return () => window.removeEventListener('popstate', restoreSelection)
+  }, [])
+
+  useEffect(() => {
     const stageExists = committedStage === null || model.stages.some((item) => item.key === committedStage)
     const decisionExists = committedDecisionId === null || model.decisions.some((item) => item.id === committedDecisionId)
     if (!stageExists || !decisionExists) commitSelection(stageExists ? committedStage : null, decisionExists ? committedDecisionId : null)
@@ -62,7 +74,7 @@ export function DashboardPage({ overview, freshness = 'LIVE', sourceError = null
 
   useEffect(() => {
     const handle = (event: KeyboardEvent) => {
-      if (editableTarget(event.target)) return
+      if (editableTarget(event.target) || event.altKey || event.ctrlKey || event.metaKey) return
       if ((event.key === 'e' || event.key === 'E') && !environmentOpen) {
         event.preventDefault()
         setEnvironmentOpen(true)


### PR DESCRIPTION
## Summary

Follow-up to merged Dashboard PRs #358 and #359.

- restore Dashboard stage/decision selection when browser history changes while the Dashboard remains mounted
- clear transient hover previews when restoring URL state
- prevent the single-key `E` shortcut from intercepting Ctrl/Meta/Alt-modified browser or operating-system shortcuts
- add focused regressions for `popstate` restoration and modified-key isolation

## Scope

- 2 files only
- no API or data-contract changes
- no layout or chart changes
- no changes to Live Training, Lightweight Charts, or the `ENTRY → REDUCE → EXIT` / `ENTRY → OPEN` Trade lifecycle background bands

## Verification on exact head `067c6fb72cb77ea815de5ba4a1e63815e1359fed`

GitHub Actions run **#5835** completed successfully:

- Studio Vitest: **112 passed** across 27 files
- Dashboard `popstate` restoration regression: passed
- modified-key shortcut isolation regression: passed
- TypeScript typecheck: passed
- Vite production build: passed
- fixed-viewport Dashboard and Live Training browser checks: passed
- Ruff and format checks: passed
- MyPy: passed
- import architecture: passed
- dead-code report: passed
- full Python suite: **2,914 passed, 6 skipped**
- total branch coverage: **82.34%** against the 80% requirement
- critical branch coverage ratchet: passed
- package and uv identity: passed
- Ubuntu and Windows compatibility: passed
- training image build, identity evidence, and non-root runtime probe: passed
