### PR TITLE
Add deterministic universal instrument episode routing

### DIFF
--- a/docs/implementation/2026-08-11-universal-episode-router-plan.md
+++ b/docs/implementation/2026-08-11-universal-episode-router-plan.md
@@ -1,0 +1,335 @@
+# Universal Single-Instrument Episode Router Implementation Plan
+
+## Conclusion
+
+Implement U2 as a fail-closed Gymnasium facade that routes complete episodes across immutable single-symbol environments while exposing one generic policy-facing instrument contract:
+
+```text
+symbols = ("INSTRUMENT",)
+action_names = ("target_weight:INSTRUMENT",)
+action_shape = (1,)
+```
+
+The implementation must not mutate `ResidualMarketEnv.dataset` after construction. Each concrete symbol remains inside its own independently constructed environment and immutable binding. The wrapper selects exactly one concrete environment at reset, delegates the whole episode to it, and switches only after termination or truncation.
+
+This is a stacked change on top of the U1 universal-instrument artifact bundle. It does not change the current BTC training generation, existing profiles, normalization, BC, PPO, reward definitions, serving, or production authorization.
+
+## Scope
+
+### Included
+
+- immutable concrete-dataset and episode binding contracts;
+- deterministic balanced train-symbol routing;
+- train/validation/test leakage guards;
+- generic single-instrument policy-facing symbols and one-action contract;
+- a lazy, cached Gymnasium facade over independent concrete environments;
+- fail-closed environment schema validation;
+- terminal and reset telemetry carrying concrete episode identity;
+- universal policy-manifest and concrete deployment-binding identity contracts;
+- focused unit, contract, and real-environment integration tests.
+
+### Excluded
+
+- PostgreSQL dataset payload loading;
+- target-local feature selection;
+- instrument descriptors as observations;
+- symbol-balanced normalization;
+- universal BC or critic warm start;
+- PPO/Lagrangian training orchestration;
+- zero-shot evaluation gates;
+- checkpoint or serving integration;
+- changing any maintained default or active generation.
+
+## Design boundaries
+
+### 1. Concrete binding ownership
+
+`InstrumentDatasetBinding` owns the non-policy identity required to prove which concrete market data is loaded:
+
+```text
+concrete_symbol
+source_dataset_id
+symbol_dataset_digest
+execution_metadata_digest
+instrument_descriptor_digest
+split
+```
+
+All digests are lowercase SHA-256 values. `split` must be one of `train`, `validation`, or `test`.
+
+The binding validates a loaded environment before use:
+
+- exactly one dataset symbol;
+- the dataset symbol equals `concrete_symbol`;
+- the dataset ID equals `source_dataset_id`;
+- target-weight action mode;
+- exactly one action;
+- underlying concrete action name equals `target_weight:<concrete_symbol>`.
+
+### 2. Deterministic balanced router
+
+`DeterministicBalancedInstrumentRouter` receives:
+
+```text
+train_symbols
+partition_digest
+run_seed
+environment_index
+```
+
+For completed episode count `k`:
+
+```text
+cycle, position = divmod(k, len(train_symbols))
+```
+
+A cycle-specific permutation is produced by sorting train symbols with canonical content-digest keys derived from the immutable routing identity and cycle number. Therefore:
+
+- every train symbol appears exactly once per cycle;
+- no symbol appears twice before all train symbols appear once;
+- the same identity and completed count always return the same route;
+- different environment indices can produce distinct deterministic orders;
+- no process-global or mutable random-number generator is used.
+
+### 3. Training split guard
+
+The training facade requires exact closure:
+
+```text
+binding symbols == partition train symbols
+all binding.split == "train"
+```
+
+Validation/test bindings, missing train bindings, extra bindings, duplicate bindings, or a partition mismatch fail during construction before any environment factory is called.
+
+### 4. Independent environment state
+
+The facade receives an environment factory and lazily creates at most one environment per concrete symbol. Constructed environments are cached and never rebound to another dataset.
+
+Each concrete environment therefore owns independent:
+
+- dataset;
+- hybrid and shadow books;
+- order books;
+- pending targets;
+- reward tracker;
+- episode sampler;
+- execution random state;
+- observation runtime state.
+
+A factory failure is propagated. The router never falls back to another symbol.
+
+### 5. Generic policy-facing contract
+
+The facade exposes only:
+
+```text
+policy_symbols = ("INSTRUMENT",)
+action_names = ("target_weight:INSTRUMENT",)
+action_space.shape = (1,)
+```
+
+Concrete symbols remain in binding and telemetry records, not in the policy-facing action layout. The observation itself is delegated unchanged because every underlying dataset is single-symbol and must satisfy the same Gymnasium space contract.
+
+The first loaded environment establishes the canonical observation and action spaces. Every later environment must match those spaces exactly before reset is delegated. A mismatch stops the run.
+
+### 6. Episode lifecycle
+
+Initial reset:
+
+1. route from completed count zero;
+2. load and validate the selected environment;
+3. derive a deterministic per-episode seed;
+4. reset the concrete environment;
+5. create an immutable `InstrumentEpisodeBinding` from returned episode boundaries;
+6. attach the binding payload and digest to reset info.
+
+During an active episode:
+
+- `step` delegates only to the selected concrete environment;
+- an early `reset` is rejected;
+- `step` before reset or after completion is rejected;
+- completed episode count advances only when `terminated or truncated` is true.
+
+Terminal info preserves the ending episode binding so vector-environment auto-reset cannot erase the concrete identity of the transition.
+
+### 7. Seed contract
+
+`run_seed` is immutable construction identity. A reset seed may be omitted or equal `run_seed`; a different value is rejected instead of silently changing the routing sequence.
+
+The concrete episode seed is derived from:
+
+```text
+run_seed
+environment_index
+completed_episode_count
+selected binding digest
+partition digest
+```
+
+and reduced to an unsigned 32-bit value. This separates routing determinism from process scheduling.
+
+### 8. Universal policy and deployment identity
+
+`UniversalSingleInstrumentPolicyManifest` contains only generic/training identity:
+
+```text
+architecture_digest
+observation_schema_digest
+action_schema_digest
+instrument_descriptor_schema_digest
+normalizer_digest
+reward_environment_digest
+training_catalog_digest
+training_symbol_split_digest
+training_symbols_digest
+zero_shot_evidence_digest
+```
+
+Its canonical payload must not contain a concrete ticker. Its digest is the policy digest.
+
+`SingleInstrumentDeploymentBinding` contains the concrete deployment identity:
+
+```text
+policy_digest
+concrete_symbol
+market_instrument_contract_digest
+dataset_feature_schema_digest
+execution_metadata_digest
+instrument_descriptor_evidence_digest
+seen_in_training
+```
+
+This separation permits `seen_in_training=false` while keeping concrete asset binding outside architecture identity.
+
+## Failure behavior
+
+The implementation fails closed for:
+
+- fewer than one train symbol;
+- invalid or duplicate train symbols;
+- non-integer or negative seed/index/count values;
+- invalid SHA-256 fields;
+- binding closure different from partition train closure;
+- any validation/test binding in the training facade;
+- environment factory returning the wrong type/contract;
+- multi-symbol concrete environments;
+- dataset ID or concrete symbol mismatch;
+- non-target-weight or multi-action environments;
+- observation/action-space mismatch across symbols;
+- reset before the prior episode completes;
+- step before reset or after completion;
+- factory/reset/step failure;
+- non-boolean termination flags;
+- malformed episode boundaries;
+- concrete symbol leakage into the universal policy manifest.
+
+No failing output is converted into a different route or treated as a skipped symbol.
+
+## TDD sequence and commits
+
+### Commit 1 — plan
+
+```text
+docs(rl): plan universal episode routing
+```
+
+Add this plan only.
+
+### Commit 2 — RED contracts
+
+```text
+test(rl): define universal episode routing contracts
+```
+
+Add tests that import the not-yet-existing U2 modules and specify:
+
+- immutable binding validation and digests;
+- balanced cycle closure and determinism;
+- split leakage rejection;
+- generic one-action facade;
+- lifecycle and terminal telemetry;
+- factory failure without fallback;
+- schema mismatch rejection;
+- policy/deployment identity separation.
+
+Expected RED is missing U2 modules only.
+
+### Commit 3 — binding and router core
+
+```text
+feat(rl): add deterministic universal instrument router
+```
+
+Implement immutable bindings, canonical serialization, and deterministic balanced routing. Make core contract tests green while facade tests remain RED.
+
+### Commit 4 — routed Gym facade
+
+```text
+feat(rl): route complete single-instrument episodes
+```
+
+Implement the lazy cached facade, space validation, seed derivation, lifecycle guards, and reset/terminal info enrichment.
+
+### Commit 5 — policy/deployment identity
+
+```text
+feat(rl): separate universal policy and deployment identity
+```
+
+Implement generic universal policy manifest and concrete deployment binding contracts.
+
+### Commit 6 — integration and review fixes
+
+```text
+test(rl): harden universal episode routing boundaries
+```
+
+Add real `ResidualMarketEnv` integration tests and any regression tests found during self-review. Update documentation only where needed to match the implemented contract.
+
+## Focused verification
+
+Run on each implementation head:
+
+```text
+pytest tests/rl/test_universal_instrument_binding.py -q
+pytest tests/rl/test_universal_episode_router.py -q
+pytest tests/rl/test_universal_single_instrument_identity.py -q
+ruff check changed files
+ruff format --check changed files
+mypy changed source files
+```
+
+## Repository verification
+
+The final exact head must pass:
+
+- full pytest with branch coverage;
+- critical branch-coverage ratchets;
+- Ruff;
+- Ruff format;
+- MyPy;
+- Import Linter;
+- Vulture;
+- frontend tests, typecheck, build, and fixed-viewport checks;
+- Windows and Ubuntu compatibility;
+- training image and packaged non-root runtime probe;
+- PostgreSQL specialist workflow when triggered;
+- package and uv identity.
+
+## Completion criteria
+
+U2 is software-complete only when:
+
+1. train bindings close exactly over the U1 partition train split;
+2. each cycle uses every train symbol once before repetition;
+3. each environment handles exactly one concrete symbol for a complete episode;
+4. no book/order/reward state is shared across concrete environments;
+5. the policy-facing symbol and action contracts remain generic and scalar;
+6. validation/test bindings cannot enter the training router;
+7. factory, dataset, schema, and lifecycle failures stop the run without fallback;
+8. reset and terminal info preserve the concrete episode binding;
+9. universal policy identity contains no concrete ticker;
+10. exact-head CI is fully green and the stacked PR is Ready for review.
+
+Passing these criteria is infrastructure evidence only. It is not evidence of profitable learning, zero-shot generalization, sealed-test success, or production readiness. Production remains **NO-GO**.

--- a/docs/implementation/2026-08-11-universal-episode-router-red.md
+++ b/docs/implementation/2026-08-11-universal-episode-router-red.md
@@ -1,0 +1,11 @@
+# Universal Episode Router RED Evidence
+
+The contract-test commit is:
+
+```text
+3f6d64c37edcf870af7bd49aeec61a5928497459
+```
+
+This head adds the complete U2 contract tests before the implementation modules exist. The expected repository failure is collection-time `ModuleNotFoundError` for the new `trade_rl.rl.universal_*` modules. Any unrelated failure must be investigated before implementation begins.
+
+The active BTC training generation and existing runtime artifacts are outside this stacked PR and remain untouched.

--- a/docs/implementation/2026-08-11-universal-episode-router-red.md
+++ b/docs/implementation/2026-08-11-universal-episode-router-red.md
@@ -8,4 +8,6 @@ The contract-test commit is:
 
 This head adds the complete U2 contract tests before the implementation modules exist. The expected repository failure is collection-time `ModuleNotFoundError` for the new `trade_rl.rl.universal_*` modules. Any unrelated failure must be investigated before implementation begins.
 
+The verification PR was temporarily retargeted to `main` only to make GitHub Actions evaluate this exact branch head; it will return to its stacked U1 base after verification.
+
 The active BTC training generation and existing runtime artifacts are outside this stacked PR and remain untouched.

--- a/docs/implementation/2026-08-11-universal-episode-router-red.md
+++ b/docs/implementation/2026-08-11-universal-episode-router-red.md
@@ -8,6 +8,12 @@ The contract-test commit is:
 
 This head adds the complete U2 contract tests before the implementation modules exist. The expected repository failure is collection-time `ModuleNotFoundError` for the new `trade_rl.rl.universal_*` modules. Any unrelated failure must be investigated before implementation begins.
 
+The test-format correction is isolated in:
+
+```text
+a0fdd42779a584a7ac1bdbc1f8d7ed50541e440b
+```
+
 The verification PR was temporarily retargeted to `main` only to make GitHub Actions evaluate this exact branch head; it will return to its stacked U1 base after verification.
 
 The active BTC training generation and existing runtime artifacts are outside this stacked PR and remain untouched.

--- a/docs/implementation/2026-08-11-universal-episode-router-red.md
+++ b/docs/implementation/2026-08-11-universal-episode-router-red.md
@@ -14,6 +14,22 @@ The test-format correction is isolated in:
 a0fdd42779a584a7ac1bdbc1f8d7ed50541e440b
 ```
 
+Formatted RED verification head:
+
+```text
+b7c89cd3f9369a364e9005c5d1c14f9416152864
+```
+
+At that exact head, frontend, workflow security, Ruff, Ruff format, MyPy, Import Linter, Vulture, serving smoke, Windows/Ubuntu compatibility, PostgreSQL specialist checks, and the complete training image passed. Full pytest stopped only on the four expected collection-time `ModuleNotFoundError` failures for the new U2 modules.
+
+Initial GREEN implementation commits:
+
+```text
+b8642a644c9f93e6572fecb6713e8ba8245d5ad9  binding and balanced router
+e84d764a96f0982f3d36187154d482418a7f7a4f  episode-routed Gymnasium facade
+0ab717c8ea42fa0dbf14fb5d280e791beb81b229  policy/deployment identity separation
+```
+
 The verification PR was temporarily retargeted to `main` only to make GitHub Actions evaluate this exact branch head; it will return to its stacked U1 base after verification.
 
 The active BTC training generation and existing runtime artifacts are outside this stacked PR and remain untouched.

--- a/tests/rl/test_episode_routed_environment.py
+++ b/tests/rl/test_episode_routed_environment.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import gymnasium as gym
+import numpy as np
+import pytest
+
+from trade_rl.artifacts.hashing import content_digest
+from trade_rl.rl.actions import ActionMode, ActionSpec, ActionValidationMode
+from trade_rl.rl.episode_routed_environment import EpisodeRoutedSingleInstrumentEnv
+from trade_rl.rl.instrument_episode_routing import (
+    GENERIC_INSTRUMENT_ACTION_NAMES,
+    GENERIC_INSTRUMENT_SYMBOLS,
+    InstrumentDatasetBinding,
+    InstrumentDatasetSplit,
+)
+
+
+def _digest(label: str) -> str:
+    return content_digest(label)
+
+
+@dataclass(frozen=True, slots=True)
+class _Dataset:
+    symbols: tuple[str, ...]
+    dataset_id: str
+
+
+class _SingleSymbolEnv(gym.Env[np.ndarray, np.ndarray]):
+    metadata = {"render_modes": []}
+
+    def __init__(
+        self,
+        symbol: str,
+        *,
+        dataset_id: str | None = None,
+        observation_contract_digest: str | None = None,
+        action_spec: ActionSpec | None = None,
+        fail_on_reset: bool = False,
+        both_terminal_flags: bool = False,
+    ) -> None:
+        super().__init__()
+        self.symbol = symbol
+        self.dataset = _Dataset(
+            symbols=(symbol,),
+            dataset_id=dataset_id or _digest(f"dataset:{symbol}"),
+        )
+        self.action_spec = action_spec or ActionSpec(
+            mode=ActionMode.TARGET_WEIGHT,
+            risk_tilt_enabled=False,
+            target_weight_count=1,
+            validation_mode=ActionValidationMode.FAIL_CLOSED,
+        )
+        self.action_names = self.action_spec.names_for_symbols(self.dataset.symbols)
+        self.action_spec_digest = _digest(
+            f"action:{self.action_spec.mode}:{self.action_names}"
+        )
+        self.action_space = gym.spaces.Box(
+            low=-1.0,
+            high=1.0,
+            shape=(1,),
+            dtype=np.float32,
+        )
+        self.observation_space = gym.spaces.Box(
+            low=-10.0,
+            high=10.0,
+            shape=(2,),
+            dtype=np.float32,
+        )
+        self.observation_schema = "single_instrument_observation_v1"
+        self.observation_contract_digest = (
+            observation_contract_digest or _digest("observation-contract")
+        )
+        self.environment_digest = _digest(f"environment:{symbol}")
+        self.fail_on_reset = fail_on_reset
+        self.both_terminal_flags = both_terminal_flags
+        self.reset_count = 0
+        self.step_count = 0
+        self.last_reset_seed: int | None = None
+        self.received_actions: list[np.ndarray] = []
+        self.closed = False
+        self._active = False
+
+    def reset(
+        self,
+        *,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[np.ndarray, dict[str, Any]]:
+        del options
+        if self.fail_on_reset:
+            raise RuntimeError(f"reset failed for {self.symbol}")
+        super().reset(seed=seed)
+        self.last_reset_seed = seed
+        self.reset_count += 1
+        self.step_count = 0
+        self._active = True
+        start = 100 * self.reset_count
+        return np.array([float(self.reset_count), 0.0], dtype=np.float32), {
+            "start_index": start,
+            "end_index": start + 12,
+            "child_symbol": self.symbol,
+        }
+
+    def step(
+        self,
+        action: np.ndarray,
+    ) -> tuple[np.ndarray, float, bool, bool, dict[str, Any]]:
+        if not self._active:
+            raise RuntimeError("child step outside an episode")
+        self.received_actions.append(np.asarray(action).copy())
+        self.step_count += 1
+        self._active = False
+        return (
+            np.array([float(self.reset_count), 1.0], dtype=np.float32),
+            float(action[0]),
+            True,
+            self.both_terminal_flags,
+            {"child_symbol": self.symbol},
+        )
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _binding(
+    symbol: str,
+    *,
+    split: InstrumentDatasetSplit | str = InstrumentDatasetSplit.TRAIN,
+) -> InstrumentDatasetBinding:
+    return InstrumentDatasetBinding(
+        concrete_symbol=symbol,
+        source_dataset_id=_digest(f"source:{symbol}"),
+        symbol_dataset_digest=_digest(f"dataset:{symbol}"),
+        execution_metadata_digest=_digest(f"execution:{symbol}"),
+        instrument_descriptor_digest=_digest(f"descriptor:{symbol}"),
+        partition_digest=_digest("partition"),
+        split=split,
+    )
+
+
+def _wrapper(
+    symbols: tuple[str, ...] = ("BTCUSDT", "ETHUSDT", "SOLUSDT"),
+    *,
+    environment_index: int = 0,
+    child_overrides: dict[str, _SingleSymbolEnv] | None = None,
+) -> tuple[EpisodeRoutedSingleInstrumentEnv, dict[str, _SingleSymbolEnv]]:
+    children = {
+        symbol: _SingleSymbolEnv(symbol)
+        for symbol in symbols
+    }
+    children.update(child_overrides or {})
+    bindings = tuple(_binding(symbol) for symbol in symbols)
+    wrapper = EpisodeRoutedSingleInstrumentEnv(
+        children,
+        bindings=bindings,
+        run_seed=37,
+        environment_index=environment_index,
+        partition_digest=_digest("partition"),
+    )
+    return wrapper, children
+
+
+def test_wrapper_exposes_only_generic_one_action_policy_contract() -> None:
+    wrapper, _ = _wrapper()
+
+    assert wrapper.symbols == GENERIC_INSTRUMENT_SYMBOLS
+    assert wrapper.action_names == GENERIC_INSTRUMENT_ACTION_NAMES
+    assert wrapper.action_space.shape == (1,)
+    assert wrapper.action_spec.mode is ActionMode.TARGET_WEIGHT
+    assert wrapper.action_spec.target_weight_count == 1
+    assert wrapper.observation_schema == "single_instrument_observation_v1"
+    assert wrapper.environment_digest == wrapper.environment_digest
+
+
+def test_reset_routes_one_child_and_emits_digest_bound_episode_identity() -> None:
+    wrapper, children = _wrapper()
+    expected_route = wrapper.router.route(0)
+
+    observation, info = wrapper.reset(seed=101)
+
+    selected = expected_route.binding.concrete_symbol
+    assert observation.shape == (2,)
+    assert children[selected].reset_count == 1
+    assert sum(child.reset_count for child in children.values()) == 1
+    assert info["generic_symbols"] == GENERIC_INSTRUMENT_SYMBOLS
+    assert info["generic_action_names"] == GENERIC_INSTRUMENT_ACTION_NAMES
+    episode = info["instrument_episode_binding"]
+    assert episode["concrete_symbol"] == selected
+    assert episode["completed_episode_count"] == 0
+    assert episode["episode_start"] == info["start_index"]
+    assert episode["episode_stop"] == info["end_index"]
+    assert episode["episode_binding_digest"] == wrapper.active_episode_binding.digest
+
+
+def test_terminal_transition_preserves_identity_and_advances_only_after_end() -> None:
+    wrapper, _ = _wrapper()
+    _, reset_info = wrapper.reset(seed=101)
+    binding = reset_info["instrument_episode_binding"]
+
+    _, reward, terminated, truncated, terminal_info = wrapper.step(
+        np.array([0.25], dtype=np.float32)
+    )
+
+    assert reward == pytest.approx(0.25)
+    assert terminated is True
+    assert truncated is False
+    assert terminal_info["instrument_episode_binding"] == binding
+    assert terminal_info["terminal_instrument_episode_binding"] == binding
+    assert wrapper.completed_episode_count == 1
+
+    _, next_info = wrapper.reset()
+    assert next_info["instrument_episode_binding"]["completed_episode_count"] == 1
+    assert next_info["instrument_episode_binding"]["routing_position"] == 1
+
+
+def test_every_symbol_is_selected_once_before_any_repeat() -> None:
+    wrapper, _ = _wrapper()
+    observed: list[str] = []
+
+    for _ in range(6):
+        _, info = wrapper.reset()
+        observed.append(info["instrument_episode_binding"]["concrete_symbol"])
+        wrapper.step(np.array([0.0], dtype=np.float32))
+
+    assert set(observed[:3]) == {"BTCUSDT", "ETHUSDT", "SOLUSDT"}
+    assert set(observed[3:]) == {"BTCUSDT", "ETHUSDT", "SOLUSDT"}
+
+
+def test_mid_episode_reset_and_step_outside_episode_fail_closed() -> None:
+    wrapper, _ = _wrapper()
+
+    with pytest.raises(RuntimeError, match="reset|episode"):
+        wrapper.step(np.array([0.0], dtype=np.float32))
+
+    wrapper.reset()
+    with pytest.raises(RuntimeError, match="active"):
+        wrapper.reset()
+
+    wrapper.step(np.array([0.0], dtype=np.float32))
+    with pytest.raises(RuntimeError, match="reset|episode"):
+        wrapper.step(np.array([0.0], dtype=np.float32))
+
+
+def test_non_scalar_action_is_rejected_before_child_execution() -> None:
+    wrapper, children = _wrapper()
+    _, info = wrapper.reset()
+    selected = info["instrument_episode_binding"]["concrete_symbol"]
+
+    with pytest.raises(ValueError, match="\(1,\)"):
+        wrapper.step(np.array([[0.0]], dtype=np.float32))
+
+    assert children[selected].received_actions == []
+
+
+def test_selected_child_reset_failure_never_falls_back_or_advances_cursor() -> None:
+    symbols = ("BTCUSDT", "ETHUSDT", "SOLUSDT")
+    provisional, _ = _wrapper(symbols)
+    selected = provisional.router.route(0).binding.concrete_symbol
+    provisional.close()
+    failing = _SingleSymbolEnv(selected, fail_on_reset=True)
+    wrapper, children = _wrapper(symbols, child_overrides={selected: failing})
+
+    with pytest.raises(RuntimeError, match=selected):
+        wrapper.reset()
+
+    assert wrapper.completed_episode_count == 0
+    assert sum(child.reset_count for child in children.values()) == 0
+    with pytest.raises(RuntimeError, match=selected):
+        wrapper.reset()
+    assert wrapper.router.route(0).binding.concrete_symbol == selected
+
+
+def test_reset_options_cannot_select_or_override_concrete_symbol() -> None:
+    wrapper, _ = _wrapper()
+
+    with pytest.raises(ValueError, match="symbol"):
+        wrapper.reset(options={"concrete_symbol": "BTCUSDT"})
+
+
+def test_child_terminal_flags_must_remain_exclusive() -> None:
+    symbols = ("BTCUSDT",)
+    child = _SingleSymbolEnv("BTCUSDT", both_terminal_flags=True)
+    wrapper, _ = _wrapper(symbols, child_overrides={"BTCUSDT": child})
+    wrapper.reset()
+
+    with pytest.raises(RuntimeError, match="terminated.*truncated|exclusive"):
+        wrapper.step(np.array([0.0], dtype=np.float32))
+
+    assert wrapper.completed_episode_count == 0
+
+
+def test_construction_rejects_dataset_action_and_observation_contract_mismatch() -> None:
+    binding = _binding("BTCUSDT")
+
+    wrong_dataset = _SingleSymbolEnv("BTCUSDT", dataset_id=_digest("wrong"))
+    with pytest.raises(ValueError, match="dataset"):
+        EpisodeRoutedSingleInstrumentEnv(
+            {"BTCUSDT": wrong_dataset},
+            bindings=(binding,),
+            run_seed=1,
+            environment_index=0,
+            partition_digest=_digest("partition"),
+        )
+
+    wrong_action = _SingleSymbolEnv(
+        "BTCUSDT",
+        action_spec=ActionSpec(
+            mode=ActionMode.RESIDUAL,
+            risk_tilt_enabled=False,
+            validation_mode=ActionValidationMode.FAIL_CLOSED,
+        ),
+    )
+    with pytest.raises(ValueError, match="target-weight|action"):
+        EpisodeRoutedSingleInstrumentEnv(
+            {"BTCUSDT": wrong_action},
+            bindings=(binding,),
+            run_seed=1,
+            environment_index=0,
+            partition_digest=_digest("partition"),
+        )
+
+    eth_binding = _binding("ETHUSDT")
+    children = {
+        "BTCUSDT": _SingleSymbolEnv("BTCUSDT"),
+        "ETHUSDT": _SingleSymbolEnv(
+            "ETHUSDT",
+            observation_contract_digest=_digest("different-observation"),
+        ),
+    }
+    with pytest.raises(ValueError, match="observation"):
+        EpisodeRoutedSingleInstrumentEnv(
+            children,
+            bindings=(binding, eth_binding),
+            run_seed=1,
+            environment_index=0,
+            partition_digest=_digest("partition"),
+        )
+
+
+def test_construction_requires_exact_child_and_binding_symbol_closure() -> None:
+    binding = _binding("BTCUSDT")
+
+    with pytest.raises(ValueError, match="closure|symbols"):
+        EpisodeRoutedSingleInstrumentEnv(
+            {"ETHUSDT": _SingleSymbolEnv("ETHUSDT")},
+            bindings=(binding,),
+            run_seed=1,
+            environment_index=0,
+            partition_digest=_digest("partition"),
+        )
+
+
+def test_close_closes_every_child_once() -> None:
+    wrapper, children = _wrapper()
+
+    wrapper.close()
+    wrapper.close()
+
+    assert all(child.closed for child in children.values())

--- a/tests/rl/test_instrument_episode_routing.py
+++ b/tests/rl/test_instrument_episode_routing.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from trade_rl.artifacts.hashing import content_digest
+from trade_rl.rl.instrument_episode_routing import (
+    GENERIC_INSTRUMENT_ACTION_NAMES,
+    GENERIC_INSTRUMENT_SYMBOL,
+    GENERIC_INSTRUMENT_SYMBOLS,
+    DeterministicBalancedInstrumentRouter,
+    InstrumentDatasetBinding,
+    InstrumentDatasetSplit,
+    InstrumentEpisodeBinding,
+)
+
+
+def _digest(label: str) -> str:
+    return content_digest(label)
+
+
+def _binding(
+    symbol: str,
+    *,
+    split: InstrumentDatasetSplit | str = InstrumentDatasetSplit.TRAIN,
+    partition_digest: str | None = None,
+) -> InstrumentDatasetBinding:
+    return InstrumentDatasetBinding(
+        concrete_symbol=symbol,
+        source_dataset_id=_digest(f"source:{symbol}"),
+        symbol_dataset_digest=_digest(f"dataset:{symbol}"),
+        execution_metadata_digest=_digest(f"execution:{symbol}"),
+        instrument_descriptor_digest=_digest(f"descriptor:{symbol}"),
+        partition_digest=partition_digest or _digest("partition"),
+        split=split,
+    )
+
+
+def test_generic_policy_contract_is_one_identity_free_instrument_slot() -> None:
+    assert GENERIC_INSTRUMENT_SYMBOL == "INSTRUMENT"
+    assert GENERIC_INSTRUMENT_SYMBOLS == ("INSTRUMENT",)
+    assert GENERIC_INSTRUMENT_ACTION_NAMES == ("target_weight:INSTRUMENT",)
+
+
+def test_dataset_binding_is_canonical_digest_bound_and_round_trips() -> None:
+    binding = _binding("BTCUSDT")
+
+    payload = binding.to_json_dict()
+
+    assert payload["schema_version"] == "instrument_dataset_binding_v1"
+    assert payload["binding_digest"] == binding.digest
+    assert InstrumentDatasetBinding.from_json_dict(payload) == binding
+    assert "INSTRUMENT" not in binding.digest_payload().values()
+
+
+def test_dataset_binding_rejects_generic_symbol_invalid_digest_and_split() -> None:
+    with pytest.raises(ValueError, match="concrete_symbol"):
+        _binding("INSTRUMENT")
+    with pytest.raises(ValueError, match="symbol_dataset_digest"):
+        replace(_binding("BTCUSDT"), symbol_dataset_digest="not-a-digest")
+    with pytest.raises(ValueError, match="split"):
+        _binding("BTCUSDT", split="shadow")
+
+
+def test_dataset_binding_strict_load_rejects_extra_or_tampered_fields() -> None:
+    payload = _binding("BTCUSDT").to_json_dict()
+
+    with pytest.raises(ValueError, match="fields"):
+        InstrumentDatasetBinding.from_json_dict({**payload, "ticker_id": 7})
+
+    tampered = dict(payload)
+    tampered["concrete_symbol"] = "ETHUSDT"
+    with pytest.raises(ValueError, match="digest"):
+        InstrumentDatasetBinding.from_json_dict(tampered)
+
+
+def test_router_is_input_order_independent_and_balanced_per_cycle() -> None:
+    bindings = tuple(
+        _binding(symbol)
+        for symbol in ("BTCUSDT", "ETHUSDT", "SOLUSDT", "XRPUSDT", "ADAUSDT")
+    )
+    first = DeterministicBalancedInstrumentRouter(
+        bindings,
+        run_seed=41,
+        environment_index=3,
+        partition_digest=_digest("partition"),
+    )
+    reordered = DeterministicBalancedInstrumentRouter(
+        tuple(reversed(bindings)),
+        run_seed=41,
+        environment_index=3,
+        partition_digest=_digest("partition"),
+    )
+
+    first_routes = tuple(first.route(index) for index in range(2 * len(bindings)))
+    reordered_routes = tuple(
+        reordered.route(index) for index in range(2 * len(bindings))
+    )
+
+    assert tuple(route.binding.concrete_symbol for route in first_routes) == tuple(
+        route.binding.concrete_symbol for route in reordered_routes
+    )
+    for cycle in range(2):
+        cycle_routes = first_routes[cycle * len(bindings) : (cycle + 1) * len(bindings)]
+        assert {route.binding.concrete_symbol for route in cycle_routes} == {
+            binding.concrete_symbol for binding in bindings
+        }
+        assert tuple(route.routing_position for route in cycle_routes) == tuple(
+            range(len(bindings))
+        )
+        assert {route.routing_cycle for route in cycle_routes} == {cycle}
+
+
+def test_router_route_is_stateless_and_repeatable() -> None:
+    router = DeterministicBalancedInstrumentRouter(
+        tuple(_binding(symbol) for symbol in ("BTCUSDT", "ETHUSDT", "SOLUSDT")),
+        run_seed=11,
+        environment_index=0,
+        partition_digest=_digest("partition"),
+    )
+
+    assert router.route(7) == router.route(7)
+    assert router.route(7).completed_episode_count == 7
+    assert router.route(7).routing_cycle == 2
+    assert router.route(7).routing_position == 1
+
+
+def test_router_identity_changes_with_environment_index_without_mutable_rng() -> None:
+    bindings = tuple(
+        _binding(symbol) for symbol in ("BTCUSDT", "ETHUSDT", "SOLUSDT")
+    )
+    first = DeterministicBalancedInstrumentRouter(
+        bindings,
+        run_seed=11,
+        environment_index=0,
+        partition_digest=_digest("partition"),
+    )
+    second = DeterministicBalancedInstrumentRouter(
+        bindings,
+        run_seed=11,
+        environment_index=1,
+        partition_digest=_digest("partition"),
+    )
+
+    assert first.digest != second.digest
+    assert first.to_json_dict()["environment_index"] == 0
+    assert second.to_json_dict()["environment_index"] == 1
+
+
+def test_router_rejects_non_train_duplicate_and_foreign_partition_bindings() -> None:
+    train = _binding("BTCUSDT")
+    validation = _binding("ETHUSDT", split=InstrumentDatasetSplit.VALIDATION)
+    foreign = _binding("SOLUSDT", partition_digest=_digest("another-partition"))
+
+    with pytest.raises(ValueError, match="train"):
+        DeterministicBalancedInstrumentRouter(
+            (train, validation),
+            run_seed=1,
+            environment_index=0,
+            partition_digest=_digest("partition"),
+        )
+    with pytest.raises(ValueError, match="unique"):
+        DeterministicBalancedInstrumentRouter(
+            (train, train),
+            run_seed=1,
+            environment_index=0,
+            partition_digest=_digest("partition"),
+        )
+    with pytest.raises(ValueError, match="partition"):
+        DeterministicBalancedInstrumentRouter(
+            (train, foreign),
+            run_seed=1,
+            environment_index=0,
+            partition_digest=_digest("partition"),
+        )
+
+
+def test_router_rejects_invalid_indices_and_seed_types() -> None:
+    bindings = (_binding("BTCUSDT"),)
+
+    with pytest.raises(ValueError, match="run_seed"):
+        DeterministicBalancedInstrumentRouter(
+            bindings,
+            run_seed=True,
+            environment_index=0,
+            partition_digest=_digest("partition"),
+        )
+    with pytest.raises(ValueError, match="environment_index"):
+        DeterministicBalancedInstrumentRouter(
+            bindings,
+            run_seed=1,
+            environment_index=-1,
+            partition_digest=_digest("partition"),
+        )
+
+    router = DeterministicBalancedInstrumentRouter(
+        bindings,
+        run_seed=1,
+        environment_index=0,
+        partition_digest=_digest("partition"),
+    )
+    with pytest.raises(ValueError, match="completed_episode_count"):
+        router.route(-1)
+    with pytest.raises(ValueError, match="completed_episode_count"):
+        router.route(True)
+
+
+def test_episode_binding_closes_route_dataset_and_episode_range() -> None:
+    router = DeterministicBalancedInstrumentRouter(
+        tuple(_binding(symbol) for symbol in ("BTCUSDT", "ETHUSDT")),
+        run_seed=5,
+        environment_index=2,
+        partition_digest=_digest("partition"),
+    )
+    route = router.route(3)
+
+    episode = InstrumentEpisodeBinding.from_route(
+        route,
+        episode_start=120,
+        episode_stop=360,
+    )
+
+    payload = episode.to_json_dict()
+    assert payload["episode_binding_digest"] == episode.digest
+    assert payload["concrete_symbol"] == route.binding.concrete_symbol
+    assert payload["environment_index"] == 2
+    assert payload["completed_episode_count"] == 3
+    assert payload["routing_cycle"] == 1
+    assert payload["routing_position"] == 1
+    assert InstrumentEpisodeBinding.from_json_dict(payload) == episode
+
+
+def test_episode_binding_rejects_invalid_range_or_tampered_payload() -> None:
+    router = DeterministicBalancedInstrumentRouter(
+        (_binding("BTCUSDT"),),
+        run_seed=5,
+        environment_index=2,
+        partition_digest=_digest("partition"),
+    )
+    route = router.route(0)
+
+    with pytest.raises(ValueError, match="episode"):
+        InstrumentEpisodeBinding.from_route(
+            route,
+            episode_start=12,
+            episode_stop=12,
+        )
+
+    episode = InstrumentEpisodeBinding.from_route(
+        route,
+        episode_start=12,
+        episode_stop=24,
+    )
+    tampered = episode.to_json_dict()
+    tampered["routing_position"] = 3
+    with pytest.raises(ValueError, match="digest|routing"):
+        InstrumentEpisodeBinding.from_json_dict(tampered)

--- a/tests/rl/test_universal_episode_router.py
+++ b/tests/rl/test_universal_episode_router.py
@@ -31,9 +31,7 @@ def test_router_uses_every_symbol_once_before_repetition() -> None:
     first_cycle = tuple(router.route(index) for index in range(count))
     second_cycle = tuple(router.route(count + index) for index in range(count))
 
-    assert {route.concrete_symbol for route in first_cycle} == set(
-        router.train_symbols
-    )
+    assert {route.concrete_symbol for route in first_cycle} == set(router.train_symbols)
     assert len({route.concrete_symbol for route in first_cycle}) == count
     assert {route.concrete_symbol for route in second_cycle} == set(
         router.train_symbols
@@ -51,7 +49,9 @@ def test_router_is_deterministic_and_routes_have_canonical_identity() -> None:
 
     assert observed == tuple(second.route(index) for index in range(17))
     assert all(isinstance(route, InstrumentRoute) for route in observed)
-    assert all(route.digest == content_digest(route.to_json_dict()) for route in observed)
+    assert all(
+        route.digest == content_digest(route.to_json_dict()) for route in observed
+    )
     assert first.digest == second.digest
 
 

--- a/tests/rl/test_universal_episode_router.py
+++ b/tests/rl/test_universal_episode_router.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import pytest
+
+from trade_rl.artifacts.hashing import content_digest
+from trade_rl.rl.universal_episode_router import (
+    DeterministicBalancedInstrumentRouter,
+    InstrumentRoute,
+)
+
+
+def _router(*, environment_index: int = 0) -> DeterministicBalancedInstrumentRouter:
+    return DeterministicBalancedInstrumentRouter(
+        train_symbols=(
+            "BTCUSDT",
+            "ETHUSDT",
+            "SOLUSDT",
+            "XRPUSDT",
+            "ADAUSDT",
+        ),
+        partition_digest=content_digest("partition"),
+        run_seed=17,
+        environment_index=environment_index,
+    )
+
+
+def test_router_uses_every_symbol_once_before_repetition() -> None:
+    router = _router()
+    count = len(router.train_symbols)
+
+    first_cycle = tuple(router.route(index) for index in range(count))
+    second_cycle = tuple(router.route(count + index) for index in range(count))
+
+    assert {route.concrete_symbol for route in first_cycle} == set(
+        router.train_symbols
+    )
+    assert len({route.concrete_symbol for route in first_cycle}) == count
+    assert {route.concrete_symbol for route in second_cycle} == set(
+        router.train_symbols
+    )
+    assert tuple(route.routing_cycle for route in first_cycle) == (0,) * count
+    assert tuple(route.routing_position for route in first_cycle) == tuple(range(count))
+    assert tuple(route.routing_cycle for route in second_cycle) == (1,) * count
+
+
+def test_router_is_deterministic_and_routes_have_canonical_identity() -> None:
+    first = _router()
+    second = _router()
+
+    observed = tuple(first.route(index) for index in range(17))
+
+    assert observed == tuple(second.route(index) for index in range(17))
+    assert all(isinstance(route, InstrumentRoute) for route in observed)
+    assert all(route.digest == content_digest(route.to_json_dict()) for route in observed)
+    assert first.digest == second.digest
+
+
+def test_environment_index_is_part_of_router_identity() -> None:
+    first = _router(environment_index=0)
+    second = _router(environment_index=1)
+
+    assert first.digest != second.digest
+    assert first.to_json_dict()["environment_index"] == 0
+    assert second.to_json_dict()["environment_index"] == 1
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "match"),
+    [
+        ("train_symbols", (), "train_symbols"),
+        ("train_symbols", ("BTCUSDT", "BTCUSDT"), "unique"),
+        ("partition_digest", "x", "SHA-256"),
+        ("run_seed", -1, "run_seed"),
+        ("environment_index", -1, "environment_index"),
+    ],
+)
+def test_router_rejects_invalid_identity(
+    field: str,
+    value: object,
+    match: str,
+) -> None:
+    payload: dict[str, object] = {
+        "train_symbols": ("BTCUSDT",),
+        "partition_digest": content_digest("partition"),
+        "run_seed": 17,
+        "environment_index": 0,
+    }
+    payload[field] = value
+
+    with pytest.raises(ValueError, match=match):
+        DeterministicBalancedInstrumentRouter(**payload)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("completed_episode_count", [-1, True, 1.5])
+def test_router_rejects_invalid_completed_episode_count(
+    completed_episode_count: object,
+) -> None:
+    with pytest.raises(ValueError, match="completed_episode_count"):
+        _router().route(completed_episode_count)  # type: ignore[arg-type]

--- a/tests/rl/test_universal_instrument_binding.py
+++ b/tests/rl/test_universal_instrument_binding.py
@@ -31,9 +31,7 @@ def _binding(symbol: str, *, split: str = "train") -> InstrumentDatasetBinding:
 def test_generic_policy_facing_contract_is_exactly_one_instrument() -> None:
     assert GENERIC_INSTRUMENT_SYMBOL == "INSTRUMENT"
     assert GENERIC_INSTRUMENT_SYMBOLS == ("INSTRUMENT",)
-    assert GENERIC_TARGET_WEIGHT_ACTION_NAMES == (
-        "target_weight:INSTRUMENT",
-    )
+    assert GENERIC_TARGET_WEIGHT_ACTION_NAMES == ("target_weight:INSTRUMENT",)
 
 
 def test_dataset_binding_is_canonical_and_round_trips() -> None:

--- a/tests/rl/test_universal_instrument_binding.py
+++ b/tests/rl/test_universal_instrument_binding.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import pytest
+
+from trade_rl.artifacts.hashing import content_digest
+from trade_rl.rl.universal_instrument_binding import (
+    GENERIC_INSTRUMENT_SYMBOL,
+    GENERIC_INSTRUMENT_SYMBOLS,
+    GENERIC_TARGET_WEIGHT_ACTION_NAMES,
+    InstrumentDatasetBinding,
+    InstrumentEpisodeBinding,
+    validate_training_instrument_bindings,
+)
+
+
+def _digest(value: object) -> str:
+    return content_digest(value)
+
+
+def _binding(symbol: str, *, split: str = "train") -> InstrumentDatasetBinding:
+    return InstrumentDatasetBinding(
+        concrete_symbol=symbol,
+        source_dataset_id=_digest((symbol, "source")),
+        symbol_dataset_digest=_digest((symbol, "dataset")),
+        execution_metadata_digest=_digest((symbol, "execution")),
+        instrument_descriptor_digest=_digest((symbol, "descriptor")),
+        split=split,
+    )
+
+
+def test_generic_policy_facing_contract_is_exactly_one_instrument() -> None:
+    assert GENERIC_INSTRUMENT_SYMBOL == "INSTRUMENT"
+    assert GENERIC_INSTRUMENT_SYMBOLS == ("INSTRUMENT",)
+    assert GENERIC_TARGET_WEIGHT_ACTION_NAMES == (
+        "target_weight:INSTRUMENT",
+    )
+
+
+def test_dataset_binding_is_canonical_and_round_trips() -> None:
+    binding = _binding("BTCUSDT")
+
+    assert InstrumentDatasetBinding.from_json_dict(binding.to_json_dict()) == binding
+    assert binding.digest == content_digest(binding.to_json_dict())
+    assert binding.to_json_dict() == {
+        "concrete_symbol": "BTCUSDT",
+        "execution_metadata_digest": _digest(("BTCUSDT", "execution")),
+        "instrument_descriptor_digest": _digest(("BTCUSDT", "descriptor")),
+        "schema_version": "instrument_dataset_binding_v1",
+        "source_dataset_id": _digest(("BTCUSDT", "source")),
+        "split": "train",
+        "symbol_dataset_digest": _digest(("BTCUSDT", "dataset")),
+    }
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "match"),
+    [
+        ("concrete_symbol", " ", "non-empty"),
+        ("source_dataset_id", "x", "SHA-256"),
+        ("symbol_dataset_digest", "x", "SHA-256"),
+        ("execution_metadata_digest", "x", "SHA-256"),
+        ("instrument_descriptor_digest", "x", "SHA-256"),
+        ("split", "sealed", "split"),
+    ],
+)
+def test_dataset_binding_rejects_invalid_identity(
+    field: str,
+    value: str,
+    match: str,
+) -> None:
+    payload: dict[str, object] = {
+        "concrete_symbol": "BTCUSDT",
+        "source_dataset_id": _digest("source"),
+        "symbol_dataset_digest": _digest("dataset"),
+        "execution_metadata_digest": _digest("execution"),
+        "instrument_descriptor_digest": _digest("descriptor"),
+        "split": "train",
+    }
+    payload[field] = value
+
+    with pytest.raises(ValueError, match=match):
+        InstrumentDatasetBinding(**payload)  # type: ignore[arg-type]
+
+
+def test_episode_binding_flattens_concrete_identity_for_telemetry() -> None:
+    dataset_binding = _binding("ETHUSDT")
+    episode = InstrumentEpisodeBinding(
+        dataset_binding=dataset_binding,
+        episode_start=12,
+        episode_stop=44,
+        episode_seed=123,
+        environment_index=2,
+        completed_episode_count=7,
+        routing_cycle=1,
+        routing_position=2,
+    )
+
+    payload = episode.to_json_dict()
+
+    assert payload["concrete_symbol"] == "ETHUSDT"
+    assert payload["source_dataset_id"] == dataset_binding.source_dataset_id
+    assert payload["dataset_binding_digest"] == dataset_binding.digest
+    assert payload["episode_start"] == 12
+    assert payload["episode_stop"] == 44
+    assert payload["routing_cycle"] == 1
+    assert payload["routing_position"] == 2
+    assert episode.digest == content_digest(payload)
+    assert InstrumentEpisodeBinding.from_json_dict(payload) == episode
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "match"),
+    [
+        ("episode_start", -1, "episode_start"),
+        ("episode_stop", 0, "episode_stop"),
+        ("episode_seed", -1, "episode_seed"),
+        ("environment_index", -1, "environment_index"),
+        ("completed_episode_count", -1, "completed_episode_count"),
+        ("routing_cycle", -1, "routing_cycle"),
+        ("routing_position", -1, "routing_position"),
+    ],
+)
+def test_episode_binding_rejects_invalid_lifecycle_values(
+    field: str,
+    value: int,
+    match: str,
+) -> None:
+    payload: dict[str, object] = {
+        "dataset_binding": _binding("BTCUSDT"),
+        "episode_start": 0,
+        "episode_stop": 10,
+        "episode_seed": 5,
+        "environment_index": 0,
+        "completed_episode_count": 0,
+        "routing_cycle": 0,
+        "routing_position": 0,
+    }
+    payload[field] = value
+
+    with pytest.raises(ValueError, match=match):
+        InstrumentEpisodeBinding(**payload)  # type: ignore[arg-type]
+
+
+def test_training_binding_validation_requires_exact_train_closure() -> None:
+    train_symbols = ("BTCUSDT", "ETHUSDT", "SOLUSDT")
+    bindings = tuple(_binding(symbol) for symbol in reversed(train_symbols))
+
+    resolved = validate_training_instrument_bindings(train_symbols, bindings)
+
+    assert tuple(resolved) == train_symbols
+    assert resolved["BTCUSDT"] == _binding("BTCUSDT")
+
+
+@pytest.mark.parametrize(
+    "bindings",
+    [
+        (_binding("BTCUSDT"), _binding("ETHUSDT")),
+        (
+            _binding("BTCUSDT"),
+            _binding("ETHUSDT"),
+            _binding("SOLUSDT"),
+            _binding("XRPUSDT"),
+        ),
+        (
+            _binding("BTCUSDT"),
+            _binding("ETHUSDT"),
+            _binding("SOLUSDT", split="validation"),
+        ),
+        (
+            _binding("BTCUSDT"),
+            _binding("ETHUSDT"),
+            _binding("ETHUSDT"),
+        ),
+    ],
+)
+def test_training_binding_validation_fails_closed_on_leakage_or_closure(
+    bindings: tuple[InstrumentDatasetBinding, ...],
+) -> None:
+    with pytest.raises(ValueError, match="closure|train|duplicate"):
+        validate_training_instrument_bindings(
+            ("BTCUSDT", "ETHUSDT", "SOLUSDT"),
+            bindings,
+        )

--- a/tests/rl/test_universal_policy_identity.py
+++ b/tests/rl/test_universal_policy_identity.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import pytest
+
+from trade_rl.artifacts.hashing import content_digest
+from trade_rl.rl.instrument_episode_routing import (
+    GENERIC_INSTRUMENT_ACTION_NAMES,
+    GENERIC_INSTRUMENT_SYMBOLS,
+)
+from trade_rl.rl.universal_policy_identity import (
+    SINGLE_INSTRUMENT_DEPLOYMENT_BINDING_SCHEMA,
+    UNIVERSAL_SINGLE_INSTRUMENT_ACTION_SCHEMA,
+    UNIVERSAL_SINGLE_INSTRUMENT_POLICY_SCHEMA,
+    SingleInstrumentDeploymentBinding,
+    UniversalSingleInstrumentPolicyIdentity,
+)
+
+
+def _digest(label: str) -> str:
+    return content_digest(label)
+
+
+def _policy() -> UniversalSingleInstrumentPolicyIdentity:
+    return UniversalSingleInstrumentPolicyIdentity(
+        architecture_digest=_digest("architecture"),
+        observation_schema_digest=_digest("observation"),
+        instrument_descriptor_schema_digest=_digest("descriptor-schema"),
+        normalizer_digest=_digest("normalizer"),
+        reward_environment_digest=_digest("reward-environment"),
+        training_catalog_digest=_digest("catalog"),
+        training_symbol_split_digest=_digest("split"),
+        training_symbols_digest=_digest(("BTCUSDT", "ETHUSDT", "SOLUSDT")),
+        zero_shot_evidence_digest=_digest("zero-shot-evidence"),
+    )
+
+
+def test_universal_policy_identity_is_generic_and_digest_bound() -> None:
+    identity = _policy()
+
+    payload = identity.to_json_dict()
+
+    assert payload["schema_version"] == UNIVERSAL_SINGLE_INSTRUMENT_POLICY_SCHEMA
+    assert payload["action_schema"] == UNIVERSAL_SINGLE_INSTRUMENT_ACTION_SCHEMA
+    assert payload["generic_symbols"] == GENERIC_INSTRUMENT_SYMBOLS
+    assert payload["generic_action_names"] == GENERIC_INSTRUMENT_ACTION_NAMES
+    assert payload["policy_digest"] == identity.policy_digest
+    assert UniversalSingleInstrumentPolicyIdentity.from_json_dict(payload) == identity
+
+
+def test_universal_policy_payload_cannot_contain_concrete_ticker_identity() -> None:
+    payload = _policy().to_json_dict()
+    serialized = json.dumps(payload, sort_keys=True)
+
+    for symbol in ("BTCUSDT", "ETHUSDT", "SOLUSDT"):
+        assert symbol not in serialized
+
+    with pytest.raises(ValueError, match="fields|concrete"):
+        UniversalSingleInstrumentPolicyIdentity.from_json_dict(
+            {**payload, "concrete_symbol": "BTCUSDT"}
+        )
+
+
+def test_universal_policy_identity_rejects_invalid_fixed_contract_or_digest() -> None:
+    identity = _policy()
+
+    with pytest.raises(ValueError, match="generic_symbols"):
+        replace(identity, generic_symbols=("BTCUSDT",))
+    with pytest.raises(ValueError, match="generic_action_names"):
+        replace(identity, generic_action_names=("target_weight:BTCUSDT",))
+    with pytest.raises(ValueError, match="action_schema"):
+        replace(identity, action_schema="portfolio_weights_v1")
+
+    tampered = identity.to_json_dict()
+    tampered["normalizer_digest"] = _digest("other-normalizer")
+    with pytest.raises(ValueError, match="digest"):
+        UniversalSingleInstrumentPolicyIdentity.from_json_dict(tampered)
+
+
+def test_universal_policy_identity_rejects_bad_digest_field() -> None:
+    with pytest.raises(ValueError, match="architecture_digest"):
+        replace(_policy(), architecture_digest="not-a-digest")
+
+
+def test_deployment_binding_is_the_only_contract_with_concrete_symbol() -> None:
+    policy = _policy()
+    binding = SingleInstrumentDeploymentBinding(
+        policy_digest=policy.policy_digest,
+        concrete_symbol="XRPUSDT",
+        market_instrument_contract_digest=_digest("market-instrument"),
+        dataset_feature_schema_digest=_digest("feature-schema"),
+        execution_metadata_digest=_digest("execution"),
+        instrument_descriptor_evidence_digest=_digest("descriptor-evidence"),
+        seen_in_training=False,
+    )
+
+    payload = binding.to_json_dict()
+
+    assert payload["schema_version"] == SINGLE_INSTRUMENT_DEPLOYMENT_BINDING_SCHEMA
+    assert payload["concrete_symbol"] == "XRPUSDT"
+    assert payload["seen_in_training"] is False
+    assert payload["binding_digest"] == binding.digest
+    assert SingleInstrumentDeploymentBinding.from_json_dict(payload) == binding
+
+
+def test_deployment_binding_supports_seen_and_unseen_without_changing_policy() -> None:
+    policy = _policy()
+    unseen = SingleInstrumentDeploymentBinding(
+        policy_digest=policy.policy_digest,
+        concrete_symbol="XRPUSDT",
+        market_instrument_contract_digest=_digest("market-instrument:xrp"),
+        dataset_feature_schema_digest=_digest("feature-schema"),
+        execution_metadata_digest=_digest("execution:xrp"),
+        instrument_descriptor_evidence_digest=_digest("descriptor:xrp"),
+        seen_in_training=False,
+    )
+    seen = SingleInstrumentDeploymentBinding(
+        policy_digest=policy.policy_digest,
+        concrete_symbol="BTCUSDT",
+        market_instrument_contract_digest=_digest("market-instrument:btc"),
+        dataset_feature_schema_digest=_digest("feature-schema"),
+        execution_metadata_digest=_digest("execution:btc"),
+        instrument_descriptor_evidence_digest=_digest("descriptor:btc"),
+        seen_in_training=True,
+    )
+
+    assert unseen.policy_digest == seen.policy_digest == policy.policy_digest
+    assert unseen.digest != seen.digest
+
+
+def test_deployment_binding_rejects_generic_symbol_non_boolean_and_tampering() -> None:
+    policy = _policy()
+    kwargs = {
+        "policy_digest": policy.policy_digest,
+        "concrete_symbol": "XRPUSDT",
+        "market_instrument_contract_digest": _digest("market-instrument"),
+        "dataset_feature_schema_digest": _digest("feature-schema"),
+        "execution_metadata_digest": _digest("execution"),
+        "instrument_descriptor_evidence_digest": _digest("descriptor-evidence"),
+        "seen_in_training": False,
+    }
+
+    with pytest.raises(ValueError, match="concrete_symbol"):
+        SingleInstrumentDeploymentBinding(**{**kwargs, "concrete_symbol": "INSTRUMENT"})
+    with pytest.raises(ValueError, match="seen_in_training"):
+        SingleInstrumentDeploymentBinding(**{**kwargs, "seen_in_training": 1})
+
+    binding = SingleInstrumentDeploymentBinding(**kwargs)
+    tampered = binding.to_json_dict()
+    tampered["concrete_symbol"] = "ADAUSDT"
+    with pytest.raises(ValueError, match="digest"):
+        SingleInstrumentDeploymentBinding.from_json_dict(tampered)
+    with pytest.raises(ValueError, match="fields"):
+        SingleInstrumentDeploymentBinding.from_json_dict(
+            {**binding.to_json_dict(), "symbol_index": 4}
+        )

--- a/tests/rl/test_universal_single_instrument_env.py
+++ b/tests/rl/test_universal_single_instrument_env.py
@@ -178,17 +178,21 @@ def test_facade_exposes_generic_single_action_and_routes_whole_episodes() -> Non
     assert terminated is True
     assert truncated is False
     assert reset_info["instrument_episode_binding"]["concrete_symbol"] == first_symbol
-    assert terminal_info["instrument_episode_binding"] == reset_info[
-        "instrument_episode_binding"
-    ]
-    assert terminal_info["instrument_episode_binding_digest"] == reset_info[
-        "instrument_episode_binding_digest"
-    ]
+    assert (
+        terminal_info["instrument_episode_binding"]
+        == reset_info["instrument_episode_binding"]
+    )
+    assert (
+        terminal_info["instrument_episode_binding_digest"]
+        == reset_info["instrument_episode_binding_digest"]
+    )
     assert env.completed_episode_count == 1
 
     _, second_reset = env.reset()
 
-    assert second_reset["instrument_episode_binding"]["concrete_symbol"] == second_symbol
+    assert (
+        second_reset["instrument_episode_binding"]["concrete_symbol"] == second_symbol
+    )
     assert calls == [first_symbol, second_symbol]
     assert created[first_symbol] is not created[second_symbol]
 

--- a/tests/rl/test_universal_single_instrument_env.py
+++ b/tests/rl/test_universal_single_instrument_env.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import Any
+
+import gymnasium as gym
+import numpy as np
+import pytest
+
+from trade_rl.artifacts.hashing import content_digest
+from trade_rl.rl.actions import ActionMode, ActionSpec, ActionValidationMode
+from trade_rl.rl.universal_episode_router import (
+    DeterministicBalancedInstrumentRouter,
+)
+from trade_rl.rl.universal_instrument_binding import (
+    GENERIC_INSTRUMENT_SYMBOLS,
+    GENERIC_TARGET_WEIGHT_ACTION_NAMES,
+    InstrumentDatasetBinding,
+)
+from trade_rl.rl.universal_single_instrument_env import (
+    EpisodeRoutedSingleInstrumentEnv,
+)
+
+
+def _digest(value: object) -> str:
+    return content_digest(value)
+
+
+def _binding(symbol: str, *, split: str = "train") -> InstrumentDatasetBinding:
+    return InstrumentDatasetBinding(
+        concrete_symbol=symbol,
+        source_dataset_id=_digest((symbol, "source")),
+        symbol_dataset_digest=_digest((symbol, "dataset")),
+        execution_metadata_digest=_digest((symbol, "execution")),
+        instrument_descriptor_digest=_digest((symbol, "descriptor")),
+        split=split,
+    )
+
+
+class FakeSingleInstrumentEnv(gym.Env[np.ndarray, np.ndarray]):
+    metadata = {"render_modes": []}
+
+    def __init__(
+        self,
+        binding: InstrumentDatasetBinding,
+        *,
+        observation_size: int = 2,
+        terminate_after: int = 1,
+        malformed_termination: bool = False,
+    ) -> None:
+        super().__init__()
+        self.binding = binding
+        self.dataset = SimpleNamespace(
+            symbols=(binding.concrete_symbol,),
+            dataset_id=binding.source_dataset_id,
+        )
+        self.action_spec = ActionSpec(
+            mode=ActionMode.TARGET_WEIGHT,
+            risk_tilt_enabled=False,
+            target_weight_count=1,
+            validation_mode=ActionValidationMode.FAIL_CLOSED,
+        )
+        self.action_names = (f"target_weight:{binding.concrete_symbol}",)
+        self.action_space = gym.spaces.Box(
+            low=-1.0,
+            high=1.0,
+            shape=(1,),
+            dtype=np.float32,
+        )
+        self.observation_space = gym.spaces.Box(
+            low=-10.0,
+            high=10.0,
+            shape=(observation_size,),
+            dtype=np.float32,
+        )
+        self.terminate_after = terminate_after
+        self.malformed_termination = malformed_termination
+        self.steps = 0
+        self.reset_seeds: list[int | None] = []
+        self.closed = False
+
+    def reset(
+        self,
+        *,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[np.ndarray, dict[str, Any]]:
+        super().reset(seed=seed)
+        del options
+        self.reset_seeds.append(seed)
+        self.steps = 0
+        return np.zeros(self.observation_space.shape, dtype=np.float32), {
+            "start_index": 5,
+            "end_index": 17,
+        }
+
+    def step(
+        self,
+        action: np.ndarray,
+    ) -> tuple[np.ndarray, float, bool, bool, dict[str, Any]]:
+        assert self.action_space.contains(action)
+        self.steps += 1
+        terminated: bool | int = self.steps >= self.terminate_after
+        if self.malformed_termination:
+            terminated = 1
+        return (
+            np.full(self.observation_space.shape, self.steps, dtype=np.float32),
+            float(self.steps),
+            terminated,  # type: ignore[return-value]
+            False,
+            {"concrete_step": self.steps},
+        )
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _build_env(
+    *,
+    factory_override: Callable[[InstrumentDatasetBinding], FakeSingleInstrumentEnv]
+    | None = None,
+    bindings: tuple[InstrumentDatasetBinding, ...] | None = None,
+    run_seed: int = 17,
+    environment_index: int = 0,
+) -> tuple[
+    EpisodeRoutedSingleInstrumentEnv,
+    list[str],
+    dict[str, FakeSingleInstrumentEnv],
+]:
+    train_symbols = ("BTCUSDT", "ETHUSDT", "SOLUSDT")
+    resolved_bindings = bindings or tuple(_binding(symbol) for symbol in train_symbols)
+    calls: list[str] = []
+    created: dict[str, FakeSingleInstrumentEnv] = {}
+
+    def factory(binding: InstrumentDatasetBinding) -> FakeSingleInstrumentEnv:
+        calls.append(binding.concrete_symbol)
+        env = (
+            factory_override(binding)
+            if factory_override is not None
+            else FakeSingleInstrumentEnv(binding)
+        )
+        created[binding.concrete_symbol] = env
+        return env
+
+    env = EpisodeRoutedSingleInstrumentEnv(
+        train_symbols=train_symbols,
+        partition_digest=_digest("partition"),
+        bindings=resolved_bindings,
+        environment_factory=factory,
+        run_seed=run_seed,
+        environment_index=environment_index,
+    )
+    return env, calls, created
+
+
+def test_facade_exposes_generic_single_action_and_routes_whole_episodes() -> None:
+    env, calls, created = _build_env()
+    router = DeterministicBalancedInstrumentRouter(
+        train_symbols=("BTCUSDT", "ETHUSDT", "SOLUSDT"),
+        partition_digest=_digest("partition"),
+        run_seed=17,
+        environment_index=0,
+    )
+    first_symbol = router.route(0).concrete_symbol
+    second_symbol = router.route(1).concrete_symbol
+
+    assert calls == [first_symbol]
+    assert env.policy_symbols == GENERIC_INSTRUMENT_SYMBOLS
+    assert env.action_names == GENERIC_TARGET_WEIGHT_ACTION_NAMES
+    assert env.action_space.shape == (1,)
+
+    _, reset_info = env.reset(seed=17)
+    _, _, terminated, truncated, terminal_info = env.step(
+        np.asarray([0.25], dtype=np.float32)
+    )
+
+    assert terminated is True
+    assert truncated is False
+    assert reset_info["instrument_episode_binding"]["concrete_symbol"] == first_symbol
+    assert terminal_info["instrument_episode_binding"] == reset_info[
+        "instrument_episode_binding"
+    ]
+    assert terminal_info["instrument_episode_binding_digest"] == reset_info[
+        "instrument_episode_binding_digest"
+    ]
+    assert env.completed_episode_count == 1
+
+    _, second_reset = env.reset()
+
+    assert second_reset["instrument_episode_binding"]["concrete_symbol"] == second_symbol
+    assert calls == [first_symbol, second_symbol]
+    assert created[first_symbol] is not created[second_symbol]
+
+
+def test_reset_before_episode_completion_and_invalid_step_order_fail_closed() -> None:
+    env, _, _ = _build_env(
+        factory_override=lambda binding: FakeSingleInstrumentEnv(
+            binding,
+            terminate_after=2,
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="reset"):
+        env.step(np.asarray([0.0], dtype=np.float32))
+
+    env.reset()
+    env.step(np.asarray([0.0], dtype=np.float32))
+    with pytest.raises(RuntimeError, match="active episode"):
+        env.reset()
+
+    env.step(np.asarray([0.0], dtype=np.float32))
+    with pytest.raises(RuntimeError, match="completed"):
+        env.step(np.asarray([0.0], dtype=np.float32))
+
+
+def test_factory_failure_is_propagated_without_symbol_fallback() -> None:
+    train_symbols = ("BTCUSDT", "ETHUSDT", "SOLUSDT")
+    router = DeterministicBalancedInstrumentRouter(
+        train_symbols=train_symbols,
+        partition_digest=_digest("partition"),
+        run_seed=17,
+        environment_index=0,
+    )
+    failing_symbol = router.route(1).concrete_symbol
+
+    def factory(binding: InstrumentDatasetBinding) -> FakeSingleInstrumentEnv:
+        if binding.concrete_symbol == failing_symbol:
+            raise RuntimeError("injected dataset load failure")
+        return FakeSingleInstrumentEnv(binding)
+
+    env, calls, _ = _build_env(factory_override=factory)
+    env.reset()
+    env.step(np.asarray([0.0], dtype=np.float32))
+
+    with pytest.raises(RuntimeError, match="injected dataset load failure"):
+        env.reset()
+
+    assert calls[-1] == failing_symbol
+    assert len(calls) == 2
+
+
+def test_later_environment_must_match_first_observation_contract() -> None:
+    train_symbols = ("BTCUSDT", "ETHUSDT", "SOLUSDT")
+    router = DeterministicBalancedInstrumentRouter(
+        train_symbols=train_symbols,
+        partition_digest=_digest("partition"),
+        run_seed=17,
+        environment_index=0,
+    )
+    mismatched_symbol = router.route(1).concrete_symbol
+
+    def factory(binding: InstrumentDatasetBinding) -> FakeSingleInstrumentEnv:
+        return FakeSingleInstrumentEnv(
+            binding,
+            observation_size=(3 if binding.concrete_symbol == mismatched_symbol else 2),
+        )
+
+    env, _, _ = _build_env(factory_override=factory)
+    env.reset()
+    env.step(np.asarray([0.0], dtype=np.float32))
+
+    with pytest.raises(ValueError, match="observation space"):
+        env.reset()
+
+
+def test_split_leakage_fails_before_environment_factory_call() -> None:
+    calls: list[str] = []
+
+    def factory(binding: InstrumentDatasetBinding) -> FakeSingleInstrumentEnv:
+        calls.append(binding.concrete_symbol)
+        return FakeSingleInstrumentEnv(binding)
+
+    with pytest.raises(ValueError, match="train"):
+        _build_env(
+            factory_override=factory,
+            bindings=(
+                _binding("BTCUSDT"),
+                _binding("ETHUSDT"),
+                _binding("SOLUSDT", split="validation"),
+            ),
+        )
+
+    assert calls == []
+
+
+def test_reset_seed_cannot_change_immutable_routing_identity() -> None:
+    env, _, created = _build_env(run_seed=17)
+
+    with pytest.raises(ValueError, match="run_seed"):
+        env.reset(seed=18)
+
+    env.reset(seed=17)
+    active_symbol = env.active_episode_binding.dataset_binding.concrete_symbol
+    assert created[active_symbol].reset_seeds
+
+
+def test_non_boolean_termination_flags_are_rejected() -> None:
+    env, _, _ = _build_env(
+        factory_override=lambda binding: FakeSingleInstrumentEnv(
+            binding,
+            malformed_termination=True,
+        )
+    )
+    env.reset()
+
+    with pytest.raises(TypeError, match="terminated"):
+        env.step(np.asarray([0.0], dtype=np.float32))
+
+
+def test_close_closes_every_cached_concrete_environment() -> None:
+    env, _, created = _build_env()
+    env.reset()
+    env.step(np.asarray([0.0], dtype=np.float32))
+    env.reset()
+
+    env.close()
+
+    assert created
+    assert all(concrete.closed for concrete in created.values())

--- a/tests/rl/test_universal_single_instrument_identity.py
+++ b/tests/rl/test_universal_single_instrument_identity.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from trade_rl.artifacts.hashing import content_digest
+from trade_rl.rl.universal_instrument_binding import (
+    GENERIC_INSTRUMENT_SYMBOLS,
+    GENERIC_TARGET_WEIGHT_ACTION_NAMES,
+)
+from trade_rl.rl.universal_single_instrument_identity import (
+    SingleInstrumentDeploymentBinding,
+    UniversalSingleInstrumentPolicyManifest,
+)
+
+
+def _digest(value: object) -> str:
+    return content_digest(value)
+
+
+def _manifest() -> UniversalSingleInstrumentPolicyManifest:
+    return UniversalSingleInstrumentPolicyManifest(
+        architecture_digest=_digest("architecture"),
+        observation_schema_digest=_digest("observation"),
+        action_schema_digest=_digest("action"),
+        instrument_descriptor_schema_digest=_digest("descriptor-schema"),
+        normalizer_digest=_digest("normalizer"),
+        reward_environment_digest=_digest("reward-environment"),
+        training_catalog_digest=_digest("catalog"),
+        training_symbol_split_digest=_digest("split"),
+        training_symbols_digest=_digest(("BTCUSDT", "ETHUSDT")),
+        zero_shot_evidence_digest=_digest("zero-shot"),
+    )
+
+
+def test_universal_policy_manifest_is_generic_and_canonical() -> None:
+    manifest = _manifest()
+    payload = manifest.to_json_dict()
+    serialized = json.dumps(payload, sort_keys=True)
+
+    assert payload["policy_symbols"] == list(GENERIC_INSTRUMENT_SYMBOLS)
+    assert payload["action_names"] == list(GENERIC_TARGET_WEIGHT_ACTION_NAMES)
+    assert payload["action_shape"] == [1]
+    assert "BTCUSDT" not in serialized
+    assert "ETHUSDT" not in serialized
+    assert manifest.policy_digest == content_digest(payload)
+    assert UniversalSingleInstrumentPolicyManifest.from_json_dict(payload) == manifest
+
+
+def test_concrete_symbol_lives_only_in_deployment_binding() -> None:
+    manifest = _manifest()
+    binding = SingleInstrumentDeploymentBinding(
+        policy_digest=manifest.policy_digest,
+        concrete_symbol="XRPUSDT",
+        market_instrument_contract_digest=_digest("market-contract"),
+        dataset_feature_schema_digest=_digest("feature-schema"),
+        execution_metadata_digest=_digest("execution"),
+        instrument_descriptor_evidence_digest=_digest("descriptor-evidence"),
+        seen_in_training=False,
+    )
+
+    assert binding.to_json_dict()["concrete_symbol"] == "XRPUSDT"
+    assert binding.to_json_dict()["seen_in_training"] is False
+    assert binding.digest == content_digest(binding.to_json_dict())
+    assert SingleInstrumentDeploymentBinding.from_json_dict(
+        binding.to_json_dict()
+    ) == binding
+    assert "XRPUSDT" not in json.dumps(manifest.to_json_dict(), sort_keys=True)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "architecture_digest",
+        "observation_schema_digest",
+        "action_schema_digest",
+        "instrument_descriptor_schema_digest",
+        "normalizer_digest",
+        "reward_environment_digest",
+        "training_catalog_digest",
+        "training_symbol_split_digest",
+        "training_symbols_digest",
+        "zero_shot_evidence_digest",
+    ],
+)
+def test_policy_manifest_rejects_invalid_digests(field: str) -> None:
+    payload = {
+        "architecture_digest": _digest("architecture"),
+        "observation_schema_digest": _digest("observation"),
+        "action_schema_digest": _digest("action"),
+        "instrument_descriptor_schema_digest": _digest("descriptor-schema"),
+        "normalizer_digest": _digest("normalizer"),
+        "reward_environment_digest": _digest("reward-environment"),
+        "training_catalog_digest": _digest("catalog"),
+        "training_symbol_split_digest": _digest("split"),
+        "training_symbols_digest": _digest("symbols"),
+        "zero_shot_evidence_digest": _digest("zero-shot"),
+    }
+    payload[field] = "invalid"
+
+    with pytest.raises(ValueError, match="SHA-256"):
+        UniversalSingleInstrumentPolicyManifest(**payload)
+
+
+def test_deployment_binding_validates_concrete_identity_and_boolean() -> None:
+    manifest = _manifest()
+    common = {
+        "policy_digest": manifest.policy_digest,
+        "concrete_symbol": "BTCUSDT",
+        "market_instrument_contract_digest": _digest("market-contract"),
+        "dataset_feature_schema_digest": _digest("feature-schema"),
+        "execution_metadata_digest": _digest("execution"),
+        "instrument_descriptor_evidence_digest": _digest("descriptor-evidence"),
+        "seen_in_training": True,
+    }
+
+    with pytest.raises(ValueError, match="non-empty"):
+        SingleInstrumentDeploymentBinding(**{**common, "concrete_symbol": " "})
+    with pytest.raises(TypeError, match="boolean"):
+        SingleInstrumentDeploymentBinding(**{**common, "seen_in_training": 1})
+    with pytest.raises(ValueError, match="SHA-256"):
+        SingleInstrumentDeploymentBinding(**{**common, "policy_digest": "bad"})

--- a/tests/rl/test_universal_single_instrument_identity.py
+++ b/tests/rl/test_universal_single_instrument_identity.py
@@ -63,9 +63,10 @@ def test_concrete_symbol_lives_only_in_deployment_binding() -> None:
     assert binding.to_json_dict()["concrete_symbol"] == "XRPUSDT"
     assert binding.to_json_dict()["seen_in_training"] is False
     assert binding.digest == content_digest(binding.to_json_dict())
-    assert SingleInstrumentDeploymentBinding.from_json_dict(
-        binding.to_json_dict()
-    ) == binding
+    assert (
+        SingleInstrumentDeploymentBinding.from_json_dict(binding.to_json_dict())
+        == binding
+    )
     assert "XRPUSDT" not in json.dumps(manifest.to_json_dict(), sort_keys=True)
 
 

--- a/trade_rl/rl/episode_routed_environment.py
+++ b/trade_rl/rl/episode_routed_environment.py
@@ -1,0 +1,419 @@
+"""Gym facade that routes complete episodes across isolated single-symbol envs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Protocol, TypeAlias
+
+import gymnasium as gym
+import numpy as np
+
+from trade_rl.artifacts.hashing import content_digest
+from trade_rl.rl.actions import ActionMode, ActionSpec, ActionValidationMode
+from trade_rl.rl.instrument_episode_routing import (
+    GENERIC_INSTRUMENT_ACTION_NAMES,
+    GENERIC_INSTRUMENT_SYMBOLS,
+    DeterministicBalancedInstrumentRouter,
+    InstrumentDatasetBinding,
+    InstrumentEpisodeBinding,
+)
+
+EPISODE_ROUTED_SINGLE_INSTRUMENT_ENVIRONMENT_SCHEMA = (
+    "episode_routed_single_instrument_environment_v1"
+)
+_GENERIC_ACTION_SPEC_SCHEMA = "generic_single_instrument_action_v1"
+_CHILD_RESET_SEED_SCHEMA = "episode_routed_child_reset_seed_v1"
+_FORBIDDEN_RESET_OPTION_KEYS = frozenset(
+    {
+        "concrete_symbol",
+        "dataset_id",
+        "instrument",
+        "symbol",
+    }
+)
+
+Observation: TypeAlias = np.ndarray | dict[str, np.ndarray]
+
+
+class _DatasetContract(Protocol):
+    symbols: tuple[str, ...]
+    dataset_id: str
+
+
+class SingleInstrumentChildEnvironment(Protocol):
+    """Runtime surface required from one isolated concrete-symbol child."""
+
+    dataset: _DatasetContract
+    action_spec: ActionSpec
+    action_names: tuple[str, ...]
+    action_spec_digest: str
+    action_space: gym.spaces.Space[np.ndarray]
+    observation_space: gym.spaces.Space[Any]
+    observation_schema: str
+    observation_contract_digest: str
+    environment_digest: str
+
+    def reset(
+        self,
+        *,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[Observation, dict[str, Any]]: ...
+
+    def step(
+        self,
+        action: np.ndarray,
+    ) -> tuple[Observation, float, bool, bool, dict[str, Any]]: ...
+
+    def close(self) -> None: ...
+
+
+def _non_negative_info_index(info: Mapping[str, Any], key: str) -> int:
+    value = info.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"child reset info {key} must be a non-negative integer")
+    return value
+
+
+def _same_space(
+    left: gym.spaces.Space[Any],
+    right: gym.spaces.Space[Any],
+) -> bool:
+    try:
+        return bool(left == right)
+    except (TypeError, ValueError):
+        return False
+
+
+class EpisodeRoutedSingleInstrumentEnv(gym.Env[Observation, np.ndarray]):
+    """Expose one generic slot while selecting one concrete child per episode."""
+
+    metadata = {"render_modes": []}
+
+    def __init__(
+        self,
+        child_environments: Mapping[str, SingleInstrumentChildEnvironment],
+        *,
+        bindings: Sequence[InstrumentDatasetBinding],
+        run_seed: int,
+        environment_index: int,
+        partition_digest: str,
+    ) -> None:
+        super().__init__()
+        children = dict(child_environments)
+        if not children:
+            raise ValueError("child environment mapping must not be empty")
+        if any(not isinstance(symbol, str) or not symbol for symbol in children):
+            raise ValueError("child environment symbols must be non-empty strings")
+        if len({id(child) for child in children.values()}) != len(children):
+            raise ValueError("each concrete symbol requires an isolated child environment")
+
+        self.router = DeterministicBalancedInstrumentRouter(
+            bindings,
+            run_seed=run_seed,
+            environment_index=environment_index,
+            partition_digest=partition_digest,
+        )
+        binding_by_symbol = {
+            binding.concrete_symbol: binding for binding in self.router.bindings
+        }
+        if frozenset(children) != frozenset(binding_by_symbol):
+            raise ValueError("child environment and binding symbol closure mismatch")
+
+        first_symbol = self.router.bindings[0].concrete_symbol
+        first = children[first_symbol]
+        self._validate_child(
+            first_symbol,
+            first,
+            binding_by_symbol[first_symbol],
+        )
+        observation_space = first.observation_space
+        observation_schema = first.observation_schema
+        observation_contract_digest = first.observation_contract_digest
+        action_space = first.action_space
+
+        for binding in self.router.bindings[1:]:
+            symbol = binding.concrete_symbol
+            child = children[symbol]
+            self._validate_child(symbol, child, binding)
+            if not _same_space(observation_space, child.observation_space):
+                raise ValueError("child observation spaces do not match")
+            if observation_schema != child.observation_schema:
+                raise ValueError("child observation schemas do not match")
+            if observation_contract_digest != child.observation_contract_digest:
+                raise ValueError("child observation contract digests do not match")
+            if not _same_space(action_space, child.action_space):
+                raise ValueError("child action spaces do not match")
+
+        self._children = children
+        self._bindings = binding_by_symbol
+        self.symbols = GENERIC_INSTRUMENT_SYMBOLS
+        self.action_names = GENERIC_INSTRUMENT_ACTION_NAMES
+        self.action_spec = ActionSpec(
+            mode=ActionMode.TARGET_WEIGHT,
+            risk_tilt_enabled=False,
+            target_weight_count=1,
+            validation_mode=ActionValidationMode.FAIL_CLOSED,
+        )
+        self.action_space = action_space
+        self.observation_space = observation_space
+        self.observation_schema = observation_schema
+        self.observation_contract_digest = observation_contract_digest
+        self.action_spec_digest = content_digest(
+            {
+                "schema_version": _GENERIC_ACTION_SPEC_SCHEMA,
+                "mode": ActionMode.TARGET_WEIGHT.value,
+                "symbols": self.symbols,
+                "action_names": self.action_names,
+                "shape": (1,),
+                "validation_mode": ActionValidationMode.FAIL_CLOSED.value,
+            }
+        )
+        self._environment_digest = content_digest(
+            {
+                "schema_version": (
+                    EPISODE_ROUTED_SINGLE_INSTRUMENT_ENVIRONMENT_SCHEMA
+                ),
+                "router_digest": self.router.digest,
+                "generic_symbols": self.symbols,
+                "generic_action_names": self.action_names,
+                "action_spec_digest": self.action_spec_digest,
+                "observation_schema": self.observation_schema,
+                "observation_contract_digest": self.observation_contract_digest,
+                "child_runtime_identities": tuple(
+                    (
+                        binding.digest,
+                        children[binding.concrete_symbol].environment_digest,
+                    )
+                    for binding in self.router.bindings
+                ),
+            }
+        )
+        self._completed_episode_count = 0
+        self._active_child: SingleInstrumentChildEnvironment | None = None
+        self._active_episode_binding: InstrumentEpisodeBinding | None = None
+        self._episode_active = False
+        self._failed_symbol: str | None = None
+        self._closed = False
+
+    @staticmethod
+    def _validate_child(
+        symbol: str,
+        child: SingleInstrumentChildEnvironment,
+        binding: InstrumentDatasetBinding,
+    ) -> None:
+        dataset = getattr(child, "dataset", None)
+        if dataset is None:
+            raise ValueError("child environment dataset is missing")
+        if tuple(getattr(dataset, "symbols", ())) != (symbol,):
+            raise ValueError("child dataset must contain exactly its concrete symbol")
+        if getattr(dataset, "dataset_id", None) != binding.symbol_dataset_digest:
+            raise ValueError("child dataset identity does not match its binding")
+        action_spec = getattr(child, "action_spec", None)
+        if not isinstance(action_spec, ActionSpec):
+            raise ValueError("child action specification is missing")
+        if action_spec.mode is not ActionMode.TARGET_WEIGHT:
+            raise ValueError("child must use direct target-weight action mode")
+        if action_spec.target_weight_count != 1 or action_spec.size != 1:
+            raise ValueError("child target-weight action must have shape (1,)")
+        expected_action_names = (f"target_weight:{symbol}",)
+        if tuple(getattr(child, "action_names", ())) != expected_action_names:
+            raise ValueError("child concrete action names do not match its symbol")
+        action_space = getattr(child, "action_space", None)
+        if getattr(action_space, "shape", None) != (1,):
+            raise ValueError("child action space must have shape (1,)")
+        for field_name in (
+            "action_spec_digest",
+            "environment_digest",
+            "observation_contract_digest",
+            "observation_schema",
+            "observation_space",
+        ):
+            if getattr(child, field_name, None) is None:
+                raise ValueError(f"child {field_name} is missing")
+
+    @property
+    def environment_digest(self) -> str:
+        return self._environment_digest
+
+    @property
+    def completed_episode_count(self) -> int:
+        return self._completed_episode_count
+
+    @property
+    def active_episode_binding(self) -> InstrumentEpisodeBinding:
+        binding = self._active_episode_binding
+        if binding is None:
+            raise RuntimeError("environment has no active or completed episode binding")
+        return binding
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise RuntimeError("episode-routed environment is closed")
+        if self._failed_symbol is not None:
+            raise RuntimeError(
+                "episode-routed environment is fail-closed after child failure for "
+                f"{self._failed_symbol}"
+            )
+
+    def _child_reset_seed(self, *, user_seed: int | None) -> int:
+        route = self.router.route(self._completed_episode_count)
+        if user_seed is not None and (
+            isinstance(user_seed, bool) or not isinstance(user_seed, int) or user_seed < 0
+        ):
+            raise ValueError("reset seed must be a non-negative integer or null")
+        digest = content_digest(
+            {
+                "schema_version": _CHILD_RESET_SEED_SCHEMA,
+                "router_digest": self.router.digest,
+                "binding_digest": route.binding.digest,
+                "completed_episode_count": route.completed_episode_count,
+                "user_seed": user_seed,
+            }
+        )
+        return int(digest[:8], 16)
+
+    @staticmethod
+    def _validate_reset_options(options: Mapping[str, Any]) -> None:
+        forbidden = sorted(_FORBIDDEN_RESET_OPTION_KEYS.intersection(options))
+        if forbidden:
+            raise ValueError(
+                "reset options cannot select or override concrete symbol fields: "
+                f"{forbidden}"
+            )
+
+    @staticmethod
+    def _enrich_info(
+        info: Mapping[str, Any],
+        binding: InstrumentEpisodeBinding,
+        *,
+        terminal: bool,
+    ) -> dict[str, Any]:
+        payload = binding.to_json_dict()
+        enriched = dict(info)
+        enriched.update(
+            {
+                "generic_symbols": GENERIC_INSTRUMENT_SYMBOLS,
+                "generic_action_names": GENERIC_INSTRUMENT_ACTION_NAMES,
+                "instrument_episode_binding": payload,
+            }
+        )
+        if terminal:
+            enriched["terminal_instrument_episode_binding"] = payload
+        return enriched
+
+    def reset(
+        self,
+        *,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[Observation, dict[str, Any]]:
+        self._ensure_open()
+        if self._episode_active:
+            raise RuntimeError("cannot reset while an instrument episode is active")
+        resolved_options = dict(options or {})
+        self._validate_reset_options(resolved_options)
+        super().reset(seed=seed)
+        route = self.router.route(self._completed_episode_count)
+        symbol = route.binding.concrete_symbol
+        child = self._children[symbol]
+        child_seed = self._child_reset_seed(user_seed=seed)
+        try:
+            observation, child_info = child.reset(
+                seed=child_seed,
+                options=resolved_options or None,
+            )
+        except Exception:
+            self._failed_symbol = symbol
+            raise
+        if not isinstance(child_info, Mapping):
+            self._failed_symbol = symbol
+            raise ValueError("child reset info must be a mapping")
+        episode_start = _non_negative_info_index(child_info, "start_index")
+        episode_stop = _non_negative_info_index(child_info, "end_index")
+        try:
+            binding = InstrumentEpisodeBinding.from_route(
+                route,
+                episode_start=episode_start,
+                episode_stop=episode_stop,
+            )
+        except Exception:
+            self._failed_symbol = symbol
+            raise
+        self._active_child = child
+        self._active_episode_binding = binding
+        self._episode_active = True
+        return observation, self._enrich_info(child_info, binding, terminal=False)
+
+    def step(
+        self,
+        action: np.ndarray,
+    ) -> tuple[Observation, float, bool, bool, dict[str, Any]]:
+        self._ensure_open()
+        if (
+            not self._episode_active
+            or self._active_child is None
+            or self._active_episode_binding is None
+        ):
+            raise RuntimeError("reset must start an instrument episode before step")
+        vector = np.asarray(action)
+        if vector.shape != (1,):
+            raise ValueError("episode-routed action must have exact shape (1,)")
+        parsed = self.action_spec.parse(
+            vector,
+            mode=ActionValidationMode.FAIL_CLOSED,
+        )
+        maintained_action = parsed.as_array()
+        try:
+            observation, reward, terminated, truncated, child_info = (
+                self._active_child.step(maintained_action)
+            )
+        except Exception:
+            self._failed_symbol = (
+                self._active_episode_binding.dataset_binding.concrete_symbol
+            )
+            self._episode_active = False
+            raise
+        if not isinstance(terminated, bool) or not isinstance(truncated, bool):
+            self._failed_symbol = (
+                self._active_episode_binding.dataset_binding.concrete_symbol
+            )
+            self._episode_active = False
+            raise ValueError("child terminal flags must be booleans")
+        if terminated and truncated:
+            self._failed_symbol = (
+                self._active_episode_binding.dataset_binding.concrete_symbol
+            )
+            self._episode_active = False
+            raise RuntimeError("terminated and truncated must remain exclusive")
+        if not isinstance(child_info, Mapping):
+            self._failed_symbol = (
+                self._active_episode_binding.dataset_binding.concrete_symbol
+            )
+            self._episode_active = False
+            raise ValueError("child step info must be a mapping")
+        terminal = terminated or truncated
+        info = self._enrich_info(
+            child_info,
+            self._active_episode_binding,
+            terminal=terminal,
+        )
+        if terminal:
+            self._episode_active = False
+            self._completed_episode_count += 1
+        return observation, float(reward), terminated, truncated, info
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        for child in self._children.values():
+            child.close()
+        self._closed = True
+        self._episode_active = False
+
+
+__all__ = [
+    "EPISODE_ROUTED_SINGLE_INSTRUMENT_ENVIRONMENT_SCHEMA",
+    "EpisodeRoutedSingleInstrumentEnv",
+    "SingleInstrumentChildEnvironment",
+]

--- a/trade_rl/rl/instrument_episode_routing.py
+++ b/trade_rl/rl/instrument_episode_routing.py
@@ -1,0 +1,476 @@
+"""Deterministic train-only routing for universal single-instrument episodes."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import Enum
+
+from trade_rl.artifacts.hashing import content_digest
+from trade_rl.domain.common import require_sha256
+
+GENERIC_INSTRUMENT_SYMBOL = "INSTRUMENT"
+GENERIC_INSTRUMENT_SYMBOLS = (GENERIC_INSTRUMENT_SYMBOL,)
+GENERIC_INSTRUMENT_ACTION_NAMES = (
+    f"target_weight:{GENERIC_INSTRUMENT_SYMBOL}",
+)
+
+INSTRUMENT_DATASET_BINDING_SCHEMA = "instrument_dataset_binding_v1"
+INSTRUMENT_EPISODE_BINDING_SCHEMA = "instrument_episode_binding_v1"
+DETERMINISTIC_BALANCED_INSTRUMENT_ROUTER_SCHEMA = (
+    "deterministic_balanced_instrument_router_v1"
+)
+_DETERMINISTIC_PERMUTATION_SCHEMA = "instrument_routing_permutation_v1"
+
+
+class InstrumentDatasetSplit(str, Enum):
+    """Symbol-disjoint role assigned by the immutable universal partition."""
+
+    TRAIN = "train"
+    VALIDATION = "validation"
+    TEST = "test"
+
+
+def _require_string(value: object, *, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{field} must be a non-empty string")
+    return value
+
+
+def _require_digest(value: object, *, field: str) -> str:
+    resolved = _require_string(value, field=field)
+    require_sha256(resolved, field=field)
+    return resolved
+
+
+def _require_non_negative_integer(value: object, *, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{field} must be a non-negative integer")
+    return value
+
+
+def _require_exact_fields(
+    value: Mapping[str, object],
+    *,
+    expected: frozenset[str],
+    field: str,
+) -> None:
+    observed = frozenset(value)
+    if observed != expected:
+        missing = sorted(expected - observed)
+        extra = sorted(observed - expected)
+        raise ValueError(
+            f"{field} fields mismatch: missing={missing}, extra={extra}"
+        )
+
+
+_DATASET_BINDING_FIELDS = frozenset(
+    {
+        "schema_version",
+        "concrete_symbol",
+        "source_dataset_id",
+        "symbol_dataset_digest",
+        "execution_metadata_digest",
+        "instrument_descriptor_digest",
+        "partition_digest",
+        "split",
+        "binding_digest",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class InstrumentDatasetBinding:
+    """Immutable evidence binding for one concrete single-symbol dataset."""
+
+    concrete_symbol: str
+    source_dataset_id: str
+    symbol_dataset_digest: str
+    execution_metadata_digest: str
+    instrument_descriptor_digest: str
+    partition_digest: str
+    split: InstrumentDatasetSplit | str
+
+    def __post_init__(self) -> None:
+        concrete_symbol = _require_string(
+            self.concrete_symbol,
+            field="concrete_symbol",
+        )
+        if concrete_symbol == GENERIC_INSTRUMENT_SYMBOL:
+            raise ValueError("concrete_symbol must not use the generic INSTRUMENT slot")
+        object.__setattr__(self, "concrete_symbol", concrete_symbol)
+        for field_name in (
+            "source_dataset_id",
+            "symbol_dataset_digest",
+            "execution_metadata_digest",
+            "instrument_descriptor_digest",
+            "partition_digest",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _require_digest(getattr(self, field_name), field=field_name),
+            )
+        try:
+            split = InstrumentDatasetSplit(self.split)
+        except (TypeError, ValueError) as error:
+            raise ValueError("split is not supported") from error
+        object.__setattr__(self, "split", split)
+
+    def digest_payload(self) -> dict[str, object]:
+        return {
+            "schema_version": INSTRUMENT_DATASET_BINDING_SCHEMA,
+            "concrete_symbol": self.concrete_symbol,
+            "source_dataset_id": self.source_dataset_id,
+            "symbol_dataset_digest": self.symbol_dataset_digest,
+            "execution_metadata_digest": self.execution_metadata_digest,
+            "instrument_descriptor_digest": self.instrument_descriptor_digest,
+            "partition_digest": self.partition_digest,
+            "split": InstrumentDatasetSplit(self.split).value,
+        }
+
+    @property
+    def digest(self) -> str:
+        return content_digest(self.digest_payload())
+
+    def to_json_dict(self) -> dict[str, object]:
+        return {**self.digest_payload(), "binding_digest": self.digest}
+
+    @classmethod
+    def from_json_dict(
+        cls,
+        value: Mapping[str, object],
+    ) -> InstrumentDatasetBinding:
+        if not isinstance(value, Mapping):
+            raise ValueError("instrument dataset binding must be a mapping")
+        payload = dict(value)
+        _require_exact_fields(
+            payload,
+            expected=_DATASET_BINDING_FIELDS,
+            field="instrument dataset binding",
+        )
+        if payload["schema_version"] != INSTRUMENT_DATASET_BINDING_SCHEMA:
+            raise ValueError("instrument dataset binding schema mismatch")
+        observed_digest = _require_digest(
+            payload["binding_digest"],
+            field="binding_digest",
+        )
+        binding = cls(
+            concrete_symbol=payload["concrete_symbol"],  # type: ignore[arg-type]
+            source_dataset_id=payload["source_dataset_id"],  # type: ignore[arg-type]
+            symbol_dataset_digest=payload["symbol_dataset_digest"],  # type: ignore[arg-type]
+            execution_metadata_digest=payload["execution_metadata_digest"],  # type: ignore[arg-type]
+            instrument_descriptor_digest=payload[
+                "instrument_descriptor_digest"
+            ],  # type: ignore[arg-type]
+            partition_digest=payload["partition_digest"],  # type: ignore[arg-type]
+            split=payload["split"],  # type: ignore[arg-type]
+        )
+        if observed_digest != binding.digest:
+            raise ValueError("instrument dataset binding digest mismatch")
+        return binding
+
+
+@dataclass(frozen=True, slots=True)
+class InstrumentRoute:
+    """One deterministic route resolved from completed-episode count."""
+
+    binding: InstrumentDatasetBinding
+    router_digest: str
+    environment_index: int
+    completed_episode_count: int
+    routing_cycle: int
+    routing_position: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.binding, InstrumentDatasetBinding):
+            raise TypeError("binding must be InstrumentDatasetBinding")
+        _require_digest(self.router_digest, field="router_digest")
+        for field_name in (
+            "environment_index",
+            "completed_episode_count",
+            "routing_cycle",
+            "routing_position",
+        ):
+            _require_non_negative_integer(getattr(self, field_name), field=field_name)
+
+
+@dataclass(frozen=True, slots=True)
+class DeterministicBalancedInstrumentRouter:
+    """Stateless hash-ranked permutations with one visit per symbol per cycle."""
+
+    bindings: tuple[InstrumentDatasetBinding, ...]
+    run_seed: int
+    environment_index: int
+    partition_digest: str
+
+    def __init__(
+        self,
+        bindings: Sequence[InstrumentDatasetBinding],
+        *,
+        run_seed: int,
+        environment_index: int,
+        partition_digest: str,
+    ) -> None:
+        object.__setattr__(self, "bindings", tuple(bindings))
+        object.__setattr__(self, "run_seed", run_seed)
+        object.__setattr__(self, "environment_index", environment_index)
+        object.__setattr__(self, "partition_digest", partition_digest)
+        self.__post_init__()
+
+    def __post_init__(self) -> None:
+        if not self.bindings:
+            raise ValueError("router bindings must not be empty")
+        if any(not isinstance(item, InstrumentDatasetBinding) for item in self.bindings):
+            raise TypeError("router bindings must be InstrumentDatasetBinding values")
+        run_seed = _require_non_negative_integer(self.run_seed, field="run_seed")
+        environment_index = _require_non_negative_integer(
+            self.environment_index,
+            field="environment_index",
+        )
+        partition_digest = _require_digest(
+            self.partition_digest,
+            field="partition_digest",
+        )
+        if any(
+            binding.split is not InstrumentDatasetSplit.TRAIN
+            for binding in self.bindings
+        ):
+            raise ValueError("training router accepts train bindings only")
+        if any(
+            binding.partition_digest != partition_digest
+            for binding in self.bindings
+        ):
+            raise ValueError("router binding partition digest mismatch")
+        symbols = tuple(binding.concrete_symbol for binding in self.bindings)
+        if len(set(symbols)) != len(symbols):
+            raise ValueError("router concrete symbols must be unique")
+        binding_digests = tuple(binding.digest for binding in self.bindings)
+        if len(set(binding_digests)) != len(binding_digests):
+            raise ValueError("router binding digests must be unique")
+        ordered = tuple(sorted(self.bindings, key=lambda item: item.concrete_symbol))
+        object.__setattr__(self, "bindings", ordered)
+        object.__setattr__(self, "run_seed", run_seed)
+        object.__setattr__(self, "environment_index", environment_index)
+        object.__setattr__(self, "partition_digest", partition_digest)
+
+    def digest_payload(self) -> dict[str, object]:
+        return {
+            "schema_version": DETERMINISTIC_BALANCED_INSTRUMENT_ROUTER_SCHEMA,
+            "run_seed": self.run_seed,
+            "environment_index": self.environment_index,
+            "partition_digest": self.partition_digest,
+            "binding_digests": tuple(binding.digest for binding in self.bindings),
+        }
+
+    @property
+    def digest(self) -> str:
+        return content_digest(self.digest_payload())
+
+    def to_json_dict(self) -> dict[str, object]:
+        return {**self.digest_payload(), "router_digest": self.digest}
+
+    def _permutation(self, routing_cycle: int) -> tuple[InstrumentDatasetBinding, ...]:
+        cycle = _require_non_negative_integer(routing_cycle, field="routing_cycle")
+
+        def score(binding: InstrumentDatasetBinding) -> tuple[str, str]:
+            ranking_digest = content_digest(
+                {
+                    "schema_version": _DETERMINISTIC_PERMUTATION_SCHEMA,
+                    "run_seed": self.run_seed,
+                    "environment_index": self.environment_index,
+                    "partition_digest": self.partition_digest,
+                    "routing_cycle": cycle,
+                    "binding_digest": binding.digest,
+                }
+            )
+            return ranking_digest, binding.concrete_symbol
+
+        return tuple(sorted(self.bindings, key=score))
+
+    def route(self, completed_episode_count: int) -> InstrumentRoute:
+        count = _require_non_negative_integer(
+            completed_episode_count,
+            field="completed_episode_count",
+        )
+        routing_cycle, routing_position = divmod(count, len(self.bindings))
+        permutation = self._permutation(routing_cycle)
+        return InstrumentRoute(
+            binding=permutation[routing_position],
+            router_digest=self.digest,
+            environment_index=self.environment_index,
+            completed_episode_count=count,
+            routing_cycle=routing_cycle,
+            routing_position=routing_position,
+        )
+
+
+_EPISODE_BINDING_FIELDS = frozenset(
+    {
+        "schema_version",
+        "concrete_symbol",
+        "source_dataset_id",
+        "symbol_dataset_digest",
+        "execution_metadata_digest",
+        "instrument_descriptor_digest",
+        "partition_digest",
+        "split",
+        "dataset_binding_digest",
+        "router_digest",
+        "environment_index",
+        "completed_episode_count",
+        "routing_cycle",
+        "routing_position",
+        "episode_start",
+        "episode_stop",
+        "episode_binding_digest",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class InstrumentEpisodeBinding:
+    """Concrete dataset identity and routing coordinates for one episode."""
+
+    dataset_binding: InstrumentDatasetBinding
+    router_digest: str
+    environment_index: int
+    completed_episode_count: int
+    routing_cycle: int
+    routing_position: int
+    episode_start: int
+    episode_stop: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.dataset_binding, InstrumentDatasetBinding):
+            raise TypeError("dataset_binding must be InstrumentDatasetBinding")
+        if self.dataset_binding.split is not InstrumentDatasetSplit.TRAIN:
+            raise ValueError("episode binding requires a train dataset binding")
+        _require_digest(self.router_digest, field="router_digest")
+        for field_name in (
+            "environment_index",
+            "completed_episode_count",
+            "routing_cycle",
+            "routing_position",
+            "episode_start",
+            "episode_stop",
+        ):
+            _require_non_negative_integer(getattr(self, field_name), field=field_name)
+        if self.episode_stop <= self.episode_start:
+            raise ValueError("episode_stop must be greater than episode_start")
+
+    @classmethod
+    def from_route(
+        cls,
+        route: InstrumentRoute,
+        *,
+        episode_start: int,
+        episode_stop: int,
+    ) -> InstrumentEpisodeBinding:
+        if not isinstance(route, InstrumentRoute):
+            raise TypeError("route must be InstrumentRoute")
+        return cls(
+            dataset_binding=route.binding,
+            router_digest=route.router_digest,
+            environment_index=route.environment_index,
+            completed_episode_count=route.completed_episode_count,
+            routing_cycle=route.routing_cycle,
+            routing_position=route.routing_position,
+            episode_start=episode_start,
+            episode_stop=episode_stop,
+        )
+
+    def digest_payload(self) -> dict[str, object]:
+        binding = self.dataset_binding
+        return {
+            "schema_version": INSTRUMENT_EPISODE_BINDING_SCHEMA,
+            "concrete_symbol": binding.concrete_symbol,
+            "source_dataset_id": binding.source_dataset_id,
+            "symbol_dataset_digest": binding.symbol_dataset_digest,
+            "execution_metadata_digest": binding.execution_metadata_digest,
+            "instrument_descriptor_digest": binding.instrument_descriptor_digest,
+            "partition_digest": binding.partition_digest,
+            "split": InstrumentDatasetSplit(binding.split).value,
+            "dataset_binding_digest": binding.digest,
+            "router_digest": self.router_digest,
+            "environment_index": self.environment_index,
+            "completed_episode_count": self.completed_episode_count,
+            "routing_cycle": self.routing_cycle,
+            "routing_position": self.routing_position,
+            "episode_start": self.episode_start,
+            "episode_stop": self.episode_stop,
+        }
+
+    @property
+    def digest(self) -> str:
+        return content_digest(self.digest_payload())
+
+    def to_json_dict(self) -> dict[str, object]:
+        return {**self.digest_payload(), "episode_binding_digest": self.digest}
+
+    @classmethod
+    def from_json_dict(
+        cls,
+        value: Mapping[str, object],
+    ) -> InstrumentEpisodeBinding:
+        if not isinstance(value, Mapping):
+            raise ValueError("instrument episode binding must be a mapping")
+        payload = dict(value)
+        _require_exact_fields(
+            payload,
+            expected=_EPISODE_BINDING_FIELDS,
+            field="instrument episode binding",
+        )
+        if payload["schema_version"] != INSTRUMENT_EPISODE_BINDING_SCHEMA:
+            raise ValueError("instrument episode binding schema mismatch")
+        dataset_binding = InstrumentDatasetBinding(
+            concrete_symbol=payload["concrete_symbol"],  # type: ignore[arg-type]
+            source_dataset_id=payload["source_dataset_id"],  # type: ignore[arg-type]
+            symbol_dataset_digest=payload["symbol_dataset_digest"],  # type: ignore[arg-type]
+            execution_metadata_digest=payload["execution_metadata_digest"],  # type: ignore[arg-type]
+            instrument_descriptor_digest=payload[
+                "instrument_descriptor_digest"
+            ],  # type: ignore[arg-type]
+            partition_digest=payload["partition_digest"],  # type: ignore[arg-type]
+            split=payload["split"],  # type: ignore[arg-type]
+        )
+        observed_dataset_digest = _require_digest(
+            payload["dataset_binding_digest"],
+            field="dataset_binding_digest",
+        )
+        if observed_dataset_digest != dataset_binding.digest:
+            raise ValueError("instrument episode dataset binding digest mismatch")
+        episode = cls(
+            dataset_binding=dataset_binding,
+            router_digest=payload["router_digest"],  # type: ignore[arg-type]
+            environment_index=payload["environment_index"],  # type: ignore[arg-type]
+            completed_episode_count=payload[
+                "completed_episode_count"
+            ],  # type: ignore[arg-type]
+            routing_cycle=payload["routing_cycle"],  # type: ignore[arg-type]
+            routing_position=payload["routing_position"],  # type: ignore[arg-type]
+            episode_start=payload["episode_start"],  # type: ignore[arg-type]
+            episode_stop=payload["episode_stop"],  # type: ignore[arg-type]
+        )
+        observed_episode_digest = _require_digest(
+            payload["episode_binding_digest"],
+            field="episode_binding_digest",
+        )
+        if observed_episode_digest != episode.digest:
+            raise ValueError("instrument episode binding digest mismatch")
+        return episode
+
+
+__all__ = [
+    "DETERMINISTIC_BALANCED_INSTRUMENT_ROUTER_SCHEMA",
+    "GENERIC_INSTRUMENT_ACTION_NAMES",
+    "GENERIC_INSTRUMENT_SYMBOL",
+    "GENERIC_INSTRUMENT_SYMBOLS",
+    "INSTRUMENT_DATASET_BINDING_SCHEMA",
+    "INSTRUMENT_EPISODE_BINDING_SCHEMA",
+    "DeterministicBalancedInstrumentRouter",
+    "InstrumentDatasetBinding",
+    "InstrumentDatasetSplit",
+    "InstrumentEpisodeBinding",
+    "InstrumentRoute",
+]

--- a/trade_rl/rl/universal_episode_router.py
+++ b/trade_rl/rl/universal_episode_router.py
@@ -1,0 +1,164 @@
+"""Deterministic balanced routing for universal single-instrument episodes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from trade_rl.artifacts.hashing import content_digest
+from trade_rl.domain.common import (
+    require_non_empty,
+    require_sha256,
+    require_unique_non_empty,
+)
+
+INSTRUMENT_ROUTE_SCHEMA: Final = "instrument_route_v1"
+DETERMINISTIC_INSTRUMENT_ROUTER_SCHEMA: Final = (
+    "deterministic_balanced_instrument_router_v1"
+)
+
+
+def _require_non_negative_int(value: object, *, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{field} must be a non-negative integer")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class InstrumentRoute:
+    """One deterministic position in a balanced symbol cycle."""
+
+    concrete_symbol: str
+    completed_episode_count: int
+    routing_cycle: int
+    routing_position: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.concrete_symbol, str):
+            raise TypeError("concrete_symbol must be a string")
+        symbol = require_non_empty(
+            self.concrete_symbol,
+            field="concrete_symbol",
+        )
+        _require_non_negative_int(
+            self.completed_episode_count,
+            field="completed_episode_count",
+        )
+        _require_non_negative_int(
+            self.routing_cycle,
+            field="routing_cycle",
+        )
+        _require_non_negative_int(
+            self.routing_position,
+            field="routing_position",
+        )
+        object.__setattr__(self, "concrete_symbol", symbol)
+
+    def to_json_dict(self) -> dict[str, object]:
+        return {
+            "completed_episode_count": self.completed_episode_count,
+            "concrete_symbol": self.concrete_symbol,
+            "routing_cycle": self.routing_cycle,
+            "routing_position": self.routing_position,
+            "schema_version": INSTRUMENT_ROUTE_SCHEMA,
+        }
+
+    @property
+    def digest(self) -> str:
+        return content_digest(self.to_json_dict())
+
+
+@dataclass(frozen=True, slots=True)
+class DeterministicBalancedInstrumentRouter:
+    """Route each symbol exactly once per deterministic environment-local cycle."""
+
+    train_symbols: tuple[str, ...]
+    partition_digest: str
+    run_seed: int
+    environment_index: int
+
+    def __post_init__(self) -> None:
+        try:
+            raw_symbols = tuple(self.train_symbols)
+        except TypeError as error:
+            raise ValueError("train_symbols must be a non-empty tuple") from error
+        symbols = require_unique_non_empty(
+            raw_symbols,
+            field="train_symbols",
+        )
+        partition_digest = require_sha256(
+            self.partition_digest,
+            field="partition_digest",
+        )
+        _require_non_negative_int(self.run_seed, field="run_seed")
+        _require_non_negative_int(
+            self.environment_index,
+            field="environment_index",
+        )
+        object.__setattr__(self, "train_symbols", symbols)
+        object.__setattr__(self, "partition_digest", partition_digest)
+
+    def to_json_dict(self) -> dict[str, object]:
+        return {
+            "environment_index": self.environment_index,
+            "partition_digest": self.partition_digest,
+            "run_seed": self.run_seed,
+            "schema_version": DETERMINISTIC_INSTRUMENT_ROUTER_SCHEMA,
+            "train_symbols": list(self.train_symbols),
+        }
+
+    @property
+    def digest(self) -> str:
+        return content_digest(self.to_json_dict())
+
+    def cycle_symbols(self, routing_cycle: int) -> tuple[str, ...]:
+        """Return one immutable permutation for the requested cycle."""
+
+        cycle = _require_non_negative_int(
+            routing_cycle,
+            field="routing_cycle",
+        )
+
+        def key(symbol: str) -> tuple[str, str]:
+            return (
+                content_digest(
+                    {
+                        "environment_index": self.environment_index,
+                        "partition_digest": self.partition_digest,
+                        "routing_cycle": cycle,
+                        "run_seed": self.run_seed,
+                        "schema_version": DETERMINISTIC_INSTRUMENT_ROUTER_SCHEMA,
+                        "symbol": symbol,
+                    }
+                ),
+                symbol,
+            )
+
+        return tuple(sorted(self.train_symbols, key=key))
+
+    def route(self, completed_episode_count: int) -> InstrumentRoute:
+        """Resolve the exact symbol and cycle position for one episode count."""
+
+        completed = _require_non_negative_int(
+            completed_episode_count,
+            field="completed_episode_count",
+        )
+        routing_cycle, routing_position = divmod(
+            completed,
+            len(self.train_symbols),
+        )
+        concrete_symbol = self.cycle_symbols(routing_cycle)[routing_position]
+        return InstrumentRoute(
+            concrete_symbol=concrete_symbol,
+            completed_episode_count=completed,
+            routing_cycle=routing_cycle,
+            routing_position=routing_position,
+        )
+
+
+__all__ = [
+    "DETERMINISTIC_INSTRUMENT_ROUTER_SCHEMA",
+    "INSTRUMENT_ROUTE_SCHEMA",
+    "DeterministicBalancedInstrumentRouter",
+    "InstrumentRoute",
+]

--- a/trade_rl/rl/universal_instrument_binding.py
+++ b/trade_rl/rl/universal_instrument_binding.py
@@ -1,0 +1,374 @@
+"""Immutable concrete-instrument bindings for universal single-instrument runs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Final
+
+from trade_rl.artifacts.hashing import content_digest
+from trade_rl.domain.common import (
+    require_non_empty,
+    require_sha256,
+    require_unique_non_empty,
+)
+
+GENERIC_INSTRUMENT_SYMBOL: Final = "INSTRUMENT"
+GENERIC_INSTRUMENT_SYMBOLS: Final = (GENERIC_INSTRUMENT_SYMBOL,)
+GENERIC_TARGET_WEIGHT_ACTION_NAMES: Final = (
+    f"target_weight:{GENERIC_INSTRUMENT_SYMBOL}",
+)
+INSTRUMENT_SPLITS: Final = frozenset({"train", "validation", "test"})
+INSTRUMENT_DATASET_BINDING_SCHEMA: Final = "instrument_dataset_binding_v1"
+INSTRUMENT_EPISODE_BINDING_SCHEMA: Final = "instrument_episode_binding_v1"
+
+_DATASET_BINDING_KEYS: Final = frozenset(
+    {
+        "concrete_symbol",
+        "execution_metadata_digest",
+        "instrument_descriptor_digest",
+        "schema_version",
+        "source_dataset_id",
+        "split",
+        "symbol_dataset_digest",
+    }
+)
+_EPISODE_BINDING_KEYS: Final = frozenset(
+    {
+        "completed_episode_count",
+        "concrete_symbol",
+        "dataset_binding_digest",
+        "environment_index",
+        "episode_seed",
+        "episode_start",
+        "episode_stop",
+        "execution_metadata_digest",
+        "instrument_descriptor_digest",
+        "routing_cycle",
+        "routing_position",
+        "schema_version",
+        "source_dataset_id",
+        "split",
+        "symbol_dataset_digest",
+    }
+)
+
+
+def _require_string(value: object, *, field: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{field} must be a string")
+    return value
+
+
+def _require_non_negative_int(value: object, *, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{field} must be a non-negative integer")
+    return value
+
+
+def _require_field_closure(
+    value: Mapping[str, object],
+    *,
+    expected: frozenset[str],
+    field: str,
+) -> dict[str, object]:
+    payload = dict(value)
+    if frozenset(payload) != expected:
+        raise ValueError(f"{field} field closure mismatch")
+    return payload
+
+
+@dataclass(frozen=True, slots=True)
+class InstrumentDatasetBinding:
+    """Immutable proof of the concrete single-symbol dataset selected for one run."""
+
+    concrete_symbol: str
+    source_dataset_id: str
+    symbol_dataset_digest: str
+    execution_metadata_digest: str
+    instrument_descriptor_digest: str
+    split: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.concrete_symbol, str):
+            raise TypeError("concrete_symbol must be a string")
+        concrete_symbol = require_non_empty(
+            self.concrete_symbol,
+            field="concrete_symbol",
+        )
+        source_dataset_id = require_sha256(
+            self.source_dataset_id,
+            field="source_dataset_id",
+        )
+        symbol_dataset_digest = require_sha256(
+            self.symbol_dataset_digest,
+            field="symbol_dataset_digest",
+        )
+        execution_metadata_digest = require_sha256(
+            self.execution_metadata_digest,
+            field="execution_metadata_digest",
+        )
+        instrument_descriptor_digest = require_sha256(
+            self.instrument_descriptor_digest,
+            field="instrument_descriptor_digest",
+        )
+        if not isinstance(self.split, str) or self.split not in INSTRUMENT_SPLITS:
+            raise ValueError("split must be one of train, validation, or test")
+        object.__setattr__(self, "concrete_symbol", concrete_symbol)
+        object.__setattr__(self, "source_dataset_id", source_dataset_id)
+        object.__setattr__(
+            self,
+            "symbol_dataset_digest",
+            symbol_dataset_digest,
+        )
+        object.__setattr__(
+            self,
+            "execution_metadata_digest",
+            execution_metadata_digest,
+        )
+        object.__setattr__(
+            self,
+            "instrument_descriptor_digest",
+            instrument_descriptor_digest,
+        )
+
+    def to_json_dict(self) -> dict[str, object]:
+        return {
+            "concrete_symbol": self.concrete_symbol,
+            "execution_metadata_digest": self.execution_metadata_digest,
+            "instrument_descriptor_digest": self.instrument_descriptor_digest,
+            "schema_version": INSTRUMENT_DATASET_BINDING_SCHEMA,
+            "source_dataset_id": self.source_dataset_id,
+            "split": self.split,
+            "symbol_dataset_digest": self.symbol_dataset_digest,
+        }
+
+    @property
+    def digest(self) -> str:
+        return content_digest(self.to_json_dict())
+
+    @classmethod
+    def from_json_dict(
+        cls,
+        value: Mapping[str, object],
+    ) -> InstrumentDatasetBinding:
+        if not isinstance(value, Mapping):
+            raise TypeError("instrument dataset binding must be a mapping")
+        payload = _require_field_closure(
+            value,
+            expected=_DATASET_BINDING_KEYS,
+            field="instrument dataset binding",
+        )
+        if payload["schema_version"] != INSTRUMENT_DATASET_BINDING_SCHEMA:
+            raise ValueError("instrument dataset binding schema mismatch")
+        return cls(
+            concrete_symbol=_require_string(
+                payload["concrete_symbol"],
+                field="concrete_symbol",
+            ),
+            source_dataset_id=_require_string(
+                payload["source_dataset_id"],
+                field="source_dataset_id",
+            ),
+            symbol_dataset_digest=_require_string(
+                payload["symbol_dataset_digest"],
+                field="symbol_dataset_digest",
+            ),
+            execution_metadata_digest=_require_string(
+                payload["execution_metadata_digest"],
+                field="execution_metadata_digest",
+            ),
+            instrument_descriptor_digest=_require_string(
+                payload["instrument_descriptor_digest"],
+                field="instrument_descriptor_digest",
+            ),
+            split=_require_string(payload["split"], field="split"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class InstrumentEpisodeBinding:
+    """Concrete identity and route coordinates for one complete episode."""
+
+    dataset_binding: InstrumentDatasetBinding
+    episode_start: int
+    episode_stop: int
+    episode_seed: int
+    environment_index: int
+    completed_episode_count: int
+    routing_cycle: int
+    routing_position: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.dataset_binding, InstrumentDatasetBinding):
+            raise TypeError("dataset_binding must be an InstrumentDatasetBinding")
+        episode_start = _require_non_negative_int(
+            self.episode_start,
+            field="episode_start",
+        )
+        episode_stop = _require_non_negative_int(
+            self.episode_stop,
+            field="episode_stop",
+        )
+        if episode_stop <= episode_start:
+            raise ValueError("episode_stop must be greater than episode_start")
+        episode_seed = _require_non_negative_int(
+            self.episode_seed,
+            field="episode_seed",
+        )
+        if episode_seed > 0xFFFFFFFF:
+            raise ValueError("episode_seed must fit in an unsigned 32-bit integer")
+        _require_non_negative_int(
+            self.environment_index,
+            field="environment_index",
+        )
+        _require_non_negative_int(
+            self.completed_episode_count,
+            field="completed_episode_count",
+        )
+        _require_non_negative_int(
+            self.routing_cycle,
+            field="routing_cycle",
+        )
+        _require_non_negative_int(
+            self.routing_position,
+            field="routing_position",
+        )
+
+    def to_json_dict(self) -> dict[str, object]:
+        binding = self.dataset_binding
+        return {
+            "completed_episode_count": self.completed_episode_count,
+            "concrete_symbol": binding.concrete_symbol,
+            "dataset_binding_digest": binding.digest,
+            "environment_index": self.environment_index,
+            "episode_seed": self.episode_seed,
+            "episode_start": self.episode_start,
+            "episode_stop": self.episode_stop,
+            "execution_metadata_digest": binding.execution_metadata_digest,
+            "instrument_descriptor_digest": binding.instrument_descriptor_digest,
+            "routing_cycle": self.routing_cycle,
+            "routing_position": self.routing_position,
+            "schema_version": INSTRUMENT_EPISODE_BINDING_SCHEMA,
+            "source_dataset_id": binding.source_dataset_id,
+            "split": binding.split,
+            "symbol_dataset_digest": binding.symbol_dataset_digest,
+        }
+
+    @property
+    def digest(self) -> str:
+        return content_digest(self.to_json_dict())
+
+    @classmethod
+    def from_json_dict(
+        cls,
+        value: Mapping[str, object],
+    ) -> InstrumentEpisodeBinding:
+        if not isinstance(value, Mapping):
+            raise TypeError("instrument episode binding must be a mapping")
+        payload = _require_field_closure(
+            value,
+            expected=_EPISODE_BINDING_KEYS,
+            field="instrument episode binding",
+        )
+        if payload["schema_version"] != INSTRUMENT_EPISODE_BINDING_SCHEMA:
+            raise ValueError("instrument episode binding schema mismatch")
+        binding = InstrumentDatasetBinding(
+            concrete_symbol=_require_string(
+                payload["concrete_symbol"],
+                field="concrete_symbol",
+            ),
+            source_dataset_id=_require_string(
+                payload["source_dataset_id"],
+                field="source_dataset_id",
+            ),
+            symbol_dataset_digest=_require_string(
+                payload["symbol_dataset_digest"],
+                field="symbol_dataset_digest",
+            ),
+            execution_metadata_digest=_require_string(
+                payload["execution_metadata_digest"],
+                field="execution_metadata_digest",
+            ),
+            instrument_descriptor_digest=_require_string(
+                payload["instrument_descriptor_digest"],
+                field="instrument_descriptor_digest",
+            ),
+            split=_require_string(payload["split"], field="split"),
+        )
+        observed_digest = _require_string(
+            payload["dataset_binding_digest"],
+            field="dataset_binding_digest",
+        )
+        require_sha256(observed_digest, field="dataset_binding_digest")
+        if observed_digest != binding.digest:
+            raise ValueError("instrument dataset binding digest mismatch")
+        return cls(
+            dataset_binding=binding,
+            episode_start=_require_non_negative_int(
+                payload["episode_start"],
+                field="episode_start",
+            ),
+            episode_stop=_require_non_negative_int(
+                payload["episode_stop"],
+                field="episode_stop",
+            ),
+            episode_seed=_require_non_negative_int(
+                payload["episode_seed"],
+                field="episode_seed",
+            ),
+            environment_index=_require_non_negative_int(
+                payload["environment_index"],
+                field="environment_index",
+            ),
+            completed_episode_count=_require_non_negative_int(
+                payload["completed_episode_count"],
+                field="completed_episode_count",
+            ),
+            routing_cycle=_require_non_negative_int(
+                payload["routing_cycle"],
+                field="routing_cycle",
+            ),
+            routing_position=_require_non_negative_int(
+                payload["routing_position"],
+                field="routing_position",
+            ),
+        )
+
+
+def validate_training_instrument_bindings(
+    train_symbols: Sequence[str],
+    bindings: Sequence[InstrumentDatasetBinding],
+) -> dict[str, InstrumentDatasetBinding]:
+    """Require an exact train-only binding closure in declared symbol order."""
+
+    declared = require_unique_non_empty(
+        tuple(train_symbols),
+        field="train_symbols",
+    )
+    resolved: dict[str, InstrumentDatasetBinding] = {}
+    for binding in bindings:
+        if not isinstance(binding, InstrumentDatasetBinding):
+            raise TypeError("bindings must contain InstrumentDatasetBinding values")
+        symbol = binding.concrete_symbol
+        if symbol in resolved:
+            raise ValueError(f"duplicate instrument binding for {symbol}")
+        if binding.split != "train":
+            raise ValueError("training instrument bindings must all use the train split")
+        resolved[symbol] = binding
+    if set(resolved) != set(declared):
+        raise ValueError("training instrument binding closure mismatch")
+    return {symbol: resolved[symbol] for symbol in declared}
+
+
+__all__ = [
+    "GENERIC_INSTRUMENT_SYMBOL",
+    "GENERIC_INSTRUMENT_SYMBOLS",
+    "GENERIC_TARGET_WEIGHT_ACTION_NAMES",
+    "INSTRUMENT_DATASET_BINDING_SCHEMA",
+    "INSTRUMENT_EPISODE_BINDING_SCHEMA",
+    "INSTRUMENT_SPLITS",
+    "InstrumentDatasetBinding",
+    "InstrumentEpisodeBinding",
+    "validate_training_instrument_bindings",
+]

--- a/trade_rl/rl/universal_policy_identity.py
+++ b/trade_rl/rl/universal_policy_identity.py
@@ -1,0 +1,335 @@
+"""Identity contracts for one generic policy and concrete deployments."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from trade_rl.artifacts.codec import canonical_json_bytes
+from trade_rl.artifacts.hashing import content_digest
+from trade_rl.domain.common import require_sha256
+from trade_rl.rl.instrument_episode_routing import (
+    GENERIC_INSTRUMENT_ACTION_NAMES,
+    GENERIC_INSTRUMENT_SYMBOL,
+    GENERIC_INSTRUMENT_SYMBOLS,
+)
+
+UNIVERSAL_SINGLE_INSTRUMENT_POLICY_SCHEMA = (
+    "universal_single_instrument_policy_v1"
+)
+UNIVERSAL_SINGLE_INSTRUMENT_ACTION_SCHEMA = "single_target_weight_action_v1"
+SINGLE_INSTRUMENT_DEPLOYMENT_BINDING_SCHEMA = (
+    "single_instrument_deployment_binding_v1"
+)
+
+
+def _require_non_empty_string(value: object, *, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{field} must be a non-empty string")
+    return value
+
+
+def _require_digest(value: object, *, field: str) -> str:
+    resolved = _require_non_empty_string(value, field=field)
+    require_sha256(resolved, field=field)
+    return resolved
+
+
+def _require_exact_fields(
+    value: Mapping[str, object],
+    *,
+    expected: frozenset[str],
+    field: str,
+) -> None:
+    observed = frozenset(value)
+    if observed != expected:
+        missing = sorted(expected - observed)
+        extra = sorted(observed - expected)
+        raise ValueError(f"{field} fields mismatch: missing={missing}, extra={extra}")
+
+
+def _serialized_string_tuple(value: object, *, field: str) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple)):
+        raise ValueError(f"{field} must be a string list or tuple")
+    resolved = tuple(value)
+    if not resolved or any(not isinstance(item, str) or not item for item in resolved):
+        raise ValueError(f"{field} must contain non-empty strings")
+    if len(set(resolved)) != len(resolved):
+        raise ValueError(f"{field} must contain unique strings")
+    return resolved
+
+
+_POLICY_DIGEST_FIELDS = (
+    "architecture_digest",
+    "observation_schema_digest",
+    "instrument_descriptor_schema_digest",
+    "normalizer_digest",
+    "reward_environment_digest",
+    "training_catalog_digest",
+    "training_symbol_split_digest",
+    "training_symbols_digest",
+    "zero_shot_evidence_digest",
+)
+_POLICY_FIELDS = frozenset(
+    {
+        "schema_version",
+        "action_schema",
+        "generic_symbols",
+        "generic_action_names",
+        *_POLICY_DIGEST_FIELDS,
+        "policy_digest",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class UniversalSingleInstrumentPolicyIdentity:
+    """Ticker-free identity shared by training, checkpoints, and serving."""
+
+    architecture_digest: str
+    observation_schema_digest: str
+    instrument_descriptor_schema_digest: str
+    normalizer_digest: str
+    reward_environment_digest: str
+    training_catalog_digest: str
+    training_symbol_split_digest: str
+    training_symbols_digest: str
+    zero_shot_evidence_digest: str
+    generic_symbols: tuple[str, ...] = GENERIC_INSTRUMENT_SYMBOLS
+    generic_action_names: tuple[str, ...] = GENERIC_INSTRUMENT_ACTION_NAMES
+    action_schema: str = UNIVERSAL_SINGLE_INSTRUMENT_ACTION_SCHEMA
+
+    def __post_init__(self) -> None:
+        for field_name in _POLICY_DIGEST_FIELDS:
+            object.__setattr__(
+                self,
+                field_name,
+                _require_digest(getattr(self, field_name), field=field_name),
+            )
+        generic_symbols = _serialized_string_tuple(
+            self.generic_symbols,
+            field="generic_symbols",
+        )
+        if generic_symbols != GENERIC_INSTRUMENT_SYMBOLS:
+            raise ValueError(
+                "generic_symbols must be the identity-free INSTRUMENT slot"
+            )
+        generic_action_names = _serialized_string_tuple(
+            self.generic_action_names,
+            field="generic_action_names",
+        )
+        if generic_action_names != GENERIC_INSTRUMENT_ACTION_NAMES:
+            raise ValueError(
+                "generic_action_names must contain one INSTRUMENT target weight"
+            )
+        action_schema = _require_non_empty_string(
+            self.action_schema,
+            field="action_schema",
+        )
+        if action_schema != UNIVERSAL_SINGLE_INSTRUMENT_ACTION_SCHEMA:
+            raise ValueError("action_schema must remain the universal scalar contract")
+        object.__setattr__(self, "generic_symbols", generic_symbols)
+        object.__setattr__(self, "generic_action_names", generic_action_names)
+        object.__setattr__(self, "action_schema", action_schema)
+
+    def digest_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "schema_version": UNIVERSAL_SINGLE_INSTRUMENT_POLICY_SCHEMA,
+            "action_schema": self.action_schema,
+            "generic_symbols": self.generic_symbols,
+            "generic_action_names": self.generic_action_names,
+        }
+        payload.update(
+            {field_name: getattr(self, field_name) for field_name in _POLICY_DIGEST_FIELDS}
+        )
+        return payload
+
+    @property
+    def policy_digest(self) -> str:
+        return content_digest(self.digest_payload())
+
+    def to_json_dict(self) -> dict[str, object]:
+        payload = {**self.digest_payload(), "policy_digest": self.policy_digest}
+        canonical_json_bytes(payload)
+        return payload
+
+    @classmethod
+    def from_json_dict(
+        cls,
+        value: Mapping[str, object],
+    ) -> UniversalSingleInstrumentPolicyIdentity:
+        if not isinstance(value, Mapping):
+            raise ValueError("universal policy identity must be a mapping")
+        payload = dict(value)
+        _require_exact_fields(
+            payload,
+            expected=_POLICY_FIELDS,
+            field="universal policy identity",
+        )
+        if payload["schema_version"] != UNIVERSAL_SINGLE_INSTRUMENT_POLICY_SCHEMA:
+            raise ValueError("universal policy identity schema mismatch")
+        observed_digest = _require_digest(
+            payload["policy_digest"],
+            field="policy_digest",
+        )
+        identity = cls(
+            architecture_digest=payload["architecture_digest"],  # type: ignore[arg-type]
+            observation_schema_digest=payload[
+                "observation_schema_digest"
+            ],  # type: ignore[arg-type]
+            instrument_descriptor_schema_digest=payload[
+                "instrument_descriptor_schema_digest"
+            ],  # type: ignore[arg-type]
+            normalizer_digest=payload["normalizer_digest"],  # type: ignore[arg-type]
+            reward_environment_digest=payload[
+                "reward_environment_digest"
+            ],  # type: ignore[arg-type]
+            training_catalog_digest=payload[
+                "training_catalog_digest"
+            ],  # type: ignore[arg-type]
+            training_symbol_split_digest=payload[
+                "training_symbol_split_digest"
+            ],  # type: ignore[arg-type]
+            training_symbols_digest=payload[
+                "training_symbols_digest"
+            ],  # type: ignore[arg-type]
+            zero_shot_evidence_digest=payload[
+                "zero_shot_evidence_digest"
+            ],  # type: ignore[arg-type]
+            generic_symbols=_serialized_string_tuple(
+                payload["generic_symbols"],
+                field="generic_symbols",
+            ),
+            generic_action_names=_serialized_string_tuple(
+                payload["generic_action_names"],
+                field="generic_action_names",
+            ),
+            action_schema=payload["action_schema"],  # type: ignore[arg-type]
+        )
+        if observed_digest != identity.policy_digest:
+            raise ValueError("universal policy identity digest mismatch")
+        canonical_json_bytes(payload)
+        return identity
+
+
+_DEPLOYMENT_DIGEST_FIELDS = (
+    "policy_digest",
+    "market_instrument_contract_digest",
+    "dataset_feature_schema_digest",
+    "execution_metadata_digest",
+    "instrument_descriptor_evidence_digest",
+)
+_DEPLOYMENT_FIELDS = frozenset(
+    {
+        "schema_version",
+        "concrete_symbol",
+        *_DEPLOYMENT_DIGEST_FIELDS,
+        "seen_in_training",
+        "binding_digest",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SingleInstrumentDeploymentBinding:
+    """The only U2 identity that binds a generic policy to a concrete ticker."""
+
+    policy_digest: str
+    concrete_symbol: str
+    market_instrument_contract_digest: str
+    dataset_feature_schema_digest: str
+    execution_metadata_digest: str
+    instrument_descriptor_evidence_digest: str
+    seen_in_training: bool
+
+    def __post_init__(self) -> None:
+        for field_name in _DEPLOYMENT_DIGEST_FIELDS:
+            object.__setattr__(
+                self,
+                field_name,
+                _require_digest(getattr(self, field_name), field=field_name),
+            )
+        concrete_symbol = _require_non_empty_string(
+            self.concrete_symbol,
+            field="concrete_symbol",
+        )
+        if concrete_symbol == GENERIC_INSTRUMENT_SYMBOL:
+            raise ValueError("concrete_symbol must not use the generic INSTRUMENT slot")
+        if not isinstance(self.seen_in_training, bool):
+            raise ValueError("seen_in_training must be a boolean")
+        object.__setattr__(self, "concrete_symbol", concrete_symbol)
+
+    def digest_payload(self) -> dict[str, object]:
+        return {
+            "schema_version": SINGLE_INSTRUMENT_DEPLOYMENT_BINDING_SCHEMA,
+            "policy_digest": self.policy_digest,
+            "concrete_symbol": self.concrete_symbol,
+            "market_instrument_contract_digest": (
+                self.market_instrument_contract_digest
+            ),
+            "dataset_feature_schema_digest": self.dataset_feature_schema_digest,
+            "execution_metadata_digest": self.execution_metadata_digest,
+            "instrument_descriptor_evidence_digest": (
+                self.instrument_descriptor_evidence_digest
+            ),
+            "seen_in_training": self.seen_in_training,
+        }
+
+    @property
+    def digest(self) -> str:
+        return content_digest(self.digest_payload())
+
+    def to_json_dict(self) -> dict[str, object]:
+        payload = {**self.digest_payload(), "binding_digest": self.digest}
+        canonical_json_bytes(payload)
+        return payload
+
+    @classmethod
+    def from_json_dict(
+        cls,
+        value: Mapping[str, object],
+    ) -> SingleInstrumentDeploymentBinding:
+        if not isinstance(value, Mapping):
+            raise ValueError("single-instrument deployment binding must be a mapping")
+        payload = dict(value)
+        _require_exact_fields(
+            payload,
+            expected=_DEPLOYMENT_FIELDS,
+            field="single-instrument deployment binding",
+        )
+        if payload["schema_version"] != SINGLE_INSTRUMENT_DEPLOYMENT_BINDING_SCHEMA:
+            raise ValueError("single-instrument deployment binding schema mismatch")
+        observed_digest = _require_digest(
+            payload["binding_digest"],
+            field="binding_digest",
+        )
+        binding = cls(
+            policy_digest=payload["policy_digest"],  # type: ignore[arg-type]
+            concrete_symbol=payload["concrete_symbol"],  # type: ignore[arg-type]
+            market_instrument_contract_digest=payload[
+                "market_instrument_contract_digest"
+            ],  # type: ignore[arg-type]
+            dataset_feature_schema_digest=payload[
+                "dataset_feature_schema_digest"
+            ],  # type: ignore[arg-type]
+            execution_metadata_digest=payload[
+                "execution_metadata_digest"
+            ],  # type: ignore[arg-type]
+            instrument_descriptor_evidence_digest=payload[
+                "instrument_descriptor_evidence_digest"
+            ],  # type: ignore[arg-type]
+            seen_in_training=payload["seen_in_training"],  # type: ignore[arg-type]
+        )
+        if observed_digest != binding.digest:
+            raise ValueError("single-instrument deployment binding digest mismatch")
+        canonical_json_bytes(payload)
+        return binding
+
+
+__all__ = [
+    "SINGLE_INSTRUMENT_DEPLOYMENT_BINDING_SCHEMA",
+    "UNIVERSAL_SINGLE_INSTRUMENT_ACTION_SCHEMA",
+    "UNIVERSAL_SINGLE_INSTRUMENT_POLICY_SCHEMA",
+    "SingleInstrumentDeploymentBinding",
+    "UniversalSingleInstrumentPolicyIdentity",
+]

--- a/trade_rl/rl/universal_single_instrument_env.py
+++ b/trade_rl/rl/universal_single_instrument_env.py
@@ -1,0 +1,369 @@
+"""Episode-routed Gymnasium facade for universal single-instrument training."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any, Final, cast
+
+import gymnasium as gym
+import numpy as np
+
+from trade_rl.artifacts.hashing import content_digest
+from trade_rl.rl.actions import ActionMode, ActionSpec
+from trade_rl.rl.universal_episode_router import (
+    DeterministicBalancedInstrumentRouter,
+    InstrumentRoute,
+)
+from trade_rl.rl.universal_instrument_binding import (
+    GENERIC_INSTRUMENT_SYMBOLS,
+    GENERIC_TARGET_WEIGHT_ACTION_NAMES,
+    InstrumentDatasetBinding,
+    InstrumentEpisodeBinding,
+    validate_training_instrument_bindings,
+)
+
+INSTRUMENT_EPISODE_INFO_KEY: Final = "instrument_episode_binding"
+INSTRUMENT_EPISODE_DIGEST_INFO_KEY: Final = (
+    "instrument_episode_binding_digest"
+)
+
+ConcreteSingleInstrumentEnv = gym.Env[Any, np.ndarray]
+InstrumentEnvironmentFactory = Callable[
+    [InstrumentDatasetBinding],
+    ConcreteSingleInstrumentEnv,
+]
+
+
+def _require_non_negative_int(value: object, *, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{field} must be a non-negative integer")
+    return value
+
+
+def _episode_boundary(
+    info: Mapping[str, Any],
+    *,
+    field: str,
+) -> int:
+    if field not in info:
+        raise ValueError(f"concrete reset info is missing {field}")
+    return _require_non_negative_int(info[field], field=field)
+
+
+class EpisodeRoutedSingleInstrumentEnv(gym.Env[Any, np.ndarray]):
+    """Expose one generic action while routing complete episodes by symbol."""
+
+    metadata = {"render_modes": []}
+
+    def __init__(
+        self,
+        *,
+        train_symbols: Sequence[str],
+        partition_digest: str,
+        bindings: Sequence[InstrumentDatasetBinding],
+        environment_factory: InstrumentEnvironmentFactory,
+        run_seed: int,
+        environment_index: int,
+    ) -> None:
+        super().__init__()
+        if not callable(environment_factory):
+            raise TypeError("environment_factory must be callable")
+        self._bindings = validate_training_instrument_bindings(
+            train_symbols,
+            bindings,
+        )
+        self._router = DeterministicBalancedInstrumentRouter(
+            train_symbols=tuple(self._bindings),
+            partition_digest=partition_digest,
+            run_seed=run_seed,
+            environment_index=environment_index,
+        )
+        self._environment_factory = environment_factory
+        self._run_seed = self._router.run_seed
+        self._environment_index = self._router.environment_index
+        self._environments: dict[str, ConcreteSingleInstrumentEnv] = {}
+        self._environment_object_ids: set[int] = set()
+        self._active_environment: ConcreteSingleInstrumentEnv | None = None
+        self._active_episode_binding: InstrumentEpisodeBinding | None = None
+        self._episode_complete = True
+        self._completed_episode_count = 0
+
+        initial_route = self._router.route(0)
+        initial_environment = self._load_environment(initial_route)
+        self.observation_space = initial_environment.observation_space
+        self.action_space = cast(
+            gym.spaces.Space[np.ndarray],
+            initial_environment.action_space,
+        )
+        self.metadata = dict(
+            getattr(initial_environment, "metadata", self.metadata)
+        )
+
+    @property
+    def policy_symbols(self) -> tuple[str, ...]:
+        return GENERIC_INSTRUMENT_SYMBOLS
+
+    @property
+    def action_names(self) -> tuple[str, ...]:
+        return GENERIC_TARGET_WEIGHT_ACTION_NAMES
+
+    @property
+    def router_digest(self) -> str:
+        return self._router.digest
+
+    @property
+    def completed_episode_count(self) -> int:
+        return self._completed_episode_count
+
+    @property
+    def active_episode_binding(self) -> InstrumentEpisodeBinding:
+        binding = self._active_episode_binding
+        if binding is None:
+            raise RuntimeError("environment must be reset before binding access")
+        return binding
+
+    def _validate_concrete_environment(
+        self,
+        environment: ConcreteSingleInstrumentEnv,
+        binding: InstrumentDatasetBinding,
+    ) -> None:
+        dataset = getattr(environment, "dataset", None)
+        if dataset is None:
+            raise TypeError("concrete environment must expose its dataset")
+        raw_symbols = getattr(dataset, "symbols", None)
+        try:
+            symbols = tuple(raw_symbols)
+        except TypeError as error:
+            raise TypeError(
+                "concrete environment dataset symbols are invalid"
+            ) from error
+        if symbols != (binding.concrete_symbol,):
+            raise ValueError(
+                "concrete environment dataset symbol does not match binding"
+            )
+        if getattr(dataset, "dataset_id", None) != binding.source_dataset_id:
+            raise ValueError(
+                "concrete environment dataset identity does not match binding"
+            )
+
+        action_spec = getattr(environment, "action_spec", None)
+        if not isinstance(action_spec, ActionSpec):
+            raise TypeError("concrete environment must expose an ActionSpec")
+        if (
+            action_spec.mode is not ActionMode.TARGET_WEIGHT
+            or action_spec.target_weight_count != 1
+            or action_spec.size != 1
+        ):
+            raise ValueError(
+                "concrete environment must use one target-weight action"
+            )
+        concrete_action_names = tuple(
+            getattr(environment, "action_names", ())
+        )
+        expected_action_names = (
+            f"target_weight:{binding.concrete_symbol}",
+        )
+        if concrete_action_names != expected_action_names:
+            raise ValueError(
+                "concrete environment action names do not match binding"
+            )
+        if not isinstance(environment.action_space, gym.spaces.Box):
+            raise TypeError("concrete environment action space must be a Box")
+        if environment.action_space.shape != (1,):
+            raise ValueError(
+                "concrete environment action space must have shape (1,)"
+            )
+        if not isinstance(environment.observation_space, gym.spaces.Space):
+            raise TypeError(
+                "concrete environment observation space is invalid"
+            )
+
+    def _require_space_compatibility(
+        self,
+        environment: ConcreteSingleInstrumentEnv,
+    ) -> None:
+        if environment.observation_space != self.observation_space:
+            raise ValueError(
+                "concrete environment observation space mismatch"
+            )
+        if environment.action_space != self.action_space:
+            raise ValueError("concrete environment action space mismatch")
+
+    @staticmethod
+    def _close_rejected_environment(
+        environment: ConcreteSingleInstrumentEnv,
+    ) -> None:
+        try:
+            environment.close()
+        except Exception:
+            pass
+
+    def _load_environment(
+        self,
+        route: InstrumentRoute,
+    ) -> ConcreteSingleInstrumentEnv:
+        symbol = route.concrete_symbol
+        cached = self._environments.get(symbol)
+        if cached is not None:
+            return cached
+
+        binding = self._bindings[symbol]
+        environment = self._environment_factory(binding)
+        if not isinstance(environment, gym.Env):
+            raise TypeError(
+                "environment_factory must return a Gymnasium environment"
+            )
+        object_id = id(environment)
+        if object_id in self._environment_object_ids:
+            raise ValueError(
+                "environment_factory reused one environment across symbols"
+            )
+        try:
+            self._validate_concrete_environment(environment, binding)
+            if self._environments:
+                self._require_space_compatibility(environment)
+        except Exception:
+            self._close_rejected_environment(environment)
+            raise
+        self._environments[symbol] = environment
+        self._environment_object_ids.add(object_id)
+        return environment
+
+    def _episode_seed(
+        self,
+        *,
+        route: InstrumentRoute,
+        binding: InstrumentDatasetBinding,
+    ) -> int:
+        digest = content_digest(
+            {
+                "completed_episode_count": route.completed_episode_count,
+                "dataset_binding_digest": binding.digest,
+                "environment_index": self._environment_index,
+                "partition_digest": self._router.partition_digest,
+                "run_seed": self._run_seed,
+                "schema_version": "instrument_episode_seed_v1",
+            }
+        )
+        return int(digest[:8], 16)
+
+    @staticmethod
+    def _instrument_info(
+        info: Mapping[str, Any],
+        binding: InstrumentEpisodeBinding,
+    ) -> dict[str, Any]:
+        resolved = dict(info)
+        resolved[INSTRUMENT_EPISODE_INFO_KEY] = binding.to_json_dict()
+        resolved[INSTRUMENT_EPISODE_DIGEST_INFO_KEY] = binding.digest
+        return resolved
+
+    def reset(
+        self,
+        *,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[Any, dict[str, Any]]:
+        if not self._episode_complete:
+            raise RuntimeError(
+                "cannot reset while an active episode is routed"
+            )
+        if seed is not None:
+            resolved_seed = _require_non_negative_int(
+                seed,
+                field="seed",
+            )
+            if resolved_seed != self._run_seed:
+                raise ValueError(
+                    "reset seed must equal the immutable run_seed"
+                )
+        super().reset(seed=self._run_seed)
+
+        route = self._router.route(self._completed_episode_count)
+        environment = self._load_environment(route)
+        dataset_binding = self._bindings[route.concrete_symbol]
+        episode_seed = self._episode_seed(
+            route=route,
+            binding=dataset_binding,
+        )
+        observation, raw_info = environment.reset(
+            seed=episode_seed,
+            options=options,
+        )
+        if not isinstance(raw_info, Mapping):
+            raise TypeError(
+                "concrete environment reset info must be a mapping"
+            )
+        episode_start = _episode_boundary(
+            raw_info,
+            field="start_index",
+        )
+        episode_stop = _episode_boundary(
+            raw_info,
+            field="end_index",
+        )
+        episode_binding = InstrumentEpisodeBinding(
+            dataset_binding=dataset_binding,
+            episode_start=episode_start,
+            episode_stop=episode_stop,
+            episode_seed=episode_seed,
+            environment_index=self._environment_index,
+            completed_episode_count=route.completed_episode_count,
+            routing_cycle=route.routing_cycle,
+            routing_position=route.routing_position,
+        )
+        self._active_environment = environment
+        self._active_episode_binding = episode_binding
+        self._episode_complete = False
+        return observation, self._instrument_info(
+            raw_info,
+            episode_binding,
+        )
+
+    def step(
+        self,
+        action: np.ndarray,
+    ) -> tuple[Any, float, bool, bool, dict[str, Any]]:
+        environment = self._active_environment
+        binding = self._active_episode_binding
+        if environment is None or binding is None:
+            raise RuntimeError("environment must be reset before step")
+        if self._episode_complete:
+            raise RuntimeError(
+                "step called after the routed episode completed"
+            )
+
+        observation, reward, terminated, truncated, raw_info = environment.step(
+            action
+        )
+        if not isinstance(terminated, bool):
+            raise TypeError("terminated must be a boolean")
+        if not isinstance(truncated, bool):
+            raise TypeError("truncated must be a boolean")
+        if not isinstance(raw_info, Mapping):
+            raise TypeError(
+                "concrete environment step info must be a mapping"
+            )
+        info = self._instrument_info(raw_info, binding)
+        if terminated or truncated:
+            self._episode_complete = True
+            self._completed_episode_count += 1
+        return observation, float(reward), terminated, truncated, info
+
+    def close(self) -> None:
+        first_error: Exception | None = None
+        for environment in tuple(self._environments.values()):
+            try:
+                environment.close()
+            except Exception as error:
+                if first_error is None:
+                    first_error = error
+        if first_error is not None:
+            raise first_error
+
+
+__all__ = [
+    "INSTRUMENT_EPISODE_DIGEST_INFO_KEY",
+    "INSTRUMENT_EPISODE_INFO_KEY",
+    "EpisodeRoutedSingleInstrumentEnv",
+    "InstrumentEnvironmentFactory",
+]

--- a/trade_rl/rl/universal_single_instrument_identity.py
+++ b/trade_rl/rl/universal_single_instrument_identity.py
@@ -1,0 +1,309 @@
+"""Generic policy and concrete deployment identities for universal instruments."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Final
+
+from trade_rl.artifacts.hashing import content_digest
+from trade_rl.domain.common import require_non_empty, require_sha256
+from trade_rl.rl.universal_instrument_binding import (
+    GENERIC_INSTRUMENT_SYMBOLS,
+    GENERIC_TARGET_WEIGHT_ACTION_NAMES,
+)
+
+UNIVERSAL_SINGLE_INSTRUMENT_POLICY_SCHEMA: Final = (
+    "universal_single_instrument_policy_v1"
+)
+SINGLE_INSTRUMENT_DEPLOYMENT_BINDING_SCHEMA: Final = (
+    "single_instrument_deployment_binding_v1"
+)
+
+_POLICY_MANIFEST_KEYS: Final = frozenset(
+    {
+        "action_names",
+        "action_schema_digest",
+        "action_shape",
+        "architecture_digest",
+        "instrument_descriptor_schema_digest",
+        "normalizer_digest",
+        "observation_schema_digest",
+        "policy_symbols",
+        "reward_environment_digest",
+        "schema_version",
+        "training_catalog_digest",
+        "training_symbol_split_digest",
+        "training_symbols_digest",
+        "zero_shot_evidence_digest",
+    }
+)
+_DEPLOYMENT_BINDING_KEYS: Final = frozenset(
+    {
+        "concrete_symbol",
+        "dataset_feature_schema_digest",
+        "execution_metadata_digest",
+        "instrument_descriptor_evidence_digest",
+        "market_instrument_contract_digest",
+        "policy_digest",
+        "schema_version",
+        "seen_in_training",
+    }
+)
+
+
+def _require_string(value: object, *, field: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{field} must be a string")
+    return value
+
+
+def _require_sha256_string(value: object, *, field: str) -> str:
+    return require_sha256(_require_string(value, field=field), field=field)
+
+
+def _require_field_closure(
+    value: Mapping[str, object],
+    *,
+    expected: frozenset[str],
+    field: str,
+) -> dict[str, object]:
+    payload = dict(value)
+    if frozenset(payload) != expected:
+        raise ValueError(f"{field} field closure mismatch")
+    return payload
+
+
+@dataclass(frozen=True, slots=True)
+class UniversalSingleInstrumentPolicyManifest:
+    """Generic policy identity with no concrete ticker binding."""
+
+    architecture_digest: str
+    observation_schema_digest: str
+    action_schema_digest: str
+    instrument_descriptor_schema_digest: str
+    normalizer_digest: str
+    reward_environment_digest: str
+    training_catalog_digest: str
+    training_symbol_split_digest: str
+    training_symbols_digest: str
+    zero_shot_evidence_digest: str
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "architecture_digest",
+            "observation_schema_digest",
+            "action_schema_digest",
+            "instrument_descriptor_schema_digest",
+            "normalizer_digest",
+            "reward_environment_digest",
+            "training_catalog_digest",
+            "training_symbol_split_digest",
+            "training_symbols_digest",
+            "zero_shot_evidence_digest",
+        ):
+            raw_value = getattr(self, field_name)
+            if not isinstance(raw_value, str):
+                raise TypeError(f"{field_name} must be a string")
+            require_sha256(raw_value, field=field_name)
+
+    def to_json_dict(self) -> dict[str, object]:
+        return {
+            "action_names": list(GENERIC_TARGET_WEIGHT_ACTION_NAMES),
+            "action_schema_digest": self.action_schema_digest,
+            "action_shape": [1],
+            "architecture_digest": self.architecture_digest,
+            "instrument_descriptor_schema_digest": (
+                self.instrument_descriptor_schema_digest
+            ),
+            "normalizer_digest": self.normalizer_digest,
+            "observation_schema_digest": self.observation_schema_digest,
+            "policy_symbols": list(GENERIC_INSTRUMENT_SYMBOLS),
+            "reward_environment_digest": self.reward_environment_digest,
+            "schema_version": UNIVERSAL_SINGLE_INSTRUMENT_POLICY_SCHEMA,
+            "training_catalog_digest": self.training_catalog_digest,
+            "training_symbol_split_digest": self.training_symbol_split_digest,
+            "training_symbols_digest": self.training_symbols_digest,
+            "zero_shot_evidence_digest": self.zero_shot_evidence_digest,
+        }
+
+    @property
+    def policy_digest(self) -> str:
+        return content_digest(self.to_json_dict())
+
+    @classmethod
+    def from_json_dict(
+        cls,
+        value: Mapping[str, object],
+    ) -> UniversalSingleInstrumentPolicyManifest:
+        if not isinstance(value, Mapping):
+            raise TypeError("universal policy manifest must be a mapping")
+        payload = _require_field_closure(
+            value,
+            expected=_POLICY_MANIFEST_KEYS,
+            field="universal policy manifest",
+        )
+        if payload["schema_version"] != UNIVERSAL_SINGLE_INSTRUMENT_POLICY_SCHEMA:
+            raise ValueError("universal policy manifest schema mismatch")
+        if payload["policy_symbols"] != list(GENERIC_INSTRUMENT_SYMBOLS):
+            raise ValueError("universal policy symbols must remain generic")
+        if payload["action_names"] != list(GENERIC_TARGET_WEIGHT_ACTION_NAMES):
+            raise ValueError("universal policy action names must remain generic")
+        if payload["action_shape"] != [1]:
+            raise ValueError("universal policy action shape must be [1]")
+        return cls(
+            architecture_digest=_require_sha256_string(
+                payload["architecture_digest"],
+                field="architecture_digest",
+            ),
+            observation_schema_digest=_require_sha256_string(
+                payload["observation_schema_digest"],
+                field="observation_schema_digest",
+            ),
+            action_schema_digest=_require_sha256_string(
+                payload["action_schema_digest"],
+                field="action_schema_digest",
+            ),
+            instrument_descriptor_schema_digest=_require_sha256_string(
+                payload["instrument_descriptor_schema_digest"],
+                field="instrument_descriptor_schema_digest",
+            ),
+            normalizer_digest=_require_sha256_string(
+                payload["normalizer_digest"],
+                field="normalizer_digest",
+            ),
+            reward_environment_digest=_require_sha256_string(
+                payload["reward_environment_digest"],
+                field="reward_environment_digest",
+            ),
+            training_catalog_digest=_require_sha256_string(
+                payload["training_catalog_digest"],
+                field="training_catalog_digest",
+            ),
+            training_symbol_split_digest=_require_sha256_string(
+                payload["training_symbol_split_digest"],
+                field="training_symbol_split_digest",
+            ),
+            training_symbols_digest=_require_sha256_string(
+                payload["training_symbols_digest"],
+                field="training_symbols_digest",
+            ),
+            zero_shot_evidence_digest=_require_sha256_string(
+                payload["zero_shot_evidence_digest"],
+                field="zero_shot_evidence_digest",
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SingleInstrumentDeploymentBinding:
+    """Bind one generic policy digest to one concrete deployment instrument."""
+
+    policy_digest: str
+    concrete_symbol: str
+    market_instrument_contract_digest: str
+    dataset_feature_schema_digest: str
+    execution_metadata_digest: str
+    instrument_descriptor_evidence_digest: str
+    seen_in_training: bool
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "policy_digest",
+            "market_instrument_contract_digest",
+            "dataset_feature_schema_digest",
+            "execution_metadata_digest",
+            "instrument_descriptor_evidence_digest",
+        ):
+            raw_value = getattr(self, field_name)
+            if not isinstance(raw_value, str):
+                raise TypeError(f"{field_name} must be a string")
+            require_sha256(raw_value, field=field_name)
+        if not isinstance(self.concrete_symbol, str):
+            raise TypeError("concrete_symbol must be a string")
+        object.__setattr__(
+            self,
+            "concrete_symbol",
+            require_non_empty(
+                self.concrete_symbol,
+                field="concrete_symbol",
+            ),
+        )
+        if not isinstance(self.seen_in_training, bool):
+            raise TypeError("seen_in_training must be a boolean")
+
+    def to_json_dict(self) -> dict[str, object]:
+        return {
+            "concrete_symbol": self.concrete_symbol,
+            "dataset_feature_schema_digest": self.dataset_feature_schema_digest,
+            "execution_metadata_digest": self.execution_metadata_digest,
+            "instrument_descriptor_evidence_digest": (
+                self.instrument_descriptor_evidence_digest
+            ),
+            "market_instrument_contract_digest": (
+                self.market_instrument_contract_digest
+            ),
+            "policy_digest": self.policy_digest,
+            "schema_version": SINGLE_INSTRUMENT_DEPLOYMENT_BINDING_SCHEMA,
+            "seen_in_training": self.seen_in_training,
+        }
+
+    @property
+    def digest(self) -> str:
+        return content_digest(self.to_json_dict())
+
+    @classmethod
+    def from_json_dict(
+        cls,
+        value: Mapping[str, object],
+    ) -> SingleInstrumentDeploymentBinding:
+        if not isinstance(value, Mapping):
+            raise TypeError("single-instrument deployment binding must be a mapping")
+        payload = _require_field_closure(
+            value,
+            expected=_DEPLOYMENT_BINDING_KEYS,
+            field="single-instrument deployment binding",
+        )
+        if (
+            payload["schema_version"]
+            != SINGLE_INSTRUMENT_DEPLOYMENT_BINDING_SCHEMA
+        ):
+            raise ValueError("single-instrument deployment binding schema mismatch")
+        seen_in_training = payload["seen_in_training"]
+        if not isinstance(seen_in_training, bool):
+            raise TypeError("seen_in_training must be a boolean")
+        return cls(
+            policy_digest=_require_sha256_string(
+                payload["policy_digest"],
+                field="policy_digest",
+            ),
+            concrete_symbol=_require_string(
+                payload["concrete_symbol"],
+                field="concrete_symbol",
+            ),
+            market_instrument_contract_digest=_require_sha256_string(
+                payload["market_instrument_contract_digest"],
+                field="market_instrument_contract_digest",
+            ),
+            dataset_feature_schema_digest=_require_sha256_string(
+                payload["dataset_feature_schema_digest"],
+                field="dataset_feature_schema_digest",
+            ),
+            execution_metadata_digest=_require_sha256_string(
+                payload["execution_metadata_digest"],
+                field="execution_metadata_digest",
+            ),
+            instrument_descriptor_evidence_digest=_require_sha256_string(
+                payload["instrument_descriptor_evidence_digest"],
+                field="instrument_descriptor_evidence_digest",
+            ),
+            seen_in_training=seen_in_training,
+        )
+
+
+__all__ = [
+    "SINGLE_INSTRUMENT_DEPLOYMENT_BINDING_SCHEMA",
+    "UNIVERSAL_SINGLE_INSTRUMENT_POLICY_SCHEMA",
+    "SingleInstrumentDeploymentBinding",
+    "UniversalSingleInstrumentPolicyManifest",
+]


### PR DESCRIPTION
## Status

Superseded by and fully incorporated into PR #393, which was merged into `main` as `4fa5ada0f78c6316007d9fb7b5cfda002ee45435`.

The original head `67e68d907ea56f80d4308b169c098afc58d79c40` was verified as an ancestor of the merged `main` before this PR was closed. No work from this PR is being discarded.

## Original scope

Implement U2 of the approved Universal Single-Instrument Zero-Shot design as a stacked change on PR #385.

- implementation plan;
- RED contract tests for immutable dataset/episode bindings and deterministic balanced train-only routing;
- routing core implementation.

The completed/superseding implementation now lives on `main` via PR #393.