### PR TITLE
Fix training telemetry semantics

### DIFF
--- a/tests/integrations/test_training_telemetry.py
+++ b/tests/integrations/test_training_telemetry.py
@@ -130,6 +130,41 @@ def test_sampler_skips_unimportant_steps_and_preserves_position_risk_and_termina
     assert page.items[0].action == pytest.approx((0.4,))
 
 
+def test_sampler_preserves_vecenv_termination_semantics(tmp_path: Path) -> None:
+    path = tmp_path / "training-telemetry.jsonl"
+    sampler = TrainingTelemetrySampler(path, seed=7, sample_every=1)
+    truncated_info = info(1)
+    truncated_info["TimeLimit.truncated"] = True
+
+    assert (
+        sampler.consume(
+            global_step=1,
+            actions=np.asarray([[0.0]], dtype=np.float32),
+            rewards=np.asarray([0.0], dtype=np.float32),
+            dones=np.asarray([True]),
+            infos=(truncated_info,),
+        )
+        == 1
+    )
+    assert (
+        sampler.consume(
+            global_step=2,
+            actions=np.asarray([[0.0]], dtype=np.float32),
+            rewards=np.asarray([0.0], dtype=np.float32),
+            dones=np.asarray([True]),
+            infos=(info(2, terminated=True),),
+        )
+        == 1
+    )
+    sampler.close()
+
+    truncated, terminated = read_training_telemetry(path, limit=10).items
+    assert truncated.terminated is False
+    assert truncated.truncated is True
+    assert terminated.terminated is True
+    assert terminated.truncated is False
+
+
 def test_sampler_batches_durable_writes_until_rollout_boundary(tmp_path: Path) -> None:
     path = tmp_path / "training-telemetry.jsonl"
     sampler = TrainingTelemetrySampler(path, seed=7, sample_every=1)

--- a/tests/rl/test_action_head_tensorboard_ablation.py
+++ b/tests/rl/test_action_head_tensorboard_ablation.py
@@ -73,14 +73,14 @@ def test_tensorboard_uses_soft_rollout_mean_for_exploration_telemetry() -> None:
         active_mask=torch.tensor([[True, True]]),
     )
 
-    def rollout_outputs(observations: object) -> object:
+    def behavior_cloning_outputs(observations: object) -> object:
         del observations
-        calls.append("rollout")
+        calls.append("smooth")
         return smooth_outputs
 
     policy = SimpleNamespace(
         action_stage_outputs=lambda observations: hard_outputs,
-        rollout_action_stage_outputs=rollout_outputs,
+        hierarchical_behavior_cloning_outputs=behavior_cloning_outputs,
     )
     callback.model = SimpleNamespace(logger=logger, policy=policy)
     callback.locals = {
@@ -93,7 +93,7 @@ def test_tensorboard_uses_soft_rollout_mean_for_exploration_telemetry() -> None:
     assert callback._on_step()
     callback._on_rollout_end()
 
-    assert calls == ["rollout"]
+    assert calls == ["smooth"]
     assert logger.values["trade_rl/change_intensity_mean"] == pytest.approx(0.25)
     assert logger.values["trade_rl/deterministic_change_l1_mean"] == pytest.approx(0.1)
     assert logger.values["trade_rl/exploration_l1_mean"] == pytest.approx(0.3)

--- a/tests/rl/test_action_head_tensorboard_ablation.py
+++ b/tests/rl/test_action_head_tensorboard_ablation.py
@@ -53,3 +53,48 @@ def test_shared_target_head_records_common_action_stages_without_gate_metric() -
     assert logger.values["trade_rl/sampled_change_l1_mean"] == pytest.approx(0.4)
     assert logger.values["trade_rl/submission_l1_mean"] == pytest.approx(0.2)
     assert logger.values["trade_rl/effective_action_l1_mean"] == pytest.approx(0.3)
+
+
+def test_tensorboard_uses_soft_rollout_mean_for_exploration_telemetry() -> None:
+    callback = build_tensorboard_metrics_callback(enabled=True)
+    assert callback is not None
+    logger = FakeLogger()
+    calls: list[str] = []
+    hard_outputs = SimpleNamespace(
+        change_intensity=torch.tensor([[0.0, 0.0]]),
+        current_weights=torch.tensor([[0.1, -0.1]]),
+        deterministic_actions=torch.tensor([[0.1, -0.1]]),
+        active_mask=torch.tensor([[True, True]]),
+    )
+    smooth_outputs = SimpleNamespace(
+        change_intensity=torch.tensor([[0.25, 0.25]]),
+        current_weights=torch.tensor([[0.1, -0.1]]),
+        deterministic_actions=torch.tensor([[0.2, -0.1]]),
+        active_mask=torch.tensor([[True, True]]),
+    )
+
+    def rollout_outputs(observations: object) -> object:
+        del observations
+        calls.append("rollout")
+        return smooth_outputs
+
+    policy = SimpleNamespace(
+        action_stage_outputs=lambda observations: hard_outputs,
+        rollout_action_stage_outputs=rollout_outputs,
+    )
+    callback.model = SimpleNamespace(logger=logger, policy=policy)
+    callback.locals = {
+        "rewards": (),
+        "obs_tensor": {"current_weights": torch.tensor([[0.1, -0.1]])},
+        "actions": np.array([[0.4, -0.2]]),
+        "infos": [{}],
+    }
+
+    assert callback._on_step()
+    callback._on_rollout_end()
+
+    assert calls == ["rollout"]
+    assert logger.values["trade_rl/change_intensity_mean"] == pytest.approx(0.25)
+    assert logger.values["trade_rl/deterministic_change_l1_mean"] == pytest.approx(0.1)
+    assert logger.values["trade_rl/exploration_l1_mean"] == pytest.approx(0.3)
+    assert logger.values["trade_rl/sampled_change_l1_mean"] == pytest.approx(0.4)

--- a/tests/rl/test_tensorboard_logging.py
+++ b/tests/rl/test_tensorboard_logging.py
@@ -74,9 +74,7 @@ def test_tensorboard_callback_aggregates_finite_rollout_metrics() -> None:
     assert logger.values["trade_rl/reward_absolute_component_mean"] == pytest.approx(
         0.02
     )
-    assert logger.values["trade_rl/reward_excess_component_mean"] == pytest.approx(
-        0.0
-    )
+    assert logger.values["trade_rl/reward_excess_component_mean"] == pytest.approx(0.0)
     assert logger.values[
         "trade_rl/reward_baseline_penalty_weighted_mean"
     ] == pytest.approx(0.003)

--- a/tests/telemetry/test_writer_validation.py
+++ b/tests/telemetry/test_writer_validation.py
@@ -4,7 +4,40 @@ from pathlib import Path
 
 import pytest
 
-from trade_rl.telemetry import TrainingTelemetryWriter
+from trade_rl.telemetry import TrainingTelemetryRecord, TrainingTelemetryWriter
+
+
+def _record(*, terminated: bool = False, truncated: bool = False) -> TrainingTelemetryRecord:
+    return TrainingTelemetryRecord(
+        sequence=1,
+        recorded_at="2026-07-21T08:00:00+00:00",
+        global_step=32,
+        environment_step=1,
+        seed=7,
+        environment_id=0,
+        event_type="episode_end",
+        market_index=101,
+        market_time="2026-07-21T07:55:00.000000000",
+        symbol="BTCUSDT",
+        open=67_500.0,
+        high=67_900.0,
+        low=67_400.0,
+        close=67_842.3,
+        action=(0.4,),
+        executed_target=(0.4,),
+        weights_before=(0.2,),
+        weights_after=(0.4,),
+        portfolio_value=101_342.85,
+        baseline_portfolio_value=100_400.0,
+        reward=0.214,
+        drawdown=0.0086,
+        interval_cost=4.25,
+        interval_return=0.0012,
+        risk_reasons=(),
+        emergency_deleverage=False,
+        terminated=terminated,
+        truncated=truncated,
+    )
 
 
 @pytest.mark.parametrize("flush_every", (0, -1, True))
@@ -17,3 +50,19 @@ def test_writer_rejects_non_positive_or_boolean_flush_interval(
             tmp_path / "training-telemetry.jsonl",
             flush_every=flush_every,
         )
+
+
+def test_record_rejects_simultaneous_termination_and_truncation() -> None:
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        _record(terminated=True, truncated=True)
+
+
+def test_legacy_v1_dual_flags_are_normalized_as_time_limit_truncation() -> None:
+    payload = _record().to_json_dict()
+    payload["terminated"] = True
+    payload["truncated"] = True
+
+    decoded = TrainingTelemetryRecord.from_json_dict(payload)
+
+    assert decoded.terminated is False
+    assert decoded.truncated is True

--- a/tests/telemetry/test_writer_validation.py
+++ b/tests/telemetry/test_writer_validation.py
@@ -7,7 +7,9 @@ import pytest
 from trade_rl.telemetry import TrainingTelemetryRecord, TrainingTelemetryWriter
 
 
-def _record(*, terminated: bool = False, truncated: bool = False) -> TrainingTelemetryRecord:
+def _record(
+    *, terminated: bool = False, truncated: bool = False
+) -> TrainingTelemetryRecord:
     return TrainingTelemetryRecord(
         sequence=1,
         recorded_at="2026-07-21T08:00:00+00:00",

--- a/trade_rl/rl/tensorboard_logging.py
+++ b/trade_rl/rl/tensorboard_logging.py
@@ -64,9 +64,7 @@ _INFO_MEAN_TAGS = {
     "trade_rl/reward_terminal_penalty_weighted_mean": (
         "reward_terminal_penalty_weighted"
     ),
-    "trade_rl/reward_margin_penalty_weighted_mean": (
-        "reward_margin_penalty_weighted"
-    ),
+    "trade_rl/reward_margin_penalty_weighted_mean": ("reward_margin_penalty_weighted"),
     "trade_rl/reward_total_raw_mean": "reward_total_raw",
     "trade_rl/rolling_growth_gap_mean": "rolling_growth_gap",
 }

--- a/trade_rl/rl/tensorboard_logging.py
+++ b/trade_rl/rl/tensorboard_logging.py
@@ -121,7 +121,20 @@ def build_tensorboard_metrics_callback(
             if self.n_calls % log_interval == 0:
                 observations = self.locals.get("obs_tensor")
                 policy = getattr(self.model, "policy", None)
-                output_factory = getattr(policy, "action_stage_outputs", None)
+                # Rollout collection samples from the smooth distribution mean even
+                # while SB3 keeps the policy module in eval mode. Prefer an explicit
+                # rollout-stage provider, then the maintained hierarchical BC output
+                # that also forces operational=False. Falling back preserves generic
+                # and direct-head telemetry contracts.
+                output_factory = getattr(policy, "rollout_action_stage_outputs", None)
+                if not callable(output_factory):
+                    output_factory = getattr(
+                        policy,
+                        "hierarchical_behavior_cloning_outputs",
+                        None,
+                    )
+                if not callable(output_factory):
+                    output_factory = getattr(policy, "action_stage_outputs", None)
                 if not callable(output_factory):
                     output_factory = getattr(
                         policy,

--- a/trade_rl/rl/tensorboard_logging.py
+++ b/trade_rl/rl/tensorboard_logging.py
@@ -122,17 +122,14 @@ def build_tensorboard_metrics_callback(
                 observations = self.locals.get("obs_tensor")
                 policy = getattr(self.model, "policy", None)
                 # Rollout collection samples from the smooth distribution mean even
-                # while SB3 keeps the policy module in eval mode. Prefer an explicit
-                # rollout-stage provider, then the maintained hierarchical BC output
-                # that also forces operational=False. Falling back preserves generic
-                # and direct-head telemetry contracts.
-                output_factory = getattr(policy, "rollout_action_stage_outputs", None)
-                if not callable(output_factory):
-                    output_factory = getattr(
-                        policy,
-                        "hierarchical_behavior_cloning_outputs",
-                        None,
-                    )
+                # while SB3 keeps the policy module in eval mode. The hierarchical
+                # BC output already forces operational=False, so prefer it before
+                # generic or operational action-stage diagnostics.
+                output_factory = getattr(
+                    policy,
+                    "hierarchical_behavior_cloning_outputs",
+                    None,
+                )
                 if not callable(output_factory):
                     output_factory = getattr(policy, "action_stage_outputs", None)
                 if not callable(output_factory):

--- a/trade_rl/rl/training_telemetry.py
+++ b/trade_rl/rl/training_telemetry.py
@@ -61,6 +61,18 @@ def _number(value: object, *, fallback: float | None = None) -> float | None:
     return resolved if np.isfinite(resolved) else fallback
 
 
+def _transition_flags(
+    info: dict[str, object],
+    *,
+    done: bool,
+) -> tuple[bool, bool]:
+    """Recover exclusive Gymnasium flags from SB3's combined VecEnv ``done``."""
+
+    truncated = bool(info.get("TimeLimit.truncated"))
+    terminated = bool(info.get("hybrid_terminated")) or (done and not truncated)
+    return terminated, truncated
+
+
 def _risk_reasons(info: dict[str, object]) -> tuple[str, ...]:
     explicit = info.get("telemetry_risk_reasons")
     if isinstance(explicit, (tuple, list)):
@@ -321,6 +333,7 @@ class TrainingTelemetrySampler:
                     if environment_id < done_rows.size
                     else False
                 )
+                terminated, truncated = _transition_flags(info, done=done)
                 event_type = self._event_type(
                     info=info,
                     environment_step=environment_step,
@@ -424,8 +437,8 @@ class TrainingTelemetrySampler:
                         interval_return=_number(info.get("interval_net_return")),
                         risk_reasons=reasons,
                         emergency_deleverage=bool(info.get("emergency_deleverage")),
-                        terminated=bool(info.get("hybrid_terminated")) or done,
-                        truncated=bool(info.get("TimeLimit.truncated")),
+                        terminated=terminated,
+                        truncated=truncated,
                         episode_id=episode_id,
                     )
                 )

--- a/trade_rl/telemetry/training.py
+++ b/trade_rl/telemetry/training.py
@@ -211,6 +211,8 @@ class TrainingTelemetryRecord:
             _finite_tuple(values, field=field)
         if self.high is not None and self.low is not None and self.high < self.low:
             raise ValueError("high cannot be below low")
+        if self.terminated and self.truncated:
+            raise ValueError("terminated and truncated must be mutually exclusive")
 
     def to_json_dict(self) -> dict[str, object]:
         return {
@@ -256,6 +258,14 @@ class TrainingTelemetryRecord:
         event_type = _required_string(raw, "event_type")
         if event_type not in _EVENT_TYPES:
             raise ValueError("event_type is invalid")
+        terminated = _required_bool(raw, "terminated")
+        truncated = _required_bool(raw, "truncated")
+        if terminated and truncated:
+            # Historical v1 writers treated SB3 VecEnv's combined ``done`` as
+            # termination even for a time-limit transition. The environment
+            # contract keeps these flags exclusive, so dual flags identify that
+            # legacy truncation representation and can be normalized on read.
+            terminated = False
         return cls(
             sequence=_required_int(raw, "sequence", minimum=1),
             recorded_at=_required_string(raw, "recorded_at"),
@@ -284,8 +294,8 @@ class TrainingTelemetryRecord:
             interval_return=_optional_float(raw, "interval_return"),
             risk_reasons=_string_tuple(raw, "risk_reasons"),
             emergency_deleverage=_required_bool(raw, "emergency_deleverage"),
-            terminated=_required_bool(raw, "terminated"),
-            truncated=_required_bool(raw, "truncated"),
+            terminated=terminated,
+            truncated=truncated,
         )
 
 


### PR DESCRIPTION
## What

Correct two training-observability defects found during the reward/BC audit and preserve existing telemetry artifacts:

- measure hierarchical PPO exploration against the same smooth deterministic mean used by rollout sampling, rather than an operational hard-gate action;
- reconstruct exclusive Gymnasium `terminated` versus `truncated` flags from SB3 VecEnv's combined `done` signal;
- reject newly constructed telemetry records that set both flags;
- normalize historical `training_telemetry_v1` rows with the legacy dual-flag representation to a pure time-limit truncation when read.

## Why

The previous TensorBoard `exploration_l1` could include the soft-to-hard Gate semantic gap, so it was not a pure exploration measurement. The append-only training telemetry also treated every VecEnv `done` as economic termination, recording ordinary time-limit episodes as both `terminated=true` and `truncated=true`.

## Design

- Hierarchical telemetry now prefers the existing `hierarchical_behavior_cloning_outputs()` method because it explicitly uses `operational=False`, matching the smooth distribution mean used by PPO rollout collection even while the policy module is in evaluation mode.
- Direct-head and generic policy telemetry retain their existing `action_stage_outputs()` fallback.
- VecEnv flags are reconstructed as `truncated = TimeLimit.truncated` and `terminated = hybrid_terminated or (done and not truncated)`.
- The telemetry schema remains `training_telemetry_v1`; the reader repairs the one known legacy writer defect without rewriting stored evidence.

## Scope and non-goals

- no reward equation or coefficient change;
- no BC loss, teacher, or quality-gate change;
- no PPO distribution, objective, or update change;
- no action sampling or serving-prediction change;
- no risk, execution, checkpoint, or artifact-identity change;
- the active full-training container and existing artifacts remain untouched.

## TDD evidence

### Exploration and VecEnv flags

RED head `35a8787cf372ff1b5cd0471cf04d45b6087149af`:

- exactly 2 new regression failures;
- 3,173 existing tests passed;
- 26 skipped;
- the failures reproduced hard-Gate exploration drift and time-limit termination misclassification.

GREEN head `a3db260d537367f6dd4a485f1a8a9d8072986d57`:

- 3,175 passed, 26 skipped;
- total coverage 80.65%;
- all static, compatibility, image, architecture, smoke, and package checks passed.

### Legacy telemetry compatibility

RED head `dcaa0d838509e615120e9c7d3ac42aa87cc6433c`:

- exactly 2 new contract failures;
- 3,175 existing tests passed;
- 26 skipped;
- the failures reproduced missing mutual-exclusion validation and missing legacy normalization.

## Exact-head verification

Final head: `5a40750b6a8e11887d4737dccd490329ea9f6b16`

CI run `31356977117` / run number `6533`: success.

- Python: 3,177 passed, 26 skipped;
- total branch-aware coverage: 80.65% (80% required);
- frontend: 30 files / 127 tests passed;
- frontend typecheck, production build, and fixed-viewport checks: passed;
- Ruff: passed;
- Ruff format: 1,004 files already formatted;
- MyPy: 392 source files, no issues;
- Import Linter: 12 contracts kept, 0 broken;
- dead-code report: passed;
- recovery and structured-serving smoke: 2 passed;
- critical branch coverage: passed;
- package and uv identity: passed;
- Ubuntu compatibility: passed;
- Windows compatibility: passed;
- complete training image and packaged non-root runtime probe: passed;
- unresolved review threads: 0.

Production remains `NO-GO`.