### PR TITLE
Sync reviewed integration tree

### DIFF
--- a/tests/learning/test_rollout_evaluation.py
+++ b/tests/learning/test_rollout_evaluation.py
@@ -66,7 +66,9 @@ class _Environment:
             order_events=(
                 ()
                 if rejected == 0 or self._omit_rejected_event
-                else (SimpleNamespace(event_type="rejected", reason="minimum_notional"),)
+                else (
+                    SimpleNamespace(event_type="rejected", reason="minimum_notional"),
+                )
             ),
         )
         info = {

--- a/tests/operations/test_universal_training_monitor.py
+++ b/tests/operations/test_universal_training_monitor.py
@@ -251,7 +251,7 @@ def test_monitor_summarizes_bounded_v2_teacher_checkpoint_window(
         "minimum_notional": candidate["record_count"]
     }
     assert candidate["explained_execution_no_fill_count"] == 0
-    assert candidate["unexplained_execution_rejection_count"] == candidate[
-        "record_count"
-    ]
+    assert (
+        candidate["unexplained_execution_rejection_count"] == candidate["record_count"]
+    )
     assert candidate["signal_24h_pearson_mean"] == signal.pearson_correlation

--- a/tests/workflows/test_universal_causal_alpha_fitting.py
+++ b/tests/workflows/test_universal_causal_alpha_fitting.py
@@ -214,7 +214,9 @@ def test_episode_batch_uses_selected_cost_aware_controller_for_teacher_targets()
     assert batch.episode_count == 2
     assert evidence.economic_controller_config_digest == economic.digest
     assert all(item.cost_aware_target_path_digest for item in evidence.episodes)
-    assert all(item.cost_suppressed_change_count is not None for item in evidence.episodes)
+    assert all(
+        item.cost_suppressed_change_count is not None for item in evidence.episodes
+    )
 
 
 def test_sample_identity_drift_changes_fit_digest() -> None:

--- a/trade_rl/workflows/universal_causal_alpha_costs.py
+++ b/trade_rl/workflows/universal_causal_alpha_costs.py
@@ -61,15 +61,12 @@ def causal_alpha_one_way_cost_rates(
     spread = _single_symbol_cost_array(dataset, "spread_rate")
     participation = _single_symbol_cost_array(dataset, "max_participation_rate")
     if any(
-        values.size != n_bars
-        for values in (fee, maker, taker, spread, participation)
+        values.size != n_bars for values in (fee, maker, taker, spread, participation)
     ):
         raise ValueError("causal alpha dataset cost arrays must align with n_bars")
     if np.any(fee < 0.0) or np.any(maker < 0.0) or np.any(taker < 0.0):
         raise ValueError("causal alpha dataset fee rates must be non-negative")
-    if np.any(spread < 0.0) or np.any(
-        (participation <= 0.0) | (participation > 1.0)
-    ):
+    if np.any(spread < 0.0) or np.any((participation <= 0.0) | (participation > 1.0)):
         raise ValueError("causal alpha dataset spread/participation rates are invalid")
 
     # These arrays are historical bar observations. The future execution row is


### PR DESCRIPTION
Synchronize the reviewed integration tree after removing the over-scoped checkpoint-helper test. Keeps the decision-time cost fix and format-only corrections already applied. Internal integration only; main remains unchanged.