### PR TITLE
Unblock causal teacher training

### DIFF
--- a/scripts/monitor_universal_training.py
+++ b/scripts/monitor_universal_training.py
@@ -71,6 +71,10 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "scalar_trends": {
                     tag: asdict(trend) for tag, trend in member.scalar_trends.items()
                 },
+                "telemetry_trends": {
+                    field: asdict(trend)
+                    for field, trend in member.telemetry_trends.items()
+                },
             }
             for member in snapshot.members
         ],

--- a/tests/integrations/test_sb3_universal_pretraining_hook.py
+++ b/tests/integrations/test_sb3_universal_pretraining_hook.py
@@ -89,6 +89,28 @@ def test_universal_pretraining_hook_accepts_causal_trend_teacher(
     assert result["passed"] is True
 
 
+def test_universal_pretraining_hook_accepts_causal_alpha_teacher(
+    tmp_path: Path,
+) -> None:
+    result = sb3_training._apply_universal_pretraining_if_configured(
+        hook=lambda **_: {
+            "schema_version": "universal_pretraining_evidence_v1",
+            "passed": True,
+            "teacher_artifact_digest": "a" * 64,
+            "behavior_cloning_digest": "b" * 64,
+            "critic_warm_start_digest": None,
+        },
+        policy=_SavablePolicy(),
+        config=_config(behavior_cloning_teacher="causal_alpha_ridge"),
+        behavior_cloning_seed=13,
+        member_seed=7,
+        output_root=tmp_path,
+    )
+
+    assert result is not None
+    assert result["passed"] is True
+
+
 def test_universal_pretraining_hook_rejects_failed_evidence(tmp_path: Path) -> None:
     def hook(**kwargs: object) -> dict[str, object]:
         del kwargs

--- a/tests/integrations/test_training_telemetry.py
+++ b/tests/integrations/test_training_telemetry.py
@@ -137,6 +137,8 @@ def test_sampler_skips_unimportant_steps_and_preserves_position_risk_and_termina
     assert page.items[0].interval_gross_return == pytest.approx(0.0013)
     assert page.items[0].baseline_excess_return == pytest.approx(0.0008)
     assert page.items[0].target_delta_l1 == pytest.approx(0.2)
+    assert page.items[0].command_target_delta_l1 == pytest.approx(0.2)
+    assert page.items[0].command_target_sign_flip_count == 0
 
 
 def test_sampler_accepts_torch_rollout_tensors(tmp_path: Path) -> None:

--- a/tests/operations/test_universal_training_monitor.py
+++ b/tests/operations/test_universal_training_monitor.py
@@ -44,6 +44,16 @@ def _generation(
                     "baseline_portfolio_value": 100_000,
                     "drawdown": drawdown,
                     "interval_cost": 0.001,
+                    "interval_gross_return": reward + 0.01,
+                    "baseline_excess_return": reward - 0.05,
+                    "filled_turnover": 5.0 - step,
+                    "fill_count": 5 - step,
+                    "target_delta_l1": 0.5 - step * 0.05,
+                    "sign_flip_count": 5 - step,
+                    "command_target_delta_l1": 0.6 - step * 0.05,
+                    "command_target_sign_flip_count": 5 - step,
+                    "gross_pnl": reward * 100.0,
+                    "net_pnl": reward * 90.0,
                 }
             )
             for step, reward, drawdown in (
@@ -84,6 +94,12 @@ def test_monitor_reports_reward_components_and_training_health(tmp_path: Path) -
     assert member.drawdown.direction == "improving"
     assert member.telemetry_records == 4
     assert member.per_symbol_counts == {"BTCUSDT": 4}
+    assert member.telemetry_trends["baseline_excess_return"].direction == "improving"
+    assert member.telemetry_trends["filled_turnover"].direction == "improving"
+    assert member.telemetry_trends["gross_pnl"].count == 4
+    assert member.telemetry_trends["net_pnl"].count == 4
+    assert member.telemetry_trends["sign_flip_count"].direction == "improving"
+    assert member.telemetry_trends["command_target_delta_l1"].direction == "improving"
     assert snapshot.status == "healthy"
 
 
@@ -101,3 +117,56 @@ def test_monitor_fails_closed_on_oom_log(tmp_path: Path) -> None:
     )
     assert snapshot.status == "failed"
     assert any("oom" in item.lower() for item in snapshot.findings)
+
+
+def test_telemetry_trend_sampling_stays_bounded(monkeypatch, tmp_path: Path) -> None:
+    import trade_rl.operations.universal_training_monitor as module
+
+    monkeypatch.setattr(module, "MAX_TELEMETRY_TREND_POINTS", 3, raising=False)
+    member = tmp_path / "member"
+    member.mkdir()
+    (member / "telemetry.jsonl").write_text(
+        "".join(
+            json.dumps(
+                {
+                    "global_step": step,
+                    "reward": float(step),
+                    "symbol": "BTCUSDT",
+                }
+            )
+            + "\n"
+            for step in range(10)
+        ),
+        encoding="utf-8",
+    )
+
+    count, _, points, nonfinite = module._telemetry(member)
+
+    assert count == 10
+    assert nonfinite == 0
+    assert len(points["reward"]) <= 3
+    assert points["reward"][0] == (0, 0.0)
+    assert points["reward"][-1] == (9, 9.0)
+
+
+def test_monitor_reports_teacher_progress_before_member_heartbeat(
+    tmp_path: Path,
+) -> None:
+    teacher_root = tmp_path / "_shared-causal-teacher"
+    teacher_root.mkdir()
+    progress = {
+        "completed_replays": 17,
+        "phase": "causal_teacher_selection",
+        "symbol": "BTCUSDT",
+        "total_replays": 100,
+    }
+    (teacher_root / "causal-teacher-progress.json").write_text(
+        json.dumps(progress),
+        encoding="utf-8",
+    )
+
+    snapshot = inspect_universal_training_generation(tmp_path, now=NOW)
+
+    assert snapshot.status == "incomplete"
+    assert snapshot.teacher_progress == progress
+    assert snapshot.findings == ("causal teacher selection in progress 17/100",)

--- a/tests/workflows/test_universal_causal_alpha_assembly.py
+++ b/tests/workflows/test_universal_causal_alpha_assembly.py
@@ -62,7 +62,9 @@ def _training() -> ResidualTrainingConfig:
     )
 
 
-def test_assemble_routes_causal_teacher_through_shared_package(monkeypatch) -> None:
+def test_assemble_routes_causal_teacher_through_shared_package(
+    monkeypatch, tmp_path
+) -> None:
     import trade_rl.workflows.universal_training_runner as module
     from trade_rl.workflows.universal_training_runner import (
         assemble_universal_sb3_training_backend,
@@ -123,6 +125,7 @@ def test_assemble_routes_causal_teacher_through_shared_package(monkeypatch) -> N
         fold_train_range=(19, 211),
         normalizer_digest=_digest("normalizer"),
         feature_schema_digest=_digest("features"),
+        causal_teacher_evidence_root=tmp_path,
     )
 
     assert actual_bundle is bundle
@@ -132,6 +135,9 @@ def test_assemble_routes_causal_teacher_through_shared_package(monkeypatch) -> N
     assert package_kwargs["bindings"] == routed.bindings
     assert package_kwargs["fold_train_range"] == (19, 211)
     assert package_kwargs["feature_schema_digest"] == _digest("features")
+    assert package_kwargs["selection_evidence_path"] == (
+        tmp_path / "causal-teacher-selection.json"
+    )
     bundle_kwargs = observed["bundle_kwargs"]
     assert isinstance(bundle_kwargs, dict)
     assert bundle_kwargs["batches"] == package.batches

--- a/tests/workflows/test_universal_causal_alpha_fitting.py
+++ b/tests/workflows/test_universal_causal_alpha_fitting.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+import trade_rl.workflows.universal_causal_alpha_teacher as causal_alpha_module
 from trade_rl.artifacts.hashing import content_digest
 from trade_rl.learning.causal_alpha_teacher import (
     CausalAlphaControllerConfig,
@@ -64,6 +65,28 @@ def test_expanding_fit_uses_only_labels_realized_before_episode_start() -> None:
     assert fitted.train_symbols == ("AAAUSDT", "BBBUSDT")
 
 
+def test_expanding_fit_cache_reuses_identical_scope_cutoff_and_ridge() -> None:
+    blocks = {
+        "AAAUSDT": _samples("AAAUSDT", 0.0),
+        "BBBUSDT": _samples("BBBUSDT", 10.0),
+    }
+    assert hasattr(causal_alpha_module, "CausalAlphaExpandingFitCache")
+    cache_type = causal_alpha_module.CausalAlphaExpandingFitCache
+    cache = cache_type(
+        train_symbols=("AAAUSDT", "BBBUSDT"),
+        samples=blocks,
+    )
+    config = CausalAlphaRidgeConfig(ridge_strength=0.1)
+
+    first = cache.resolve(knowledge_cutoff=16, ridge_config=config)
+    second = cache.resolve(knowledge_cutoff=16, ridge_config=config)
+
+    assert second is first
+    assert cache.fit_count == 1
+    assert cache.hit_count == 1
+    assert cache.entry_count == 1
+
+
 def test_expanding_fit_scope_is_exactly_train_symbols() -> None:
     blocks = {
         "AAAUSDT": _samples("AAAUSDT", 0.0),
@@ -105,6 +128,10 @@ def test_episode_batch_fits_each_episode_at_its_own_cutoff_and_preserves_initial
 ):
     symbol = "AAAUSDT"
     samples = {symbol: _samples(symbol, 0.0)}
+    fit_cache = causal_alpha_module.CausalAlphaExpandingFitCache(
+        train_symbols=(symbol,),
+        samples=samples,
+    )
     controller = CausalAlphaControllerConfig(
         horizon_mix=CausalAlphaHorizonMix.EQUAL,
         score_scale=2.0,
@@ -120,6 +147,7 @@ def test_episode_batch_fits_each_episode_at_its_own_cutoff_and_preserves_initial
         partition=_partition(symbol),
         ridge_config=CausalAlphaRidgeConfig(ridge_strength=0.1),
         controller_config=controller,
+        fit_cache=fit_cache,
     )
 
     assert batch.contracts == _partition(symbol).contracts
@@ -135,6 +163,7 @@ def test_episode_batch_fits_each_episode_at_its_own_cutoff_and_preserves_initial
     assert batch.targets[1].shape == (4, 1)
     assert evidence.episodes[1].initial_weight == pytest.approx(0.25)
     assert batch.teacher_config_digest == evidence.digest
+    assert fit_cache.fit_count == 2
 
 
 def test_sample_identity_drift_changes_fit_digest() -> None:

--- a/tests/workflows/test_universal_causal_alpha_package.py
+++ b/tests/workflows/test_universal_causal_alpha_package.py
@@ -106,7 +106,13 @@ def test_package_builds_one_shared_teacher_identity(
 
     def build_samples(**kwargs):
         binding = kwargs["binding"]
-        value = SimpleNamespace(digest=_digest(f"samples:{binding.concrete_symbol}"))
+        value = SimpleNamespace(
+            digest=_digest(f"samples:{binding.concrete_symbol}"),
+            context_digest=_digest(f"context:{binding.concrete_symbol}"),
+            feature_schema_digest=_digest("feature-schema"),
+            reference_equity=100_000.0,
+            reference_equity_mode="fixed",
+        )
         samples[binding.concrete_symbol] = value
         return value
 
@@ -140,10 +146,21 @@ def test_package_builds_one_shared_teacher_identity(
         "default_causal_alpha_candidate_grid",
         lambda _risk: (candidate,),
     )
+    progress_payload = {
+        "completed_replays": 1,
+        "phase": "causal_teacher_selection",
+        "total_replays": 1,
+    }
+
+    def evaluate_selection(**kwargs):
+        kwargs["progress_callback"](progress_payload)
+        return selection
+
+    monkeypatch.setattr(module, "evaluate_causal_alpha_selection", evaluate_selection)
     monkeypatch.setattr(
         module,
-        "evaluate_causal_alpha_selection",
-        lambda **_kwargs: selection,
+        "CausalAlphaExpandingFitCache",
+        lambda **_kwargs: object(),
     )
 
     batch_calls: list[tuple[str, str]] = []
@@ -152,13 +169,20 @@ def test_package_builds_one_shared_teacher_identity(
         shared_digest = kwargs["teacher_config_digest"]
         symbol = kwargs["symbol"]
         batch_calls.append((symbol, shared_digest))
+        evidence_payload = {
+            "artifact_digest": _digest(f"evidence:{symbol}"),
+            "schema_version": "test_batch_evidence_v1",
+        }
         return (
             SimpleNamespace(
                 dataset_id=_digest(f"dataset:{symbol}"),
                 teacher_config_digest=shared_digest,
                 digest=_digest(f"batch:{symbol}"),
             ),
-            SimpleNamespace(digest=_digest(f"evidence:{symbol}")),
+            SimpleNamespace(
+                digest=evidence_payload["artifact_digest"],
+                to_payload=lambda payload=evidence_payload: dict(payload),
+            ),
         )
 
     monkeypatch.setattr(module, "build_causal_alpha_episode_batch", build_batch)
@@ -222,4 +246,20 @@ def test_package_builds_one_shared_teacher_identity(
     assert all(
         batch.teacher_config_digest == package.teacher_config_digest
         for batch in package.batches.values()
+    )
+    admission_path = tmp_path / "causal-teacher-admission.json"
+    package_path = tmp_path / "causal-teacher-package.json"
+    progress_path = tmp_path / "causal-teacher-progress.json"
+    assert json.loads(progress_path.read_text(encoding="utf-8")) == {
+        **progress_payload,
+        "package_digest": package.digest,
+        "phase": "causal_teacher_package_completed",
+        "teacher_admission_digest": admission.digest,
+        "teacher_admission_passed": True,
+    }
+    assert json.loads(admission_path.read_text(encoding="utf-8")) == (
+        admission.to_payload()
+    )
+    assert json.loads(package_path.read_text(encoding="utf-8")) == (
+        package.to_payload()
     )

--- a/tests/workflows/test_universal_causal_alpha_selection.py
+++ b/tests/workflows/test_universal_causal_alpha_selection.py
@@ -16,6 +16,7 @@ from trade_rl.workflows.universal_causal_alpha_teacher import (
     CausalAlphaCandidateConfig,
     CausalAlphaCandidateEpisodeMetrics,
     CausalAlphaEpisodePartition,
+    CausalAlphaExpandingFitCache,
     CausalAlphaSymbolSamples,
     evaluate_causal_alpha_selection,
     rank_causal_alpha_candidates,
@@ -184,12 +185,12 @@ def _partition(symbol: str) -> CausalAlphaEpisodePartition:
             initial_state_mode="cash",
             initial_weights=np.zeros(1, dtype=np.float64),
         )
-        for index, start in enumerate((10, 20))
+        for index, start in enumerate((8, 14, 20))
     )
     return CausalAlphaEpisodePartition(
         contracts=contracts,
-        selection_contracts=(contracts[0],),
-        holdout_contract=contracts[1],
+        selection_contracts=contracts[:2],
+        holdout_contract=contracts[2],
         train_start=2,
         train_stop=25,
     )
@@ -201,11 +202,18 @@ def test_production_selection_replays_only_selection_contracts(monkeypatch) -> N
     symbols = ("AAAUSDT", "BBBUSDT")
     samples = {symbol: _samples(symbol) for symbol in symbols}
     partitions = {symbol: _partition(symbol) for symbol in symbols}
-    candidate = _candidate("selected")
+    candidates = (_candidate("selected"), _candidate("alternate", scale=2.0))
+    fit_cache = CausalAlphaExpandingFitCache(
+        train_symbols=symbols,
+        samples=samples,
+    )
     evaluated: list[tuple[str, int, int]] = []
+    opened: list[str] = []
+    closed: list[str] = []
+    progress: list[dict[str, object]] = []
 
-    def evaluate(environment_factory, contract, *, actions):
-        symbol = environment_factory().symbol
+    def evaluate(environment, contract, *, actions):
+        symbol = environment.symbol
         assert contract != partitions[symbol].holdout_contract
         evaluated.append((symbol, contract.episode_index, len(actions)))
         return SimpleNamespace(
@@ -219,26 +227,73 @@ def test_production_selection_replays_only_selection_contracts(monkeypatch) -> N
             collapse_evidence=SimpleNamespace(execution_rejection_count=0),
         )
 
-    monkeypatch.setattr(module, "evaluate_episode_action_path", evaluate)
+    monkeypatch.setattr(
+        module,
+        "evaluate_episode_action_path_on_environment",
+        evaluate,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        module,
+        "evaluate_episode_action_path",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("selection must reuse one open environment per symbol")
+        ),
+    )
+
+    def environment_factory(symbol: str):
+        opened.append(symbol)
+        return SimpleNamespace(
+            symbol=symbol,
+            close=lambda: closed.append(symbol),
+        )
+
     selection = evaluate_causal_alpha_selection(
         train_symbols=symbols,
         samples=samples,
         partitions=partitions,
-        candidates=(candidate,),
+        candidates=candidates,
         environment_factories={
-            symbol: (lambda symbol=symbol: SimpleNamespace(symbol=symbol))
+            symbol: (lambda symbol=symbol: environment_factory(symbol))
             for symbol in symbols
         },
         episode_hours=720.0,
+        fit_cache=fit_cache,
+        progress_callback=lambda payload: progress.append(dict(payload)),
     )
 
-    assert evaluated == [("AAAUSDT", 0, 4), ("BBBUSDT", 0, 4)]
-    assert selection.selected_candidate_digest == candidate.digest
+    assert set(evaluated) == {
+        ("AAAUSDT", 0, 4),
+        ("AAAUSDT", 1, 4),
+        ("BBBUSDT", 0, 4),
+        ("BBBUSDT", 1, 4),
+    }
+    assert len(evaluated) == 8
+    assert selection.selected_candidate_digest in {
+        candidate.digest for candidate in candidates
+    }
     assert selection.holdout_episode_digests == {
         symbol: partitions[symbol].holdout_contract.digest for symbol in symbols
     }
     assert all(
-        record.episode_index == 0
+        record.episode_index in {0, 1}
         for item in selection.candidates
         for record in item.episode_metrics
     )
+    assert fit_cache.fit_count == 2
+    assert fit_cache.hit_count == 6
+    assert opened == list(symbols)
+    assert closed == list(symbols)
+    assert progress[-1] == {
+        "candidate_digest": candidates[-1].digest,
+        "completed_replays": 8,
+        "episode_index": partitions[symbols[-1]].selection_contracts[-1].episode_index,
+        "fit_cache_entries": 2,
+        "fit_cache_hits": 6,
+        "fit_count": 2,
+        "phase": "causal_teacher_selection",
+        "prediction_cache_hits": 4,
+        "prediction_count": 4,
+        "symbol": symbols[-1],
+        "total_replays": 8,
+    }

--- a/trade_rl/integrations/sb3_universal_pretraining.py
+++ b/trade_rl/integrations/sb3_universal_pretraining.py
@@ -36,7 +36,11 @@ def _apply_universal_pretraining_if_configured(
         raise ValueError(
             "Universal pretraining requires behavior cloning to be enabled"
         )
-    if config.behavior_cloning_teacher not in {"oracle", "trend_baseline"}:
+    if config.behavior_cloning_teacher not in {
+        "oracle",
+        "trend_baseline",
+        "causal_alpha_ridge",
+    }:
         raise ValueError("Universal pretraining teacher is unsupported")
     if not callable(hook):
         raise TypeError("Universal pretraining hook must be callable")

--- a/trade_rl/learning/episode_oracle_bc.py
+++ b/trade_rl/learning/episode_oracle_bc.py
@@ -208,18 +208,35 @@ def evaluate_episode_action_path(
 ) -> ActionPathEvaluation:
     environment = environment_factory()
     try:
-        wrapped = _InitialStateEvaluationEnvironment(
+        return evaluate_episode_action_path_on_environment(
             environment,
-            contract.initial_state_mode,
-        )
-        return evaluate_action_path(
-            wrapped,
-            evaluation_range=(contract.start, contract.stop),
+            contract,
             actions=actions,
             model=model,
         )
     finally:
         environment.close()
+
+
+def evaluate_episode_action_path_on_environment(
+    environment: Any,
+    contract: OracleEpisodeContract,
+    *,
+    actions: object | None = None,
+    model: object | None = None,
+) -> ActionPathEvaluation:
+    """Evaluate an episode without taking ownership of the environment lifecycle."""
+
+    wrapped = _InitialStateEvaluationEnvironment(
+        environment,
+        contract.initial_state_mode,
+    )
+    return evaluate_action_path(
+        wrapped,
+        evaluation_range=(contract.start, contract.stop),
+        actions=actions,
+        model=model,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -628,6 +645,7 @@ __all__ = [
     "EpisodeBehaviorCloningRecord",
     "aggregate_episode_behavior_cloning_holdouts",
     "evaluate_episode_action_path",
+    "evaluate_episode_action_path_on_environment",
     "evaluate_episode_behavior_cloning_holdout",
     "oracle_episode_sampling_config",
     "resolve_episode_initial_weights",

--- a/trade_rl/operations/universal_training_monitor.py
+++ b/trade_rl/operations/universal_training_monitor.py
@@ -39,6 +39,34 @@ TRAIN_TAGS = (
     "train/entropy_loss",
     "train/std",
 )
+TELEMETRY_TREND_FIELDS = (
+    "reward",
+    "portfolio_value",
+    "baseline_portfolio_value",
+    "drawdown",
+    "interval_cost",
+    "interval_return",
+    "filled_turnover",
+    "fill_count",
+    "interval_gross_return",
+    "baseline_excess_return",
+    "target_delta_l1",
+    "sign_flip_count",
+    "command_target_delta_l1",
+    "command_target_sign_flip_count",
+    "gross_pnl",
+    "net_pnl",
+)
+TELEMETRY_LOWER_IS_BETTER = {
+    "drawdown",
+    "interval_cost",
+    "filled_turnover",
+    "target_delta_l1",
+    "sign_flip_count",
+    "command_target_delta_l1",
+    "command_target_sign_flip_count",
+}
+MAX_TELEMETRY_TREND_POINTS = 4_096
 
 
 @dataclass(frozen=True, slots=True)
@@ -66,6 +94,7 @@ class UniversalTrainingMemberSnapshot:
     reward_growth: ScalarTrend
     drawdown: ScalarTrend
     scalar_trends: dict[str, ScalarTrend]
+    telemetry_trends: dict[str, ScalarTrend]
     telemetry_records: int
     per_symbol_counts: dict[str, int]
     checkpoint_count: int
@@ -80,6 +109,7 @@ class UniversalTrainingSnapshot:
     inspected_at: str
     status: str
     members: tuple[UniversalTrainingMemberSnapshot, ...]
+    teacher_progress: dict[str, object] | None
     findings: tuple[str, ...]
 
     def to_json_dict(self) -> dict[str, object]:
@@ -153,40 +183,49 @@ def _tensorboard_scalars(
     return values, nonfinite
 
 
-def _telemetry(member: Path) -> tuple[int, dict[str, int], int]:
+def _telemetry(
+    member: Path,
+) -> tuple[int, dict[str, int], dict[str, list[tuple[int, float]]], int]:
     path = member / "telemetry.jsonl"
     if not path.is_file():
-        return 0, {}, 0
+        return 0, {}, {}, 0
     count = 0
     nonfinite = 0
     symbols: Counter[str] = Counter()
-    for line in path.read_text(encoding="utf-8").splitlines():
-        if not line.strip():
-            continue
-        count += 1
-        try:
-            payload = json.loads(line)
-        except json.JSONDecodeError:
-            nonfinite += 1
-            continue
-        symbol = payload.get("symbol")
-        if isinstance(symbol, str) and symbol:
-            symbols[symbol] += 1
-        for key in (
-            "reward",
-            "portfolio_value",
-            "baseline_portfolio_value",
-            "drawdown",
-            "interval_cost",
-        ):
-            value = payload.get(key)
-            if (
-                isinstance(value, (int, float))
-                and not isinstance(value, bool)
-                and not math.isfinite(float(value))
-            ):
+    trends: dict[str, list[tuple[int, float]]] = {}
+    with path.open("r", encoding="utf-8") as telemetry_file:
+        for line in telemetry_file:
+            if not line.strip():
+                continue
+            count += 1
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
                 nonfinite += 1
-    return count, dict(sorted(symbols.items())), nonfinite
+                continue
+            symbol = payload.get("symbol")
+            if isinstance(symbol, str) and symbol:
+                symbols[symbol] += 1
+            raw_step = payload.get("global_step")
+            step = (
+                int(raw_step)
+                if isinstance(raw_step, int) and not isinstance(raw_step, bool)
+                else count
+            )
+            for key in TELEMETRY_TREND_FIELDS:
+                value = payload.get(key)
+                if not isinstance(value, (int, float)) or isinstance(value, bool):
+                    continue
+                number = float(value)
+                if not math.isfinite(number):
+                    nonfinite += 1
+                    continue
+                points = trends.setdefault(key, [])
+                points.append((step, number))
+                overflow = len(points) - MAX_TELEMETRY_TREND_POINTS
+                if overflow > 0:
+                    del points[1 : 1 + overflow]
+    return count, dict(sorted(symbols.items())), trends, nonfinite
 
 
 def _member_snapshot(member: Path, *, now: datetime) -> UniversalTrainingMemberSnapshot:
@@ -197,7 +236,9 @@ def _member_snapshot(member: Path, *, now: datetime) -> UniversalTrainingMemberS
     if now - updated > timedelta(minutes=30):
         findings.append("stale training heartbeat")
     scalars, scalar_nonfinite = _tensorboard_scalars(member)
-    telemetry_records, symbol_counts, telemetry_nonfinite = _telemetry(member)
+    telemetry_records, symbol_counts, telemetry_points, telemetry_nonfinite = (
+        _telemetry(member)
+    )
     nonfinite = scalar_nonfinite + telemetry_nonfinite
     if nonfinite:
         findings.append(f"non-finite evidence count={nonfinite}")
@@ -212,6 +253,13 @@ def _member_snapshot(member: Path, *, now: datetime) -> UniversalTrainingMemberS
             in {"trade_rl/drawdown_mean", "trade_rl/interval_cost_mean"},
         )
         for tag, points in scalars.items()
+    }
+    telemetry_trends = {
+        field: _trend(
+            points,
+            lower_is_better=field in TELEMETRY_LOWER_IS_BETTER,
+        )
+        for field, points in telemetry_points.items()
     }
     reward_total = trends.get("trade_rl/reward_mean", ScalarTrend())
     reward_growth = trends.get("trade_rl/reward_growth_raw_mean", ScalarTrend())
@@ -228,6 +276,7 @@ def _member_snapshot(member: Path, *, now: datetime) -> UniversalTrainingMemberS
         reward_growth=reward_growth,
         drawdown=drawdown,
         scalar_trends=trends,
+        telemetry_trends=telemetry_trends,
         telemetry_records=telemetry_records,
         per_symbol_counts=symbol_counts,
         checkpoint_count=len(checkpoints),
@@ -269,6 +318,20 @@ def inspect_universal_training_generation(
             findings.append(
                 f"container exited with code {container_state.get('ExitCode')}"
             )
+    teacher_progress: dict[str, object] | None = None
+    teacher_progress_path = (
+        generation / "_shared-causal-teacher" / "causal-teacher-progress.json"
+    )
+    if teacher_progress_path.is_file():
+        try:
+            raw_teacher_progress = json.loads(
+                teacher_progress_path.read_text(encoding="utf-8")
+            )
+            if not isinstance(raw_teacher_progress, dict):
+                raise TypeError("teacher progress must be an object")
+            teacher_progress = raw_teacher_progress
+        except (OSError, TypeError, json.JSONDecodeError) as error:
+            findings.append(f"invalid causal teacher progress: {error}")
     members: list[UniversalTrainingMemberSnapshot] = []
     for heartbeat in sorted(generation.glob("*/seed-*/training-heartbeat.json")):
         try:
@@ -276,7 +339,12 @@ def inspect_universal_training_generation(
         except (OSError, ValueError, TypeError, json.JSONDecodeError) as error:
             findings.append(f"invalid member evidence {heartbeat.parent}: {error}")
     if not members:
-        findings.append("no member heartbeat evidence")
+        if teacher_progress is None:
+            findings.append("no member heartbeat evidence")
+        else:
+            completed = teacher_progress.get("completed_replays", 0)
+            total = teacher_progress.get("total_replays", 0)
+            findings.append(f"causal teacher selection in progress {completed}/{total}")
     findings.extend(item for member in members for item in member.findings)
     status = "healthy"
     if findings:
@@ -286,6 +354,7 @@ def inspect_universal_training_generation(
         inspected_at=current.isoformat(),
         status=status,
         members=tuple(members),
+        teacher_progress=teacher_progress,
         findings=tuple(findings),
     )
 

--- a/trade_rl/rl/training_telemetry.py
+++ b/trade_rl/rl/training_telemetry.py
@@ -245,6 +245,7 @@ class TrainingTelemetrySampler:
         self.disabled = False
         self.last_error: str | None = None
         self._previous_weights: dict[int, tuple[float, ...]] = {}
+        self._previous_submitted_targets: dict[int, tuple[float, ...]] = {}
         self._previous_close: dict[int, float] = {}
         self._episode_ids: dict[int, int] = {}
         self._next_episode_id = self.sequence + 1
@@ -261,6 +262,7 @@ class TrainingTelemetrySampler:
     def _finish_episode(self, environment_id: int) -> None:
         self._episode_ids.pop(environment_id, None)
         self._previous_weights.pop(environment_id, None)
+        self._previous_submitted_targets.pop(environment_id, None)
         self._previous_close.pop(environment_id, None)
 
     def _weights(
@@ -347,6 +349,47 @@ class TrainingTelemetrySampler:
                     info,
                     environment_id,
                 )
+                submitted_target = _vector(
+                    info.get("submitted_target"),
+                    fallback=_vector(
+                        info.get("executed_target"),
+                        fallback=weights_after,
+                    ),
+                )
+                previous_submitted_target = self._previous_submitted_targets.get(
+                    environment_id
+                )
+                command_target_delta_l1 = (
+                    float(
+                        sum(
+                            abs(current - previous)
+                            for previous, current in zip(
+                                previous_submitted_target,
+                                submitted_target,
+                                strict=True,
+                            )
+                        )
+                    )
+                    if previous_submitted_target is not None
+                    and len(previous_submitted_target) == len(submitted_target)
+                    else None
+                )
+                command_target_sign_flip_count = (
+                    sum(
+                        1
+                        for previous, current in zip(
+                            previous_submitted_target,
+                            submitted_target,
+                            strict=True,
+                        )
+                        if previous * current < 0.0
+                    )
+                    if previous_submitted_target is not None
+                    and len(previous_submitted_target) == len(submitted_target)
+                    else None
+                )
+                if submitted_target:
+                    self._previous_submitted_targets[environment_id] = submitted_target
                 reasons = _risk_reasons(info)
                 done = (
                     bool(done_rows[environment_id])
@@ -513,6 +556,8 @@ class TrainingTelemetrySampler:
                         ),
                         target_delta_l1=target_delta_l1,
                         sign_flip_count=sign_flip_count,
+                        command_target_delta_l1=command_target_delta_l1,
+                        command_target_sign_flip_count=(command_target_sign_flip_count),
                         gross_pnl=(
                             starting_value * gross_return
                             if starting_value is not None and gross_return is not None

--- a/trade_rl/studio/telemetry.py
+++ b/trade_rl/studio/telemetry.py
@@ -65,6 +65,8 @@ class TelemetryRecordResponse(StudioModel):
     baseline_excess_return: float | None = None
     target_delta_l1: float | None = None
     sign_flip_count: int | None = Field(default=None, ge=0)
+    command_target_delta_l1: float | None = None
+    command_target_sign_flip_count: int | None = Field(default=None, ge=0)
     gross_pnl: float | None = None
     net_pnl: float | None = None
     risk_reasons: tuple[str, ...]

--- a/trade_rl/telemetry/training.py
+++ b/trade_rl/telemetry/training.py
@@ -153,6 +153,8 @@ class TrainingTelemetryRecord:
     baseline_excess_return: float | None = None
     target_delta_l1: float | None = None
     sign_flip_count: int | None = None
+    command_target_delta_l1: float | None = None
+    command_target_sign_flip_count: int | None = None
     gross_pnl: float | None = None
     net_pnl: float | None = None
     schema_version: str = TELEMETRY_SCHEMA_VERSION
@@ -188,6 +190,7 @@ class TrainingTelemetryRecord:
         for name, count in (
             ("fill_count", self.fill_count),
             ("sign_flip_count", self.sign_flip_count),
+            ("command_target_sign_flip_count", self.command_target_sign_flip_count),
         ):
             if count is not None and (
                 isinstance(count, bool) or not isinstance(count, int) or count < 0
@@ -220,6 +223,7 @@ class TrainingTelemetryRecord:
             ("interval_gross_return", self.interval_gross_return),
             ("baseline_excess_return", self.baseline_excess_return),
             ("target_delta_l1", self.target_delta_l1),
+            ("command_target_delta_l1", self.command_target_delta_l1),
             ("gross_pnl", self.gross_pnl),
             ("net_pnl", self.net_pnl),
         ):
@@ -270,6 +274,8 @@ class TrainingTelemetryRecord:
             "baseline_excess_return": self.baseline_excess_return,
             "target_delta_l1": self.target_delta_l1,
             "sign_flip_count": self.sign_flip_count,
+            "command_target_delta_l1": self.command_target_delta_l1,
+            "command_target_sign_flip_count": self.command_target_sign_flip_count,
             "gross_pnl": self.gross_pnl,
             "net_pnl": self.net_pnl,
             "risk_reasons": list(self.risk_reasons),
@@ -328,6 +334,10 @@ class TrainingTelemetryRecord:
             baseline_excess_return=_optional_float(raw, "baseline_excess_return"),
             target_delta_l1=_optional_float(raw, "target_delta_l1"),
             sign_flip_count=_optional_int(raw, "sign_flip_count"),
+            command_target_delta_l1=_optional_float(raw, "command_target_delta_l1"),
+            command_target_sign_flip_count=_optional_int(
+                raw, "command_target_sign_flip_count"
+            ),
             gross_pnl=_optional_float(raw, "gross_pnl"),
             net_pnl=_optional_float(raw, "net_pnl"),
             risk_reasons=_string_tuple(raw, "risk_reasons"),

--- a/trade_rl/workflows/universal_causal_alpha_fitting.py
+++ b/trade_rl/workflows/universal_causal_alpha_fitting.py
@@ -465,6 +465,115 @@ def _validated_sample_scope(
     return symbols, blocks, scope_digest
 
 
+class CausalAlphaExpandingFitCache:
+    """Reuse pooled train-symbol arrays and expanding fits within one package build."""
+
+    __slots__ = (
+        "_available",
+        "_blocks",
+        "_cache",
+        "_ends_24h",
+        "_ends_72h",
+        "_features",
+        "_labels_24h",
+        "_labels_72h",
+        "_scope_digest",
+        "_symbols",
+        "fit_count",
+        "hit_count",
+    )
+
+    def __init__(
+        self,
+        *,
+        train_symbols: tuple[str, ...],
+        samples: Mapping[str, CausalAlphaSymbolSamples],
+    ) -> None:
+        symbols, blocks, scope_digest = _validated_sample_scope(
+            train_symbols,
+            samples,
+        )
+        self._symbols = symbols
+        self._blocks = blocks
+        self._scope_digest = scope_digest
+        self._features = np.concatenate(
+            tuple(block.features for block in blocks), axis=0
+        )
+        self._available = np.concatenate(
+            tuple(block.feature_available for block in blocks), axis=0
+        )
+        self._labels_24h = np.concatenate(
+            tuple(block.labels_24h for block in blocks), axis=0
+        )
+        self._labels_72h = np.concatenate(
+            tuple(block.labels_72h for block in blocks), axis=0
+        )
+        self._ends_24h = np.concatenate(
+            tuple(block.label_end_indices_24h for block in blocks)
+        )
+        self._ends_72h = np.concatenate(
+            tuple(block.label_end_indices_72h for block in blocks)
+        )
+        self._cache: dict[tuple[int, str], CausalAlphaExpandingFit] = {}
+        self.fit_count = 0
+        self.hit_count = 0
+
+    @property
+    def entry_count(self) -> int:
+        return len(self._cache)
+
+    @property
+    def sample_scope_digest(self) -> str:
+        return self._scope_digest
+
+    def resolve(
+        self,
+        *,
+        knowledge_cutoff: int,
+        ridge_config: CausalAlphaRidgeConfig,
+    ) -> CausalAlphaExpandingFit:
+        key = (knowledge_cutoff, ridge_config.digest)
+        cached = self._cache.get(key)
+        if cached is not None:
+            self.hit_count += 1
+            return cached
+        feature_names = self._blocks[0].feature_names
+        model_24h = fit_causal_alpha_ridge(
+            features=self._features,
+            labels=self._labels_24h,
+            feature_available=self._available,
+            label_end_indices=self._ends_24h,
+            knowledge_cutoff=knowledge_cutoff,
+            feature_names=feature_names,
+            config=ridge_config,
+        )
+        model_72h = fit_causal_alpha_ridge(
+            features=self._features,
+            labels=self._labels_72h,
+            feature_available=self._available,
+            label_end_indices=self._ends_72h,
+            knowledge_cutoff=knowledge_cutoff,
+            feature_names=feature_names,
+            config=ridge_config,
+        )
+        fitted_ends_24h = self._ends_24h[model_24h.eligible_indices]
+        fitted_ends_72h = self._ends_72h[model_72h.eligible_indices]
+        fitted = CausalAlphaExpandingFit(
+            train_symbols=self._symbols,
+            knowledge_cutoff=knowledge_cutoff,
+            model_24h=model_24h,
+            model_72h=model_72h,
+            sample_count_24h=model_24h.sample_count,
+            sample_count_72h=model_72h.sample_count,
+            max_label_end_24h=int(np.max(fitted_ends_24h)),
+            max_label_end_72h=int(np.max(fitted_ends_72h)),
+            sample_scope_digest=self._scope_digest,
+        )
+        self._cache[key] = fitted
+        self.fit_count += 1
+        return fitted
+
+
 def fit_expanding_causal_alpha_models(
     *,
     train_symbols: tuple[str, ...],
@@ -474,46 +583,12 @@ def fit_expanding_causal_alpha_models(
 ) -> CausalAlphaExpandingFit:
     """Fit both horizons on pooled train-symbol labels realized before a cutoff."""
 
-    symbols, blocks, scope_digest = _validated_sample_scope(train_symbols, samples)
-    features = np.concatenate(tuple(block.features for block in blocks), axis=0)
-    available = np.concatenate(
-        tuple(block.feature_available for block in blocks), axis=0
-    )
-    labels_24h = np.concatenate(tuple(block.labels_24h for block in blocks), axis=0)
-    labels_72h = np.concatenate(tuple(block.labels_72h for block in blocks), axis=0)
-    ends_24h = np.concatenate(tuple(block.label_end_indices_24h for block in blocks))
-    ends_72h = np.concatenate(tuple(block.label_end_indices_72h for block in blocks))
-    feature_names = blocks[0].feature_names
-    model_24h = fit_causal_alpha_ridge(
-        features=features,
-        labels=labels_24h,
-        feature_available=available,
-        label_end_indices=ends_24h,
+    return CausalAlphaExpandingFitCache(
+        train_symbols=train_symbols,
+        samples=samples,
+    ).resolve(
         knowledge_cutoff=knowledge_cutoff,
-        feature_names=feature_names,
-        config=ridge_config,
-    )
-    model_72h = fit_causal_alpha_ridge(
-        features=features,
-        labels=labels_72h,
-        feature_available=available,
-        label_end_indices=ends_72h,
-        knowledge_cutoff=knowledge_cutoff,
-        feature_names=feature_names,
-        config=ridge_config,
-    )
-    fitted_ends_24h = ends_24h[model_24h.eligible_indices]
-    fitted_ends_72h = ends_72h[model_72h.eligible_indices]
-    return CausalAlphaExpandingFit(
-        train_symbols=symbols,
-        knowledge_cutoff=knowledge_cutoff,
-        model_24h=model_24h,
-        model_72h=model_72h,
-        sample_count_24h=model_24h.sample_count,
-        sample_count_72h=model_72h.sample_count,
-        max_label_end_24h=int(np.max(fitted_ends_24h)),
-        max_label_end_72h=int(np.max(fitted_ends_72h)),
-        sample_scope_digest=scope_digest,
+        ridge_config=ridge_config,
     )
 
 
@@ -572,6 +647,7 @@ def build_causal_alpha_episode_batch(
     ridge_config: CausalAlphaRidgeConfig,
     controller_config: CausalAlphaControllerConfig,
     teacher_config_digest: str | None = None,
+    fit_cache: CausalAlphaExpandingFitCache | None = None,
 ) -> tuple[EpisodeOracleBatch, CausalAlphaBatchEvidence]:
     """Fit at each episode start and generate one causal target path per contract."""
 
@@ -585,11 +661,18 @@ def build_causal_alpha_episode_batch(
     episode_evidence: list[CausalAlphaEpisodeEvidence] = []
     fits: dict[str, CausalAlphaExpandingFit] = {}
     for contract in partition.contracts:
-        fitted = fit_expanding_causal_alpha_models(
-            train_symbols=symbols,
-            samples=samples,
-            knowledge_cutoff=contract.start,
-            ridge_config=ridge_config,
+        fitted = (
+            fit_expanding_causal_alpha_models(
+                train_symbols=symbols,
+                samples=samples,
+                knowledge_cutoff=contract.start,
+                ridge_config=ridge_config,
+            )
+            if fit_cache is None
+            else fit_cache.resolve(
+                knowledge_cutoff=contract.start,
+                ridge_config=ridge_config,
+            )
         )
         decisions = np.arange(contract.start, contract.stop - 1, dtype=np.int64)
         prediction_features, prediction_available, actionable = (
@@ -703,6 +786,7 @@ def build_causal_alpha_episode_batch(
 
 
 __all__ = [
+    "CausalAlphaExpandingFitCache",
     "build_causal_alpha_episode_batch",
     "build_causal_alpha_symbol_samples",
     "build_chronological_episode_partition",

--- a/trade_rl/workflows/universal_causal_alpha_selection.py
+++ b/trade_rl/workflows/universal_causal_alpha_selection.py
@@ -20,12 +20,59 @@ from trade_rl.workflows.universal_causal_alpha_contracts import (
     CausalAlphaCandidateConfig,
     CausalAlphaCandidateEpisodeMetrics,
     CausalAlphaCandidateEvidence,
+    CausalAlphaExpandingFit,
     CausalAlphaSelectionEvidence,
     CausalAlphaSymbolSamples,
 )
 from trade_rl.workflows.universal_causal_alpha_fitting import (
+    CausalAlphaExpandingFitCache,
     fit_expanding_causal_alpha_models,
 )
+
+
+class _CausalAlphaPredictionCache:
+    """Reuse ridge predictions across controller-only candidate variants."""
+
+    def __init__(self) -> None:
+        self._cache: dict[
+            tuple[str, str, str],
+            tuple[np.ndarray, np.ndarray, np.ndarray],
+        ] = {}
+        self.prediction_count = 0
+        self.hit_count = 0
+
+    def resolve(
+        self,
+        *,
+        symbol: str,
+        block: CausalAlphaSymbolSamples,
+        contract: OracleEpisodeContract,
+        fitted: CausalAlphaExpandingFit,
+        ridge_digest: str,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        key = (symbol, contract.digest, ridge_digest)
+        cached = self._cache.get(key)
+        if cached is not None:
+            self.hit_count += 1
+            return cached
+        decisions = np.arange(contract.start, contract.stop - 1, dtype=np.int64)
+        prediction_features, prediction_available, actionable = (
+            block.prediction_inputs_for_decisions(decisions)
+        )
+        resolved = (
+            fitted.model_24h.predict(
+                prediction_features,
+                feature_available=prediction_available,
+            ),
+            fitted.model_72h.predict(
+                prediction_features,
+                feature_available=prediction_available,
+            ),
+            actionable,
+        )
+        self._cache[key] = resolved
+        self.prediction_count += 1
+        return resolved
 
 
 def _candidate(
@@ -208,25 +255,33 @@ def _causal_alpha_target_for_contract(
     samples: Mapping[str, CausalAlphaSymbolSamples],
     contract: OracleEpisodeContract,
     candidate: CausalAlphaCandidateConfig,
+    fit_cache: CausalAlphaExpandingFitCache | None = None,
+    prediction_cache: _CausalAlphaPredictionCache | None = None,
 ) -> np.ndarray:
-    fitted = fit_expanding_causal_alpha_models(
-        train_symbols=train_symbols,
-        samples=samples,
-        knowledge_cutoff=contract.start,
-        ridge_config=candidate.ridge,
+    fitted = (
+        fit_expanding_causal_alpha_models(
+            train_symbols=train_symbols,
+            samples=samples,
+            knowledge_cutoff=contract.start,
+            ridge_config=candidate.ridge,
+        )
+        if fit_cache is None
+        else fit_cache.resolve(
+            knowledge_cutoff=contract.start,
+            ridge_config=candidate.ridge,
+        )
     )
     block = samples[symbol]
     if contract.dataset_id != block.dataset_id:
         raise ValueError("causal alpha selection contract dataset identity drifted")
-    decisions = np.arange(contract.start, contract.stop - 1, dtype=np.int64)
-    prediction_features, prediction_available, actionable = (
-        block.prediction_inputs_for_decisions(decisions)
-    )
-    prediction_24h = fitted.model_24h.predict(
-        prediction_features, feature_available=prediction_available
-    )
-    prediction_72h = fitted.model_72h.predict(
-        prediction_features, feature_available=prediction_available
+    if prediction_cache is None:
+        prediction_cache = _CausalAlphaPredictionCache()
+    prediction_24h, prediction_72h, actionable = prediction_cache.resolve(
+        symbol=symbol,
+        block=block,
+        contract=contract,
+        fitted=fitted,
+        ridge_digest=candidate.ridge.digest,
     )
     scores = combine_causal_alpha_predictions(
         prediction_24h,

--- a/trade_rl/workflows/universal_causal_alpha_teacher.py
+++ b/trade_rl/workflows/universal_causal_alpha_teacher.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Callable
 from functools import partial
 from pathlib import Path
 from typing import Any, Mapping
@@ -21,7 +22,10 @@ from trade_rl.learning.causal_alpha_teacher import (
     CausalAlphaTeacherHoldoutMetric,
     evaluate_causal_alpha_teacher_admission,
 )
-from trade_rl.learning.episode_oracle_bc import evaluate_episode_action_path
+from trade_rl.learning.episode_oracle_bc import (
+    evaluate_episode_action_path,
+    evaluate_episode_action_path_on_environment,
+)
 from trade_rl.learning.episode_oracle_teacher import EpisodeOracleBatch
 from trade_rl.risk.pretrade import PreTradeRiskConfig
 from trade_rl.rl.universal_instrument_binding import InstrumentDatasetBinding
@@ -39,6 +43,7 @@ from trade_rl.workflows.universal_causal_alpha_contracts import (
     UniversalCausalAlphaTeacherPackage,
 )
 from trade_rl.workflows.universal_causal_alpha_fitting import (
+    CausalAlphaExpandingFitCache,
     _validated_sample_scope,
     build_causal_alpha_episode_batch,
     build_causal_alpha_symbol_samples,
@@ -49,6 +54,7 @@ from trade_rl.workflows.universal_causal_alpha_fitting import (
 )
 from trade_rl.workflows.universal_causal_alpha_selection import (
     _causal_alpha_target_for_contract,
+    _CausalAlphaPredictionCache,
     default_causal_alpha_candidate_grid,
     rank_causal_alpha_candidates,
 )
@@ -62,6 +68,8 @@ def evaluate_causal_alpha_selection(
     candidates: tuple[CausalAlphaCandidateConfig, ...],
     environment_factories: Mapping[str, Any],
     episode_hours: float,
+    fit_cache: CausalAlphaExpandingFitCache | None = None,
+    progress_callback: Callable[[Mapping[str, object]], None] | None = None,
 ) -> CausalAlphaSelectionEvidence:
     """Replay only earlier selection episodes through the production environment."""
 
@@ -77,47 +85,91 @@ def evaluate_causal_alpha_selection(
     if not np.isfinite(episode_hours) or episode_hours <= 0.0:
         raise ValueError("causal alpha episode_hours must be finite and positive")
     episode_days = float(episode_hours) / 24.0
-    by_candidate: dict[str, tuple[CausalAlphaCandidateEpisodeMetrics, ...]] = {}
-    for candidate in candidates:
-        records: list[CausalAlphaCandidateEpisodeMetrics] = []
-        for symbol in symbols:
-            factory = environment_factories[symbol]
-            if not callable(factory):
-                raise TypeError(
-                    "causal alpha selection environment factory is not callable"
-                )
+    total_replays = len(candidates) * sum(
+        len(partition_values[symbol].selection_contracts) for symbol in symbols
+    )
+    completed_replays = 0
+    prediction_cache = _CausalAlphaPredictionCache()
+    records_by_candidate: dict[str, list[CausalAlphaCandidateEpisodeMetrics]] = {
+        candidate.digest: [] for candidate in candidates
+    }
+    for symbol in symbols:
+        factory = environment_factories[symbol]
+        if not callable(factory):
+            raise TypeError(
+                "causal alpha selection environment factory is not callable"
+            )
+        environment = factory()
+        close = getattr(environment, "close", None)
+        if not callable(close):
+            raise TypeError("causal alpha selection environment is not closable")
+        try:
             partition = partition_values[symbol]
-            for contract in partition.selection_contracts:
-                actions = _causal_alpha_target_for_contract(
-                    symbol=symbol,
-                    train_symbols=symbols,
-                    samples=samples,
-                    contract=contract,
-                    candidate=candidate,
-                )
-                evaluation = evaluate_episode_action_path(
-                    factory,
-                    contract,
-                    actions=actions,
-                )
-                performance = evaluation.performance
-                collapse = evaluation.collapse_evidence
-                records.append(
-                    CausalAlphaCandidateEpisodeMetrics(
-                        candidate_digest=candidate.digest,
+            for candidate in candidates:
+                for contract in partition.selection_contracts:
+                    actions = _causal_alpha_target_for_contract(
                         symbol=symbol,
-                        episode_index=contract.episode_index,
-                        gross_return=float(performance.gross_return),
-                        net_return=float(performance.net_return),
-                        turnover_per_day=(
-                            float(performance.turnover_total) / episode_days
-                        ),
-                        total_execution_cost=float(performance.cost_total),
-                        trade_count=int(performance.trade_count),
-                        risk_violation=(int(collapse.execution_rejection_count) > 0),
+                        train_symbols=symbols,
+                        samples=samples,
+                        contract=contract,
+                        candidate=candidate,
+                        fit_cache=fit_cache,
+                        prediction_cache=prediction_cache,
                     )
-                )
-        by_candidate[candidate.digest] = tuple(records)
+                    evaluation = evaluate_episode_action_path_on_environment(
+                        environment,
+                        contract,
+                        actions=actions,
+                    )
+                    performance = evaluation.performance
+                    collapse = evaluation.collapse_evidence
+                    records_by_candidate[candidate.digest].append(
+                        CausalAlphaCandidateEpisodeMetrics(
+                            candidate_digest=candidate.digest,
+                            symbol=symbol,
+                            episode_index=contract.episode_index,
+                            gross_return=float(performance.gross_return),
+                            net_return=float(performance.net_return),
+                            turnover_per_day=(
+                                float(performance.turnover_total) / episode_days
+                            ),
+                            total_execution_cost=float(performance.cost_total),
+                            trade_count=int(performance.trade_count),
+                            risk_violation=(
+                                int(collapse.execution_rejection_count) > 0
+                            ),
+                        )
+                    )
+                    completed_replays += 1
+                    if progress_callback is not None:
+                        progress_callback(
+                            {
+                                "candidate_digest": candidate.digest,
+                                "completed_replays": completed_replays,
+                                "episode_index": contract.episode_index,
+                                "fit_cache_entries": (
+                                    fit_cache.entry_count
+                                    if fit_cache is not None
+                                    else 0
+                                ),
+                                "fit_cache_hits": (
+                                    fit_cache.hit_count if fit_cache is not None else 0
+                                ),
+                                "fit_count": (
+                                    fit_cache.fit_count if fit_cache is not None else 0
+                                ),
+                                "phase": "causal_teacher_selection",
+                                "prediction_cache_hits": prediction_cache.hit_count,
+                                "prediction_count": prediction_cache.prediction_count,
+                                "symbol": symbol,
+                                "total_replays": total_replays,
+                            }
+                        )
+        finally:
+            close()
+    by_candidate = {
+        digest: tuple(records) for digest, records in records_by_candidate.items()
+    }
     return rank_causal_alpha_candidates(
         candidates=tuple(candidates),
         metrics=by_candidate,
@@ -298,6 +350,22 @@ def build_universal_causal_alpha_teacher_package(
         symbol: partial(concrete_environment_factory, binding_by_symbol[symbol])
         for symbol in symbols
     }
+    fit_cache = CausalAlphaExpandingFitCache(
+        train_symbols=symbols,
+        samples=samples,
+    )
+    selection_path = Path(selection_evidence_path)
+    progress_path = selection_path.parent / "causal-teacher-progress.json"
+    latest_progress: dict[str, object] = {}
+
+    def persist_selection_progress(payload: Mapping[str, object]) -> None:
+        latest_progress.clear()
+        latest_progress.update(payload)
+        atomic_write_bytes(
+            progress_path,
+            canonical_json_bytes(dict(payload)) + b"\n",
+        )
+
     selection = evaluate_causal_alpha_selection(
         train_symbols=symbols,
         samples=samples,
@@ -305,8 +373,9 @@ def build_universal_causal_alpha_teacher_package(
         candidates=candidate_values,
         environment_factories=environment_factories,
         episode_hours=resolved_episode_hours,
+        fit_cache=fit_cache,
+        progress_callback=persist_selection_progress,
     )
-    selection_path = Path(selection_evidence_path)
     atomic_write_bytes(
         selection_path,
         canonical_json_bytes(selection.to_payload()) + b"\n",
@@ -340,6 +409,7 @@ def build_universal_causal_alpha_teacher_package(
             ridge_config=selected.ridge,
             controller_config=selected.controller,
             teacher_config_digest=teacher_config_digest,
+            fit_cache=fit_cache,
         )
         batches[symbol] = batch
         batch_evidence[symbol] = evidence
@@ -349,7 +419,12 @@ def build_universal_causal_alpha_teacher_package(
         environment_factories=environment_factories,
         episode_hours=resolved_episode_hours,
     )
-    return UniversalCausalAlphaTeacherPackage(
+    evidence_root = selection_path.parent
+    atomic_write_bytes(
+        evidence_root / "causal-teacher-admission.json",
+        canonical_json_bytes(teacher_admission.to_payload()) + b"\n",
+    )
+    package = UniversalCausalAlphaTeacherPackage(
         train_symbols=symbols,
         batches=batches,
         partitions=partitions,
@@ -362,9 +437,24 @@ def build_universal_causal_alpha_teacher_package(
         episode_hours=resolved_episode_hours,
         batch_evidence=batch_evidence,
     )
+    atomic_write_bytes(
+        evidence_root / "causal-teacher-package.json",
+        canonical_json_bytes(package.to_payload()) + b"\n",
+    )
+    persist_selection_progress(
+        {
+            **latest_progress,
+            "package_digest": package.digest,
+            "phase": "causal_teacher_package_completed",
+            "teacher_admission_digest": teacher_admission.digest,
+            "teacher_admission_passed": teacher_admission.passed,
+        }
+    )
+    return package
 
 
 __all__ = [
+    "CausalAlphaExpandingFitCache",
     "CausalAlphaBatchEvidence",
     "CausalAlphaCandidateConfig",
     "CausalAlphaCandidateEpisodeMetrics",


### PR DESCRIPTION
## What

Integrate the final one-commit real-data training repair on top of the merged causal-alpha teacher.

- allow `causal_alpha_ridge` through the SB3 Universal pretraining wrapper;
- reuse expanding causal-alpha fits through a shared cache to remove repeated ridge fitting;
- persist causal-teacher selection/admission/package progress for operator visibility;
- expose richer Universal telemetry trends for gross/net PnL, baseline excess, turnover, costs, target deltas and sign flips;
- align causal assembly tests with the explicit evidence-root contract.

## Why

`main@49561bf8` contains the causal-alpha teacher itself, but this follow-up closes the runtime/performance/observability gaps found during local real-data audit before long training runs.

## Integration

This branch is exactly one commit ahead of `main` and has no divergent history. The PR is opened as Draft to obtain exact-head CI before integration.
