### PR TITLE
Integrate latest BC episode-training regression

### DIFF
--- a/tests/learning/test_behavior_cloning_episode_training.py
+++ b/tests/learning/test_behavior_cloning_episode_training.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import numpy as np
+import torch
+
+from trade_rl.integrations.behavior_cloning import pretrain_policy
+from trade_rl.learning.behavior_cloning import BehaviorCloningConfig
+from trade_rl.learning.episode_teacher_artifact import (
+    EpisodeSupervisedPolicyDataset,
+)
+
+
+class _Distribution:
+    def __init__(self, mean: torch.Tensor) -> None:
+        self.mean = mean
+
+    def get_actions(self, *, deterministic: bool = False) -> torch.Tensor:
+        assert deterministic is True
+        return self.mean
+
+
+class _RecordingPolicy(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.bias = torch.nn.Parameter(torch.zeros(1, dtype=torch.float32))
+        self.device = torch.device("cpu")
+        self.training_sample_ids: list[int] = []
+
+    def get_distribution(self, observations: torch.Tensor) -> _Distribution:
+        if torch.is_grad_enabled():
+            self.training_sample_ids.extend(
+                int(value) for value in observations[:, 0].detach().cpu().tolist()
+            )
+        mean = torch.tanh(self.bias).expand(len(observations), 1)
+        return _Distribution(mean)
+
+
+def test_episode_behavior_cloning_excludes_purged_rows_from_training_and_metrics() -> (
+    None
+):
+    observations = np.arange(8, dtype=np.float32)[:, None]
+    actions = np.zeros((8, 1), dtype=np.float32)
+    actions[4:6] = 1.0
+    dataset = EpisodeSupervisedPolicyDataset(
+        observations=observations,
+        actions=actions,
+        dataset_id="a" * 64,
+        train_start=0,
+        train_stop=11,
+        environment_digest="b" * 64,
+        action_spec_digest="c" * 64,
+        teacher_config_digest="d" * 64,
+        decision_indices=np.asarray([0, 1, 4, 5, 6, 7, 8, 9], dtype=np.int64),
+        episode_ids=np.repeat(np.arange(4, dtype=np.int64), 2),
+    )
+    policy = _RecordingPolicy()
+
+    result = pretrain_policy(
+        policy,
+        dataset,
+        config=BehaviorCloningConfig(
+            epochs=1,
+            learning_rate=0.01,
+            batch_size=8,
+            validation_fraction=0.26,
+        ),
+        seed=7,
+    )
+
+    assert sorted(policy.training_sample_ids) == [0, 1, 2, 3]
+    assert result.initial_mse == 0.0
+    assert result.final_mse == 0.0
+    assert result.validation_sample_count == 2

--- a/trade_rl/integrations/behavior_cloning.py
+++ b/trade_rl/integrations/behavior_cloning.py
@@ -282,9 +282,7 @@ def pretrain_policy(
     validation_indices = split.validation_indices
     train_count = int(train_indices.size)
     validation_count = int(validation_indices.size)
-    evaluation_indices = np.sort(
-        np.concatenate((train_indices, validation_indices))
-    )
+    evaluation_indices = np.sort(np.concatenate((train_indices, validation_indices)))
     # Teacher targets and their reconstruction gates are deterministic contracts.
     # Eval mode disables stochastic regularizers while preserving autograd, so
     # both optimization and metrics fit the exact function deployed to PPO.

--- a/trade_rl/integrations/behavior_cloning.py
+++ b/trade_rl/integrations/behavior_cloning.py
@@ -18,6 +18,7 @@ from trade_rl.learning.behavior_cloning import (
     BehaviorCloningResult,
     ObservationBatchProvider,
 )
+from trade_rl.learning.episode_behavior_cloning import behavior_cloning_split
 from trade_rl.learning.hierarchical_bc_metrics import (
     HierarchicalBehaviorCloningLosses,
     HierarchicalBehaviorCloningMetrics,
@@ -265,7 +266,7 @@ def pretrain_policy(
     hierarchical_labels: HierarchicalTeacherLabels | None = None,
     progress_callback: Callable[[dict[str, object]], None] | None = None,
 ) -> BehaviorCloningResult:
-    """Fit legacy MSE or hierarchical BC with a chronological validation tail."""
+    """Fit BC with chronological episode validation and purge support."""
 
     if isinstance(seed, bool) or not isinstance(seed, int) or seed < 0:
         raise ValueError("behavior-cloning seed must be non-negative")
@@ -273,17 +274,17 @@ def pretrain_policy(
         _validate_hierarchical_labels(dataset, hierarchical_labels)
     device = torch.device(policy.device)
     sample_count = dataset.sample_count
-    validation_count = (
-        0
-        if config.validation_fraction == 0.0
-        else max(1, int(math.floor(sample_count * config.validation_fraction)))
+    split = behavior_cloning_split(
+        dataset,
+        validation_fraction=config.validation_fraction,
     )
-    train_count = sample_count - validation_count
-    if train_count <= 0:
-        raise ValueError("behavior-cloning validation leaves no training samples")
-    all_indices = np.arange(sample_count, dtype=np.int64)
-    train_indices = all_indices[:train_count]
-    validation_indices = all_indices[train_count:]
+    train_indices = split.train_indices
+    validation_indices = split.validation_indices
+    train_count = int(train_indices.size)
+    validation_count = int(validation_indices.size)
+    evaluation_indices = np.sort(
+        np.concatenate((train_indices, validation_indices))
+    )
     # Teacher targets and their reconstruction gates are deterministic contracts.
     # Eval mode disables stochastic regularizers while preserving autograd, so
     # both optimization and metrics fit the exact function deployed to PPO.
@@ -291,7 +292,7 @@ def pretrain_policy(
     initial_mse = _mean_squared_error(
         policy,
         dataset,
-        indices=all_indices,
+        indices=evaluation_indices,
         batch_size=config.batch_size,
         device=device,
         provider=observation_provider,
@@ -312,7 +313,7 @@ def pretrain_policy(
             policy,
             dataset,
             hierarchical_labels,
-            indices=all_indices,
+            indices=evaluation_indices,
             batch_size=config.batch_size,
             config=config,
             positive_class_weight=positive_class_weight,
@@ -444,7 +445,7 @@ def pretrain_policy(
     final_mse = _mean_squared_error(
         policy,
         dataset,
-        indices=all_indices,
+        indices=evaluation_indices,
         batch_size=config.batch_size,
         device=device,
         provider=observation_provider,
@@ -468,7 +469,7 @@ def pretrain_policy(
             policy,
             dataset,
             hierarchical_labels,
-            indices=all_indices,
+            indices=evaluation_indices,
             batch_size=config.batch_size,
             config=config,
             positive_class_weight=positive_class_weight,

--- a/trade_rl/learning/episode_behavior_cloning.py
+++ b/trade_rl/learning/episode_behavior_cloning.py
@@ -15,12 +15,9 @@ def _empty_int_vector() -> np.ndarray:
     return np.asarray([], dtype=np.int64)
 
 
-class EpisodeDataset(Protocol):
+class BehaviorCloningDataset(Protocol):
     @property
     def sample_count(self) -> int: ...
-
-    @property
-    def episode_ids(self) -> np.ndarray: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -135,7 +132,7 @@ def _plain_tail_split(
 
 
 def behavior_cloning_split(
-    dataset: EpisodeDataset,
+    dataset: BehaviorCloningDataset,
     *,
     validation_fraction: float,
 ) -> BehaviorCloningSplit:
@@ -232,7 +229,7 @@ def align_behavior_cloning_validation(
 
     if not hasattr(dataset, "sample_count") or not hasattr(dataset, "episode_ids"):
         raise TypeError("episode behavior cloning requires episode-aware provenance")
-    episode_dataset = cast(EpisodeDataset, dataset)
+    episode_dataset = cast(BehaviorCloningDataset, dataset)
     split = behavior_cloning_split(
         episode_dataset,
         validation_fraction=config.validation_fraction,


### PR DESCRIPTION
Preserve the latest BC branch commits and add its direct episode-dataset regression to the consolidation branch. Overlapping trainer logic will be reconciled so both explicit split consumption and direct episode-aware fallback remain valid.