### PR TITLE
Document current Universal training contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ one maintained run
 
 詳細は[Maintained single-symbol workflow](docs/SINGLE_SYMBOL.md)を参照してください。旧Multi-asset Artifactは書き換えずRead-onlyで保持します。
 
+Universal U3-U6は別の**研究用共有Policy学習経路**です。複数のtrain symbolから同じPolicyを学習しますが、各episodeと推論対象は常に1つのconcrete instrumentであり、複数銘柄を同時にportfolio配分するPolicyではありません。現行契約は[Universal Training](docs/UNIVERSAL_TRAINING.md)を参照してください。
+
 ### Repository map
 
 ```text
@@ -62,7 +64,7 @@ uv run trade-rl train run \
 
 - 因果的な市場データとMulti-Timeframe特徴量artifactの構築
 - PPO、CostCriticPPO、LagrangianPPO、SAC、TD3、TQCによる学習
-- OracleまたはTrend teacherを使ったBehavior CloningからPPOへの初期化
+- Oracle／Trend診断teacherに加え、train-only `causal_alpha_ridge` teacherを使うUniversal Behavior Cloning・critic warm start・PPO-family研究経路
 - Nested walk-forward、Seed分布、Checkpoint選択、Sealed outer test
 - Market・Limit・Stop-market注文を扱う状態付きOHLCV約定シミュレーション
 - Trade RL Studioでの学習中探索・TensorBoard診断のRead-only表示
@@ -150,6 +152,7 @@ Serving bundleの正本は`serving_bundle_v6`です。Bundleは「Baselineか学
 
 - [ドキュメント一覧](docs/README.md)
 - [Maintained single-symbol workflow](docs/SINGLE_SYMBOL.md)
+- [Universal U3-U6 training](docs/UNIVERSAL_TRAINING.md)
 - [最初の学習](START.md)
 - [アーキテクチャ](docs/ARCHITECTURE.md)
 - [設定リファレンス](docs/CONFIGURATION.md)

--- a/START.md
+++ b/START.md
@@ -172,6 +172,8 @@ PPO-familyでは、`behavior_cloning_epochs`を正数にすると、同じFeatur
 }
 ```
 
+この`oracle`例はgeneric / single-symbol BCの説明用です。Universal U6のcanonical teacherはtrain-only fitted `causal_alpha_ridge`であり、Oracle/Trendは診断・互換経路として保持します。Universalのholdout、teacher admission、shared packageの契約は[Universal Training](docs/UNIVERSAL_TRAINING.md)を参照してください。
+
 BC、PPO、CostCriticPPO、LagrangianPPOは、組み立て済みPolicyのArchitecture identityを共有します。異なる構造のCheckpointはResume時に拒否されます。
 
 ## 8. TensorBoard診断を有効にする
@@ -264,12 +266,11 @@ uv run trade-rl walk-forward run \
 
 最終判断には、複数Seed、複数Fold、複数AUM、保守的Execution、未使用Outer test、Fresh confirmation、Paper reconciliationが必要です。[研究状態](docs/RESEARCH_STATUS.md)を参照してください。
 
-
 ## 13. Universal U3-U6 full-research trainingを実行する
 
-Universal系のmaintained contractは、複数銘柄で1つのPolicyを学習し、Policy-facing symbol/actionを`INSTRUMENT`へ固定したまま、推論時は1銘柄だけを取引する構成です。U3は206 target-local market features + 9 continuous instrument descriptorsとsymbol-balanced train-only normalization、U4はsymbol-balanced Oracle BC + critic warm start、U5は4 architectureのablation + zero-shot Stage A、U6はU5選抜architectureだけをPPO / Lagrangian PPO / Discounted Lagrangian PPOへ接続します。
+Universal系のmaintained research contractは、複数train symbolで1つのPolicyを学習し、Policy-facing symbol/actionを`INSTRUMENT`へ固定したまま、各episodeと推論時は1銘柄だけを取引する構成です。U3はtarget-local market featuresとcontinuous instrument descriptorsをsymbol-balanced train-only normalizationへ通します。U4はtrain-only fitted `causal_alpha_ridge` teacherのselection/admission後にBCとcritic warm startを行い、U5は4 architectureのablation + zero-shot Stage A、U6はU5選抜architectureだけをPPO / Lagrangian PPO / Discounted Lagrangian PPOへ接続します。
 
-U6の実学習入口は次です。事前に`materialize_universal_runtime.py`で作ったsecret-free runtime manifestを必須入力にします。maintained runtime factoryはmanifestからinstrument / 9 train datasets / shared normalizerを再読込し、全digestとfrozen metadata evidenceを照合します。`--runtime-factory`を省略すると`trade_rl.workflows.binance_universal_runtime:build_runtime`を使います。互換用のartifact root、train fold、normalizer/feature schema digestを明示した場合は、manifestと一致しなければ起動前に失敗します。validation/test symbolは学習前処理へ混入しません。
+U6の実学習入口は次です。事前に`materialize_universal_runtime.py`で作ったsecret-free runtime manifestを必須入力にします。maintained runtime factoryはmanifestからinstrument / train datasets / shared normalizerを再読込し、全digestとfrozen metadata evidenceを照合します。`--runtime-factory`を省略すると`trade_rl.workflows.binance_universal_runtime:build_runtime`を使います。互換用のartifact root、train fold、normalizer/feature schema digestを明示した場合は、manifestと一致しなければ起動前に失敗します。validation/test symbolはteacher fitting、candidate selection、BCを含む学習前処理へ混入しません。
 
 ```bash
 uv sync --extra dev --extra train-sb3 --extra postgres
@@ -287,8 +288,20 @@ uv run python scripts/run_universal_full_research.py \
   --output-root artifacts/universal/full-research
 ```
 
-3つのauthored `TrainingRunConfig`は、training algorithm/cost-family/gammaの比較上必要な差分を除き、Environment / Risk / Reward / Trend / Action / Executionを同一にしてください。 上のcanonical U6 configはBC seedを17に固定し、critic-only warm startを512 step、conservative joint warm startを128 step有効化した初期maintained設定です。これらのstep数はソフトウェア契約用の初期値であり、実データ上の最適性を主張しません。CLIは非training surfaceの差分を先に拒否し、U6本体もPPO対Lagrangianの非algorithm条件と、Lagrangian対Discountedのgamma以外の差分をfail-closedで拒否します。
+Canonical U6の3方式は同じcausal teacher packageを共有し、各Algorithm/Seedでholdoutを再評価しません。Teacher selectionの結果を先に永続化し、各train symbolの最新complete 720h holdoutをexactly once replayしてteacher admissionを固定します。Admissionが失敗した場合はBC、critic warm start、PPO updateへ進みません。
 
-学習完了時は`universal-full-research-training.json`が生成されます。この時点の`research_success=false`は意図した状態です。training完走はSoftware successであり、Research successではありません。U5のvalidation selectionと一度だけのsealed unseen-symbol test、paired baseline evidence、bootstrap lower bound、worst-symbol/worst-seed/pass-fraction gate、hard-safety violation=0がそろうまでは`NO-GO`を維持してください。
+Teacher生成中を含む進捗確認:
 
-U5/U6の評価・状態遷移には既存の`StageAZeroShotEvaluationOrchestrator`、`UniversalResearchManifest`、`scripts/run_full_research_experiment.py`を使います。sealed evidenceを作る前に`zero_shot_gate_passed=true`を手動で偽装しないでください。
+```bash
+uv run python scripts/monitor_universal_training.py \
+  --generation-root artifacts/universal/full-research \
+  --output-root artifacts/universal/monitor
+```
+
+`_shared-causal-teacher/causal-teacher-progress.json`、selection/admission/package artifactに加え、学習開始後はgross/net PnL、baseline excess、turnover、execution cost、target delta、sign flip等のtelemetry trendを確認できます。Monitorは診断用であり、sealed model-selection evidenceではありません。
+
+3つのauthored `TrainingRunConfig`は、training algorithm/cost-family/gammaの比較上必要な差分を除き、Environment / Risk / Reward / Trend / Action / Executionを同一にしてください。Canonical U6 configはBC seedを17に固定し、critic-only warm startを512 step、conservative joint warm startを128 step有効化した初期maintained設定です。これらのstep数はソフトウェア契約用の初期値であり、実データ上の最適性を主張しません。CLIは非training surfaceの差分を先に拒否し、U6本体もPPO対Lagrangianの非algorithm条件と、Lagrangian対Discountedのgamma以外の差分をfail-closedで拒否します。
+
+学習完了時は`universal-full-research-training.json`が生成されます。この時点の`research_success=false`は意図した状態です。Training完走はSoftware successであり、Research successではありません。実データteacher admission、U5 validation selection、一度だけのsealed unseen-symbol test、paired baseline evidence、bootstrap lower bound、worst-symbol/worst-seed/pass-fraction gate、hard-safety violation=0がそろうまでは`NO-GO`を維持してください。
+
+U5/U6の評価・状態遷移には既存の`StageAZeroShotEvaluationOrchestrator`、`UniversalResearchManifest`、`scripts/run_full_research_experiment.py`を使います。sealed evidenceを作る前に`zero_shot_gate_passed=true`を手動で偽装しないでください。Universal teacherの詳細な因果・holdout・artifact契約は[Universal Training](docs/UNIVERSAL_TRAINING.md)を正本とします。

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Trade RL ドキュメント
 
-このDirectoryには、**現在のmainで維持している契約だけ**を置きます。完了済みの実装計画、監査ログ、一時検証記録は作業ツリーから削除し、Git履歴で参照します。
+このDirectoryの**Top-level文書は現在のmainで維持している契約の正本**です。`implementation-plans/`は設計・実装時点の履歴資料であり、現行運用の正本ではありません。監査ログや一時検証記録はGit履歴または該当Pull Requestから参照します。
 
 ## 読む順番
 
@@ -8,6 +8,7 @@
 |---|---|
 | まず動かす | [START.md](../START.md) |
 | Maintained 1 Run＝1 Instrument契約を確認する | [SINGLE_SYMBOL.md](SINGLE_SYMBOL.md) |
+| Universal U3-U6の現行学習契約を確認する | [UNIVERSAL_TRAINING.md](UNIVERSAL_TRAINING.md) |
 | 全体構造を理解する | [ARCHITECTURE.md](ARCHITECTURE.md) |
 | 設定項目を調べる | [CONFIGURATION.md](CONFIGURATION.md) |
 | 研究結果を正しく解釈する | [RESEARCH_STATUS.md](RESEARCH_STATUS.md) |
@@ -25,6 +26,7 @@ Repositoryの概要は[README.md](../README.md)が正本です。
 - `README.md`: 状態、Quickstart、能力境界、主要リンク
 - `START.md`: 実行手順とTroubleshooting
 - `SINGLE_SYMBOL.md`: Maintained 1 Run＝1 Instrument、Action、Identity、Legacy互換
+- `UNIVERSAL_TRAINING.md`: Universal runtime、causal teacher、holdout/admission、U5/U6共有、monitoring
 - `ARCHITECTURE.md`: 現行実装の責務、Data flow、Identity、Fail-closed境界
 - `CONFIGURATION.md`: 現行Schemaと設定値
 - `RESEARCH_STATUS.md`: 実装済み能力、未取得Evidence、Production gate
@@ -33,19 +35,20 @@ Repositoryの概要は[README.md](../README.md)が正本です。
 - `operations/`: 実行Runbook
 - `performance/`: Hardware別の測定・候補設定
 - `frontend/README.md`: UIと診断Telemetryの境界
+- `implementation-plans/`: 設計・実装時点の履歴。現行契約の正本ではない
 
 同じ説明を複数ファイルへ複製せず、責務を持つ文書へLinkします。
 
 ## 更新ルール
 
-1. 現在の実装を記述し、開発経緯は記述しない。
+1. Top-level維持文書は現在の実装を記述し、開発経緯は記述しない。
 2. Schema名、CLI、Path、設定名はCodeまたは維持対象Exampleと一致させる。
 3. 実装済み、検証済み、収益性、Production認可を分ける。
 4. `NO-GO`を、Pipeline失敗やモデル失敗と混同しない。
 5. 一時的なCommit SHAやActions run IDは、維持文書へ固定しない。
 6. Relative linkを使い、文書契約Testで解決可能性を確認する。
-7. 完了済みPlanやAudit reportを新たな現行文書として残さない。
+7. 完了済みPlanやSpecを現行契約の根拠として引用せず、必要な内容はTop-level維持文書へ反映する。
 
 ## 履歴資料
 
-削除された文書はGit履歴から参照できます。特定時点の設計判断を調べる場合は、該当CommitまたはPull Requestの変更履歴を使用してください。
+`implementation-plans/`配下のPlan/Specや削除済み文書は履歴資料です。特定時点の設計判断を調べる場合は、該当文書、Commit、Pull Requestの変更履歴を使用してください。現在の動作や運用判断ではTop-level維持文書を優先します。

--- a/docs/RESEARCH_STATUS.md
+++ b/docs/RESEARCH_STATUS.md
@@ -5,6 +5,9 @@
 ```text
 RepositoryIntegrity: VERIFIED_BY_MAIN_CI
 ResearchWorkflows: AVAILABLE
+UniversalCausalAlphaTeacherSoftware: IMPLEMENTED_AND_CI_VERIFIED
+UniversalCausalAlphaTeacherEmpiricalAdmission: NOT_COMPLETED
+UniversalFullResearchEmpiricalEvaluation: NOT_COMPLETED
 StageAZeroShotSoftware: IMPLEMENTED_AND_CI_VERIFIED
 StageAEmpiricalEvaluation: NOT_COMPLETED
 StageBSpotFuturesGeneralization: NOT_IMPLEMENTED
@@ -21,6 +24,8 @@ ProfitabilityClaim: NONE
 
 この表は能力境界です。実装済み、CI検証済み、研究上有効、収益性あり、Production認可済みは別の状態です。
 
+Universal causal alpha teacherのsoftware pathは実装・CI検証済みです。ただし、維持対象実データでのteacher admission、複数Seed/Foldのfull-research comparison、zero-shot、sealed evaluationはまだ別のempirical evidenceです。Software completionをteacher qualityや収益性の証明として扱いません。
+
 Stage Aのソフトウェア契約とCLIは実装・CI検証済みですが、維持対象の実データ、複数Seed・Fold、対象GPUによる実証評価は完了していません。Stage BのSpotとUSDⓈ-M先物を横断する一般化は未実装です。
 
 ## 現在のModel契約
@@ -29,13 +34,35 @@ Stage Aのソフトウェア契約とCLIは実装・CI検証済みですが、�
 
 - Clock別Causal TCN
 - Gated Cross-Timeframe Attention
-- Gated Cross-Asset Attention
+- Maintained one-symbol pathでは`single_symbol_bypass_v1`
+- Historical multi-symbol pathだけがGated Cross-Asset Attentionを使用
 - AvailabilityとStalenessの明示入力
 - 組み立て済みModelから生成するArchitecture identity
 - BC、PPO、CostCriticPPO、LagrangianPPOで同一構造
 - Checkpoint、構造化Export、ServingでのDigest照合
 
 旧Encoder Booleanと`training_run_config_v1`は維持対象ではありません。
+
+## Universal causal teacher status
+
+Canonical Universal U6 teacherは`causal_alpha_ridge`です。OracleとTrend teacherは診断・互換経路として保持します。
+
+Software contractは次を実装済みです。
+
+- train-only pooled deterministic ridgeによる24h/72h causal alpha prediction
+- prefix-only scalingとlabel cutoff
+- 各train symbolのlatest complete 720h episodeをteacher holdoutとして予約
+- holdoutをcandidate selectionへ使わない分離
+- fit/prediction cacheによる重複計算の再利用
+- selection artifactをholdout replayより前に永続化
+- per-symbol holdoutのexactly-once replayとshared teacher admission
+- U5 architecture / U6 algorithm間で同じteacher packageを共有
+- teacher admission failure時にBC、critic warm start、PPOへ進まないfail-closed順序
+- teacher build progressと経済telemetryのread-only monitoring
+
+詳細な現行契約は[UNIVERSAL_TRAINING.md](UNIVERSAL_TRAINING.md)を参照してください。
+
+これらはsoftware contractです。Teacher holdoutの経済成績が実データで合格した、最終Policyがbaselineを上回った、unseen symbolへ一般化した、という意味ではありません。
 
 ## Software verification
 
@@ -56,7 +83,7 @@ CUDA実機Evidenceは、指定Labelを持つSelf-hosted runnerが接続されて
 
 Pipeline完走は収益性を意味しません。過去の維持対象比較では、RL候補がBaselineを一貫して上回らず、Production選択は`NO-GO`でした。
 
-新しいHierarchical sequence v2も、次を固定した比較Evidenceが揃うまで優位性を主張しません。
+新しいUniversal causal teacherとHierarchical sequence v2も、次を固定した比較Evidenceが揃うまで優位性を主張しません。
 
 - 同じDataset、Fold、Seed、Teacher、Timesteps
 - 同じAction、Reward、Risk、Execution policy
@@ -65,7 +92,7 @@ Pipeline完走は収益性を意味しません。過去の維持対象比較で
 - OOS growth、Baseline uplift、Regret、Drawdown、Turnover、Cost
 - Seed dispersion、Worst fold、Throughput、GPU memory
 
-Architecture改善は、性能改善の証明ではありません。
+Architecture改善やteacher software改善は、性能改善の証明ではありません。
 
 ## Stateful execution status
 
@@ -85,7 +112,7 @@ OHLCVはQueue position、Hidden liquidity、Auction、L2 depthを表現しませ
 
 NormalizerはFold train capabilityだけでFitし、その後Freezeします。Outer testはConfiguration選択後に一度だけ開きます。
 
-Candidate eligibilityはSeed分布、Worst seed、Dispersion、Turnover、Cost、Drawdownを含みます。Sealed returnを学習や選択へ戻しません。
+Universal teacher holdoutはteacherをBCへ入れてよいか判定するadmission evidenceであり、最終Policyのsealed testではありません。Candidate eligibilityと最終評価はSeed分布、Worst seed、Dispersion、Turnover、Cost、Drawdownを含む別のzero-shot/sealed evaluationで判定します。Sealed returnを学習や選択へ戻しません。
 
 独立Foldを、Account-state handoffなしに連続Portfolio returnや1つのMaximum drawdownとして扱いません。
 
@@ -93,7 +120,9 @@ Candidate eligibilityはSeed分布、Worst seed、Dispersion、Turnover、Cost�
 
 `training_telemetry_v1`はAppend-only診断Dataです。Producer-issued`episode_id`を優先し、選択したVector environmentのCurrent episodeだけを表示します。Historical records with`null` identityはTerminalとCounter rollbackで分割します。
 
-TensorBoardには最適化ScalarとSequence attention/gate/gradient診断を表示できます。いずれもModel-selection evidenceではありません。
+Universal monitorはmember heartbeat前のcausal teacher progressも読み、学習開始後はgross/net PnL、baseline excess、turnover、execution cost、target delta、sign flip等をtrend化します。OOM、non-finite値、traceback、container failure、stale heartbeatもfindingとして扱います。
+
+TensorBoardには最適化ScalarとSequence attention/gate/gradient診断を表示できます。MonitorとTensorBoardはいずれもModel-selection evidenceではありません。
 
 ## Paper Serving and release
 

--- a/docs/UNIVERSAL_TRAINING.md
+++ b/docs/UNIVERSAL_TRAINING.md
@@ -1,0 +1,211 @@
+# Universal Training
+
+この文書は、現在の`main`で維持しているUniversal U3-U6学習経路の正本です。Universalは複数のtrain symbolから1つのPolicyを学習しますが、各episodeは1つのconcrete instrumentだけを取引し、Policy-facing symbol/actionは`INSTRUMENT`へ固定します。複数銘柄を同時配分するmulti-asset portfolio policyではありません。
+
+> **研究状態**
+>
+> - Universal runtime / U3-U6 software: 実装済み
+> - Canonical U6 teacher: `causal_alpha_ridge`
+> - Oracle / Trend teacher: 診断・互換経路
+> - 実データでのTeacher admission、複数Seed/Fold、zero-shot、sealed evaluation: 別途実証が必要
+> - Production status: **NO-GO**
+> - 収益性の主張: なし
+
+## 1. Runtimeとデータ境界
+
+U6はsecret-freeなUniversal runtime manifestとfrozen metadataを入力にします。Runtimeは宣言済みtrain symbolのDataset、shared normalizer、feature schema、instrument descriptor、execution metadataのDigestを再検証してから学習資源を組み立てます。
+
+```text
+runtime manifest
+  -> train-symbol dataset bindings
+  -> target-local causal features
+  -> continuous instrument descriptors
+  -> shared train-only normalizer
+  -> episode-routed single-instrument environments
+```
+
+Teacher fitting、candidate selection、BCにはtrain symbolだけを使用します。Validation/Test symbolをUniversal teacher前処理へ混入させません。NormalizerもFold train capabilityだけでFitし、その後Freezeします。
+
+## 2. Canonical teacher: `causal_alpha_ridge`
+
+Canonical U6は、hindsight Oracleや固定Trend ruleではなく、train-only fitted causal alpha teacherを使用します。
+
+Teacherは既存の因果的なtarget-local featureとinstrument descriptorから、24hと72hのgross forward log returnを予測する決定論的なpooled ridge modelです。FitとScalerはknowledge cutoffより前に完全実現したlabelだけを使用します。
+
+```text
+causal features + instrument descriptor
+  -> prefix-only scaling
+  -> pooled deterministic ridge
+  -> 24h / 72h gross-return prediction
+  -> bounded target exposure controller
+```
+
+各labelは、そのlabel realizationの終端がknowledge cutoffより前にある場合だけFitへ入ります。将来label、Validation/Test symbol、holdout performanceをteacher action生成へ戻しません。
+
+Feature availabilityが欠ける場合は、Fit済みmean相当、すなわちstandardized value `0`として扱います。Inactiveまたはnon-tradableなdecisionでは新しいtargetを提出せず、直前targetを維持します。
+
+## 3. Episode partitionとholdout
+
+各train symbolについて、train range内のcomplete episodeを時系列順に分割します。
+
+```text
+earlier complete episodes -> candidate selection / BC scope
+latest complete 720h episode -> causal teacher holdout
+```
+
+最新のcomplete 720h episodeはcandidate selectionへ使用しません。各holdout episodeについて、model fitはそのepisode開始前に完全実現したlabelだけを利用します。
+
+Holdoutはteacher candidateを選ぶためのtestではなく、選択済みteacherをBCへ入れてよいか判定するteacher admissionです。最終Policyの一般化評価はzero-shot / sealed evaluationで別に行います。
+
+## 4. Exposure controller
+
+Return predictionはbounded target exposureへ変換します。維持対象controllerは次を使用します。
+
+- `tanh`によるbounded exposure
+- entry / exit hysteresis
+- existing no-trade band
+- 1 decisionあたりのmaximum target-weight delta
+
+**Minimum holding periodはありません。** 次のdecisionでsignalとcontroller条件が反転すれば、positionを反転できます。不要なturnoverを抑える責務はhysteresis、no-trade band、target delta capが持ちます。
+
+## 5. Candidate selectionと計算再利用
+
+Candidate gridはearlier selection episodeだけをproduction execution replayへ通し、after-costの経済指標とrisk violationを使って決定論的にrankします。Selection中にholdoutを評価しません。
+
+同じsample scope、knowledge cutoff、ridge configで必要になるpooled fitは`CausalAlphaExpandingFitCache`で共有します。Predictionもcandidate間で再利用可能なcacheを使います。これにより、同一ridge fitをsymbol/candidateごとに繰り返す経路を避けます。
+
+Selection progressはreplay count、fit count/cache hit、prediction count/cache hitを含むprogress artifactへ逐次保存します。
+
+## 6. Teacher admissionとfail-closed順序
+
+選択後の順序は固定です。
+
+```text
+candidate selection
+  -> selection artifactを永続化
+  -> selected teacher batchを構築
+  -> 各train symbolのholdoutをexactly once replay
+  -> teacher admissionを固定
+  -> admission PASSならBC
+  -> BC economic/reconstruction gates
+  -> optional critic warm start
+  -> PPO-family updates
+```
+
+Teacher holdoutはshared package生成時に各symbol 1回だけ評価します。Seedごと、Architectureごと、Algorithmごとにholdoutを再評価しません。
+
+Teacher admissionが失敗した場合はBCを開始せず、critic warm startやPPO updateへ進みません。既存のBC reconstruction/economic gateも緩めません。
+
+## 7. U5/U6で共有するteacher identity
+
+U5 architecture ablationでは、同一のcausal teacher packageを一度だけ構築し、全architecture candidateへ渡します。U6では同一packageをPPO、Lagrangian PPO、Discounted Lagrangian PPOへ共有します。
+
+```text
+one runtime/data identity
+  -> one selected causal teacher package
+     -> U5 architecture candidates
+     -> U6 PPO
+     -> U6 Lagrangian PPO
+     -> U6 Discounted Lagrangian PPO
+```
+
+Algorithm差分のためにteacher actionやholdout admissionを作り直しません。Discount factorなどAlgorithm側の差分はcritic/optimization contractに属し、teacher identityとは分離します。
+
+## 8. Shared teacher artifacts
+
+U5/U6のshared teacher evidence rootは通常`<output-root>/_shared-causal-teacher/`です。主要artifact:
+
+```text
+_shared-causal-teacher/
+├── causal-teacher-selection.json
+├── causal-teacher-progress.json
+├── causal-teacher-admission.json
+└── causal-teacher-package.json
+```
+
+- `causal-teacher-selection.json`: candidate grid、selection metrics、selected candidate identity
+- `causal-teacher-progress.json`: teacher selection/buildの進捗とcache counters
+- `causal-teacher-admission.json`: per-symbol holdout economicsとadmission result
+- `causal-teacher-package.json`: teacher config/code/data/selection/admissionを束ねるimmutable identity
+
+各training member側では`universal-pretraining.json`とpolicy-stage snapshotを保存し、random、BC、BC+criticなどの段階を区別します。
+
+## 9. U6 full-research training
+
+事前にUniversal runtime manifestをmaterializeしてから、3つのcanonical configを同じ非Algorithm条件で実行します。
+
+```bash
+uv sync --extra dev --extra train-sb3 --extra postgres
+
+uv run python scripts/run_universal_full_research.py \
+  --selected-architecture u_medium_direct \
+  --ppo-config examples/binance-multitimeframe/universal-u6-ppo.json \
+  --lagrangian-config examples/binance-multitimeframe/universal-u6-lagrangian.json \
+  --discounted-config examples/binance-multitimeframe/universal-u6-discounted.json \
+  --runtime-manifest artifacts/universal/runtime-manifest.json \
+  --frozen-metadata-root data/runtime/frozen-metadata/usds-m \
+  --baseline supervised_allocator \
+  --fold 0 \
+  --fold 1 \
+  --output-root artifacts/universal/full-research
+```
+
+Canonical U6 configは`behavior_cloning_teacher: "causal_alpha_ridge"`を使用します。Rewardは既存のpure net-log-growth contractを維持し、teacher導入のための追加scalar cost penaltyを入れません。
+
+## 10. Universal training monitor
+
+Teacher selection中はまだmember heartbeatが存在しないため、monitorはshared teacher progressも読みます。
+
+```bash
+uv run python scripts/monitor_universal_training.py \
+  --generation-root artifacts/universal/full-research \
+  --output-root artifacts/universal/monitor
+```
+
+Docker containerも監視する場合は`--container <name>`を追加します。Monitorは次を生成します。
+
+```text
+monitor-snapshot.json
+reward-trends.json
+```
+
+Telemetry trendには少なくとも次を含めます。
+
+- reward / portfolio value / baseline portfolio value
+- drawdown / interval cost / interval return
+- filled turnover / fill count
+- interval gross return / baseline excess return
+- target delta / sign flip
+- command target delta / command sign flip
+- gross PnL / net PnL
+
+OOM、non-finite値、traceback、container failure、stale heartbeatもfail-closedなfindingとして扱います。これらのmonitor値は診断用であり、sealed model-selection evidenceではありません。
+
+## 11. Software successとResearch success
+
+次を混同しません。
+
+```text
+CI PASS
+  != teacher economic admission PASS
+  != full-training completion
+  != zero-shot / sealed evaluation PASS
+  != profitability
+  != Production authorization
+```
+
+長時間学習へ進む前に、実データteacher admission、決定論的再現、短いeconomic smokeを確認します。その後も複数Seed/Fold、zero-shot unseen-symbol evaluation、sealed test、execution sensitivity、baseline comparison、hard-safety gateが必要です。
+
+現在のProduction statusは**NO-GO**です。
+
+## 12. 関連文書
+
+- [学習クイックスタート](../START.md)
+- [設定リファレンス](CONFIGURATION.md)
+- [アーキテクチャ](ARCHITECTURE.md)
+- [研究状態](RESEARCH_STATUS.md)
+- [Reward objective](REWARD_OBJECTIVE.md)
+- [Multi-Timeframe research](MULTITIMEFRAME_RESEARCH.md)
+- [Docker GPU full training](operations/docker-gpu-full-training.md)
+
+`docs/implementation-plans/`配下は設計・実装時点の履歴資料です。現在の運用契約や正本としては、この文書と上記の現行文書を使用してください。

--- a/docs/implementation-plans/README.md
+++ b/docs/implementation-plans/README.md
@@ -1,0 +1,13 @@
+# Implementation plans and specs
+
+このDirectoryは、設計・実装時点のPlanとSpecを保存する**履歴資料**です。現在のruntime contract、設定、運用手順、Research statusの正本ではありません。
+
+現在の挙動を確認するときは、先に次のTop-level維持文書を参照してください。
+
+- [Documentation index](../README.md)
+- [Universal Training](../UNIVERSAL_TRAINING.md)
+- [Architecture](../ARCHITECTURE.md)
+- [Configuration](../CONFIGURATION.md)
+- [Research Status](../RESEARCH_STATUS.md)
+
+Plan/Specと現在のCodeが異なる場合は、現在のCodeとTop-level維持文書を優先します。Plan/Specは当時の設計意図、制約、検討過程を追跡するときだけ使用してください。


### PR DESCRIPTION
## What

Bring maintained documentation in sync with the fully integrated Universal causal-alpha training path.

- add `docs/UNIVERSAL_TRAINING.md` as the current source of truth for Universal runtime, causal teacher, selection/holdout/admission, shared package artifacts, U5/U6 reuse, and monitoring;
- clarify the distinction between the maintained single-symbol product boundary and Universal shared-policy research;
- replace stale U4 Oracle wording in `START.md` with the canonical `causal_alpha_ridge` path;
- separate software verification from empirical teacher admission / full-research evidence in `RESEARCH_STATUS.md`;
- classify `docs/implementation-plans/` as historical, non-normative engineering records;
- keep Production status `NO-GO` and make no profitability claim.

## Scope

Documentation only. No Python, configuration, reward, execution, training, or artifact behavior is changed.

## Verification

Opened as Draft to obtain exact-head repository CI, including documentation/link contracts, before merge.
