### PR TITLE
Fix legacy causal checkpoint diagnostics

### DIFF
--- a/tests/scripts/test_analyze_causal_alpha_checkpoint.py
+++ b/tests/scripts/test_analyze_causal_alpha_checkpoint.py
@@ -14,7 +14,7 @@ from trade_rl.workflows.universal_causal_alpha_contracts import (
 )
 
 
-def _checkpoint(path: Path) -> None:
+def _checkpoint(path: Path, *, include_generator: bool = True) -> None:
     signal = evaluate_causal_alpha_signal_diagnostics(
         np.asarray((-0.02, -0.01, 0.01, 0.02), dtype=np.float64),
         np.asarray((-0.01, -0.02, 0.01, 0.03), dtype=np.float64),
@@ -43,12 +43,13 @@ def _checkpoint(path: Path) -> None:
         liquidity_weight_cap_median=0.2,
         liquidity_weight_cap_max=0.3,
     )
-    payload = {
+    payload: dict[str, object] = {
         **metric.to_payload(),
-        "generator_code_digest": "1" * 64,
         "grid_digest": "2" * 64,
         "schema_version": "causal_alpha_selection_checkpoint_metric_v2",
     }
+    if include_generator:
+        payload["generator_code_digest"] = "1" * 64
     path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
 
 
@@ -64,3 +65,19 @@ def test_cli_emits_non_promotable_diagnostic_json(tmp_path: Path, capsys) -> Non
     assert payload["row_count"] == 1
     assert payload["unique_prediction_episode_count"] == 1
     assert payload["generator_code_digest"] == "1" * 64
+
+
+def test_cli_marks_legacy_missing_generator_identity_as_unavailable(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    checkpoint = tmp_path / "checkpoint.jsonl"
+    _checkpoint(checkpoint, include_generator=False)
+
+    exit_code = module.main([str(checkpoint)])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["generator_code_digest"] is None
+    assert payload["generator_identity_status"] == "unavailable_legacy"
+    assert payload["promotion_eligible"] is False

--- a/tests/workflows/test_causal_alpha_research_diagnostics.py
+++ b/tests/workflows/test_causal_alpha_research_diagnostics.py
@@ -66,16 +66,17 @@ def _metric(
 
 def _write_checkpoint(
     path: Path,
-    rows: list[tuple[CausalAlphaCandidateEpisodeMetricsV2, str, str]],
+    rows: list[tuple[CausalAlphaCandidateEpisodeMetricsV2, str, str | None]],
 ) -> None:
     payloads: list[str] = []
     for metric, grid_digest, generator_digest in rows:
-        payload = {
+        payload: dict[str, object] = {
             **metric.to_payload(),
-            "generator_code_digest": generator_digest,
             "grid_digest": grid_digest,
             "schema_version": "causal_alpha_selection_checkpoint_metric_v2",
         }
+        if generator_digest is not None:
+            payload["generator_code_digest"] = generator_digest
         payloads.append(json.dumps(payload, sort_keys=True, separators=(",", ":")))
     path.write_text("\n".join(payloads) + "\n", encoding="utf-8")
 
@@ -122,6 +123,66 @@ def test_diagnostic_checkpoint_accepts_historical_generator_and_deduplicates_sig
         _CANDIDATE_A,
         _CANDIDATE_B,
     }
+
+
+def test_diagnostic_checkpoint_accepts_uniform_legacy_missing_generator_identity(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "checkpoint.jsonl"
+    first = _metric(
+        _CANDIDATE_A,
+        symbol="BTCUSDT",
+        episode=0,
+        gross=-0.02,
+        net=-0.03,
+    )
+    second = _metric(
+        _CANDIDATE_B,
+        symbol="BTCUSDT",
+        episode=0,
+        gross=-0.01,
+        net=-0.02,
+    )
+    _write_checkpoint(path, [(first, _GRID, None), (second, _GRID, None)])
+
+    snapshot = module.load_causal_alpha_diagnostic_checkpoint_v2(path)
+    report = module.build_causal_alpha_research_report(snapshot)
+    payload = report.to_payload()
+
+    assert snapshot.generator_code_digest is None
+    assert snapshot.generator_identity_status == "unavailable_legacy"
+    assert report.generator_code_digest is None
+    assert report.generator_identity_status == "unavailable_legacy"
+    assert payload["generator_code_digest"] is None
+    assert payload["generator_identity_status"] == "unavailable_legacy"
+    assert payload["promotion_eligible"] is False
+
+
+def test_diagnostic_checkpoint_rejects_mixed_generator_identity_availability(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "checkpoint.jsonl"
+    first = _metric(
+        _CANDIDATE_A,
+        symbol="BTCUSDT",
+        episode=0,
+        gross=0.0,
+        net=0.0,
+    )
+    second = _metric(
+        _CANDIDATE_B,
+        symbol="BTCUSDT",
+        episode=0,
+        gross=0.0,
+        net=0.0,
+    )
+    _write_checkpoint(
+        path,
+        [(first, _GRID, None), (second, _GRID, _GENERATOR)],
+    )
+
+    with pytest.raises(ValueError, match="generator identity availability"):
+        module.load_causal_alpha_diagnostic_checkpoint_v2(path)
 
 
 def test_diagnostic_checkpoint_rejects_mixed_generator_identity(tmp_path: Path) -> None:

--- a/trade_rl/workflows/causal_alpha_research_diagnostics.py
+++ b/trade_rl/workflows/causal_alpha_research_diagnostics.py
@@ -2,8 +2,9 @@
 
 This module deliberately does not participate in resume or promotion.  It can
 inspect an older v2 checkpoint whose generator identity differs from the
-currently imported implementation, while still requiring every row inside the
-historical checkpoint to agree on one immutable grid/generator identity.
+currently imported implementation, including legacy checkpoints created before
+that identity was recorded.  Every row must agree on both grid identity and
+generator-identity availability.
 """
 
 from __future__ import annotations
@@ -26,6 +27,8 @@ from trade_rl.workflows.universal_causal_alpha_teacher import (
 _CHECKPOINT_SCHEMA = "causal_alpha_selection_checkpoint_metric_v2"
 _REPORT_SCHEMA = "causal_alpha_research_diagnostic_report_v1"
 _SNAPSHOT_SCHEMA = "causal_alpha_diagnostic_checkpoint_v2"
+_GENERATOR_IDENTITY_PRESENT = "present"
+_GENERATOR_IDENTITY_UNAVAILABLE_LEGACY = "unavailable_legacy"
 
 
 def _require_digest(value: object, *, field: str) -> str:
@@ -39,15 +42,19 @@ class CausalAlphaDiagnosticCheckpointV2:
     """One internally consistent historical v2 checkpoint snapshot."""
 
     grid_digest: str
-    generator_code_digest: str
+    generator_code_digest: str | None
     metrics: tuple[CausalAlphaCandidateEpisodeMetricsV2, ...]
     digest: str = ""
 
     def __post_init__(self) -> None:
         grid = _require_digest(self.grid_digest, field="grid digest")
-        generator = _require_digest(
-            self.generator_code_digest,
-            field="generator code digest",
+        generator = (
+            None
+            if self.generator_code_digest is None
+            else _require_digest(
+                self.generator_code_digest,
+                field="generator code digest",
+            )
         )
         metrics = tuple(self.metrics)
         if not metrics:
@@ -60,6 +67,7 @@ class CausalAlphaDiagnosticCheckpointV2:
         expected = content_digest(
             {
                 "generator_code_digest": generator,
+                "generator_identity_status": self.generator_identity_status,
                 "grid_digest": grid,
                 "metric_digests": tuple(item.digest for item in metrics),
                 "schema_version": _SNAPSHOT_SCHEMA,
@@ -75,6 +83,12 @@ class CausalAlphaDiagnosticCheckpointV2:
     @property
     def row_count(self) -> int:
         return len(self.metrics)
+
+    @property
+    def generator_identity_status(self) -> str:
+        if self.generator_code_digest is None:
+            return _GENERATOR_IDENTITY_UNAVAILABLE_LEGACY
+        return _GENERATOR_IDENTITY_PRESENT
 
 
 @dataclass(frozen=True, slots=True)
@@ -121,7 +135,7 @@ class CausalAlphaDiagnosticCandidateSummary:
 class CausalAlphaResearchReport:
     checkpoint_digest: str
     grid_digest: str
-    generator_code_digest: str
+    generator_code_digest: str | None
     row_count: int
     unique_prediction_episode_count: int
     duplicate_signal_row_count: int
@@ -130,8 +144,13 @@ class CausalAlphaResearchReport:
     digest: str = ""
 
     def __post_init__(self) -> None:
-        for field in ("checkpoint_digest", "grid_digest", "generator_code_digest"):
+        for field in ("checkpoint_digest", "grid_digest"):
             _require_digest(getattr(self, field), field=field.replace("_", " "))
+        if self.generator_code_digest is not None:
+            _require_digest(
+                self.generator_code_digest,
+                field="generator code digest",
+            )
         if self.row_count <= 0:
             raise ValueError("causal alpha diagnostic report must contain rows")
         if not 0 < self.unique_prediction_episode_count <= self.row_count:
@@ -160,6 +179,7 @@ class CausalAlphaResearchReport:
             "checkpoint_digest": self.checkpoint_digest,
             "duplicate_signal_row_count": self.duplicate_signal_row_count,
             "generator_code_digest": self.generator_code_digest,
+            "generator_identity_status": self.generator_identity_status,
             "grid_digest": self.grid_digest,
             "promotion_eligible": self.promotion_eligible,
             "row_count": self.row_count,
@@ -169,6 +189,12 @@ class CausalAlphaResearchReport:
         if include_digest:
             payload["artifact_digest"] = self.digest
         return payload
+
+    @property
+    def generator_identity_status(self) -> str:
+        if self.generator_code_digest is None:
+            return _GENERATOR_IDENTITY_UNAVAILABLE_LEGACY
+        return _GENERATOR_IDENTITY_PRESENT
 
 
 @dataclass(frozen=True, slots=True)
@@ -220,6 +246,7 @@ def load_causal_alpha_diagnostic_checkpoint_v2(
     identities: set[tuple[str, str, int]] = set()
     grid_digest: str | None = None
     generator_digest: str | None = None
+    generator_identity_available: bool | None = None
     with source.open("r", encoding="utf-8") as checkpoint:
         for line_number, line in enumerate(checkpoint, start=1):
             if not line.strip():
@@ -234,9 +261,21 @@ def load_causal_alpha_diagnostic_checkpoint_v2(
             if raw.get("schema_version") != _CHECKPOINT_SCHEMA:
                 raise ValueError("causal alpha diagnostic checkpoint schema mismatch")
             row_grid = _require_digest(raw.get("grid_digest"), field="grid digest")
-            row_generator = _require_digest(
-                raw.get("generator_code_digest"),
-                field="generator code digest",
+            row_generator_available = "generator_code_digest" in raw
+            if generator_identity_available is None:
+                generator_identity_available = row_generator_available
+            elif row_generator_available != generator_identity_available:
+                raise ValueError(
+                    "causal alpha diagnostic checkpoint generator identity "
+                    "availability drifted"
+                )
+            row_generator = (
+                _require_digest(
+                    raw["generator_code_digest"],
+                    field="generator code digest",
+                )
+                if row_generator_available
+                else None
             )
             if grid_digest is None:
                 grid_digest = row_grid
@@ -244,9 +283,9 @@ def load_causal_alpha_diagnostic_checkpoint_v2(
                 raise ValueError(
                     "causal alpha diagnostic checkpoint grid identity drifted"
                 )
-            if generator_digest is None:
+            if generator_digest is None and row_generator is not None:
                 generator_digest = row_generator
-            elif row_generator != generator_digest:
+            elif row_generator is not None and row_generator != generator_digest:
                 raise ValueError(
                     "causal alpha diagnostic checkpoint generator identity drifted"
                 )
@@ -256,7 +295,12 @@ def load_causal_alpha_diagnostic_checkpoint_v2(
                 raise ValueError("causal alpha diagnostic checkpoint is duplicated")
             identities.add(identity)
             metrics.append(metric)
-    if not metrics or grid_digest is None or generator_digest is None:
+    if (
+        not metrics
+        or grid_digest is None
+        or generator_identity_available is None
+        or (generator_identity_available and generator_digest is None)
+    ):
         raise ValueError("causal alpha diagnostic checkpoint is empty")
     return CausalAlphaDiagnosticCheckpointV2(
         grid_digest=grid_digest,


### PR DESCRIPTION
## What

Accept historical causal-alpha v2 diagnostic checkpoints whose rows predate recorded generator identity, while keeping them explicitly non-promotable and rejecting mixed identity availability.

## Why

The real r3 checkpoint is legacy evidence and omits `generator_code_digest`. Diagnostic inspection must support that historical format without weakening resume/promotion identity checks.

## Tests

- legacy missing generator identity reports `unavailable_legacy`;
- mixed generator identity availability fails closed;
- diagnostic CLI remains `promotion_eligible=false`.

This PR is intentionally limited to checkpoint diagnostic compatibility. V3 research-runner implementation is separate.