### PR TITLE
fix: make replay execution diagnostics trustworthy

### DIFF
--- a/docs/implementation-plans/specs/2026-08-29-replay-diagnostics-correctness.md
+++ b/docs/implementation-plans/specs/2026-08-29-replay-diagnostics-correctness.md
@@ -1,0 +1,161 @@
+# Replay Diagnostics Correctness Design
+
+## Status
+
+Implemented on a diagnostics-only follow-up branch; final repository/CI verification remains required before completion.
+
+## Objective
+
+Make replay diagnostics describe simulator-observed execution boundaries and authoritative risk projection facts instead of assuming that the requested target equals the realized position, without changing any strategy action, economic gate, reward, cost, execution, risk, fit, horizon, confirmation, or target-selection behavior.
+
+## Non-goals
+
+This change does not:
+
+- change V8/V9/V10 target generation or numerical constants;
+- change Signal, Selection, or Admission thresholds;
+- change reward (`100 * net_log_return`), costs, execution resolution, or PreTrade behavior;
+- reinterpret V10 r5 as passed;
+- change the generic `ActionPathCollapseEvidence` schema or historical V5/V6/V7/V8 replay artifact schemas;
+- claim that one post-step weight exactly explains a whole decision interval's PnL;
+- replace canonical V7/V8 PnL attribution with a requested/realized approximation;
+- introduce one-minute data, BC, or RL.
+
+## Root-cause evidence
+
+1. `evaluate_action_path` previously constructed `ActionPathCollapseEvidence` with `hard_risk_violation=False` unconditionally, while Selection/Admission require zero hard-risk violations.
+2. Closed-loop V10 can receive a simulator-observed current weight that differs from its preceding requested target because of execution, risk projection, or market movement. Existing target/submission counters cannot distinguish a genuine new strategy intent from a policy following realized state or reasserting its prior requested target.
+3. Existing V7/V8 attribution uses simulator-authoritative step economics but classifies exposure using requested target paths. Stateful execution can include existing-position gap PnL, fills, and post-fill intrabar PnL inside one decision interval, so no single post-step weight can be treated as exact whole-interval exposure.
+4. V10 replay leaves did not persist enough execution-boundary evidence to audit requested/risk-constrained/realized divergence or to prove that compact diagnostics were derived from the persisted trace.
+
+## Architecture
+
+`ActionPathEvaluation` gains an immutable `ActionPathExecutionTrace` containing decision-boundary evidence:
+
+- `pre_action_weights`: simulator current weights before the policy/action;
+- `risk_constrained_weights`: authoritative final `hybrid_risk.weights` passed to execution;
+- `post_step_weights`: simulator current weights returned after the step;
+- `applied_risk_scales`: the `hybrid_risk.risk_scale` actually applied for each decision;
+- `strategy_intent_changes`: requested target changes that are neither simply following realized state nor reasserting the prior request;
+- `realized_state_follows`: the realized state diverged from the prior request and the new request follows that realized state;
+- `rebalance_reassertions`: the realized state diverged from the prior request and the policy repeats the prior request;
+- `hard_risk_violations`: authoritative final risk projections that violate the maintained PreTrade hard-limit contract.
+
+The trace is observational. It does not alter action generation or execution. The three V10-oriented change classifications remain in the trace/V10 diagnostics only; they are deliberately not added to generic `ActionPathCollapseEvidence`, preventing V5/V6/BC artifact schema drift.
+
+V10 replay leaf schema is bumped from `causal_alpha_v10_replay_leaf_v2` to `causal_alpha_v10_replay_leaf_v3`. Each leaf persists the full execution trace plus compact V10 diagnostics. Resume validates the trace digest, strict boolean types, compact-diagnostics digest, and exact semantic reconciliation of every derived compact diagnostic with the persisted trace. Because the artifact store is immutable and schema-strict, an existing v2 leaf in the same output root is rejected rather than overwritten; producing v3 evidence requires a fresh output/artifact root.
+
+Canonical V7/V8 PnL attribution remains unchanged until exact bar-level exposure attribution is available.
+
+## Change-class semantics
+
+For tolerance `tol`, let `current` be the pre-action simulator weight, `action` the current requested action, `previous_action` the preceding requested action, and `active`/`previous_active` the current/preceding active masks. Classification is decision-level over active dimensions.
+
+- First decision: if an active `action != current`, mark a strategy intent change.
+- A dimension that is active now but was inactive on the preceding decision has no valid preceding active intent. If its `action != current`, it is a fresh strategy intent change.
+- For dimensions active on both decisions:
+  - realized-state follow: `current != previous_action` and `action == current`;
+  - rebalance reassertion: `current != previous_action`, `action == previous_action`, and `action != current`;
+  - strategy intent change: `action != previous_action` and `action != current`.
+
+This prevents an output value emitted while a dimension was inactive from being misused later as evidence of a previously active strategic target.
+
+`realized_state_follow` is intentionally causal-neutral terminology. It does not claim whether the divergence came from price movement, partial fill, minimum-notional rejection, PreTrade suppression, or another maintained execution effect.
+
+## Hard-risk projection oracle
+
+Hard-risk evidence is evaluated at the risk-projection boundary, not from end-of-step market-drifted exposure.
+
+For each decision:
+
+1. read authoritative final `hybrid_risk.weights` from the environment step result;
+2. read the `hybrid_risk.risk_scale` actually applied for that decision;
+3. compare that projected target with `environment.pre_trade_risk.config`.
+
+A hard-risk projection violation is true when any of these holds beyond `fail_closed_tolerance`:
+
+- `max(abs(risk_constrained_weights)) > max_abs_weight * applied_risk_scale`;
+- `sum(abs(risk_constrained_weights)) > max_gross * applied_risk_scale`;
+- `applied_risk_scale == 0` and any non-zero projected exposure remains.
+
+Post-step actual weights are still persisted for diagnostics, but ordinary price movement after a valid projection must not create a false Selection hard-risk failure. Conversely, an invalid final projection must be detected even if subsequent market movement happens to bring the post-step weight back inside the cap.
+
+If the maintained replay environment does not expose authoritative risk configuration, risk-constrained weights, or the applied risk scale, evaluation fails closed instead of fabricating verified safety.
+
+## V10 diagnostic identity
+
+Compact diagnostics are a deterministic function of `ActionPathExecutionTrace` and include:
+
+- strategy-intent-change count;
+- realized-state-follow count;
+- rebalance-reassertion count;
+- hard-risk-violation boolean;
+- minimum applied risk scale;
+- mean absolute pre-action, risk-constrained, and post-step weight;
+- maximum absolute post-step weight;
+- trace digest.
+
+Resume validation does not trust a self-consistent diagnostics JSON digest alone. It reconstructs the trace, recomputes the canonical diagnostics, and requires exact equality. Therefore changing a derived counter/metric and recomputing only the diagnostics digest is rejected.
+
+## Invariants
+
+- Evaluated actions are identical before and after this change for the same policy/environment inputs.
+- Gross returns, net returns, rewards, costs, turnover, trade count, and execution events are unchanged.
+- V8/V9/V10 strategy constants and candidate mappings are unchanged.
+- Existing generic `submitted_change_count`, `executed_change_count`, and economic gates retain their meanings.
+- Generic `ActionPathCollapseEvidence` does not gain V10-specific change counters.
+- Historical V5-V8 artifacts are not silently reinterpreted under a changed schema.
+- Existing V10 v2 replay leaves are not silently accepted as v3 evidence; a fresh artifact root/replay is required to populate the new trace.
+
+## Failure modes
+
+- Missing or malformed current-weight observation: fail closed.
+- Missing/malformed `hybrid_risk.weights`: fail closed.
+- Missing/invalid applied `risk_scale`: fail closed.
+- Missing authoritative `PreTradeRisk` config: fail closed.
+- Shape drift between action/current/risk/post-step weights: fail closed.
+- Non-boolean event arrays, including string values such as `"false"`: fail closed.
+- Realized-state follow miscounted as strategy change: regression test.
+- Reasserting an unchanged strategic target miscounted as new intent: regression test.
+- Newly active target misclassified using an output from a preceding inactive decision: regression test.
+- Normal post-step price drift misclassified as a hard-risk projection violation: regression test.
+- Invalid final risk projection hidden by later post-step movement: regression test.
+- Diagnostics payload changed with a recomputed self-digest but unchanged trace: resume rejection test.
+- Diagnostics changing PnL/reward/cost: regression test.
+
+## Test Oracle
+
+Correctness is observed through:
+
+- exact recorded pre-action/risk-constrained/post-step weight arrays and applied risk scales;
+- hand-computable strategy-intent/realized-state-follow/reassertion event vectors, including inactive-to-active transitions;
+- hard-risk true/false from explicit `PreTradeRiskConfig`, authoritative projected weights, and applied risk scale;
+- normal post-step drift not affecting hard-risk projection status;
+- equality of performance/economics with the pre-change action path;
+- V10 leaf trace and compact diagnostics identity validation, including semantic tamper rejection;
+- unchanged V5/V6/V7/V8 replay/attribution behavior and V10 target/gate behavior.
+
+## Required Test Layers
+
+1. Unit: execution-trace validation, strict boolean validation, change classification including active-mask transitions, hard-risk projection oracle.
+2. Integration: `evaluate_action_path` with an explicit maintained-style environment exposing risk and boundary weights.
+3. Workflow: V10 leaf write/load/resume identity and semantic-tamper rejection.
+4. Regression: V5-V10 replay/attribution/closed-loop/gate tests.
+5. Static: Ruff, Ruff format, affected Mypy, import-linter.
+6. Repository comparison: full suite against current main with independently reproduced baseline failures handled symmetrically.
+7. Normal GitHub CI on the final PR HEAD.
+
+## Quality Gate
+
+Do not mark complete unless:
+
+- RED tests fail for intended missing/wrong behavior before the corresponding production change;
+- all targeted and required regression tests pass after implementation;
+- explicit invariance tests show no economic output change;
+- V10 diagnostics are persisted, strictly typed, digest-bound, and semantically resume-safe;
+- affected static/architecture checks pass;
+- final diff contains no strategy/gate constant changes and no temporary verification helpers;
+- generic evidence schema remains unchanged;
+- full-suite/build/normal-CI regressions are compared against main;
+- independent/falsification review finds no remaining material contract mismatch;
+- remaining limitations are documented, especially that exact PnL-by-realized-exposure attribution still requires finer-grained execution evidence and a fresh DB-backed V10 run is required to populate the new diagnostics.

--- a/docs/implementation-plans/specs/2026-08-29-replay-diagnostics-correctness.md
+++ b/docs/implementation-plans/specs/2026-08-29-replay-diagnostics-correctness.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Implemented on a diagnostics-only follow-up branch; final repository/CI verification remains required before completion.
+Implemented. This document describes the stable diagnostic contract; exact-HEAD verification and CI evidence are recorded in PR #424 so the contract does not become stale when the branch HEAD changes.
 
 ## Objective
 
@@ -27,6 +27,7 @@ This change does not:
 2. Closed-loop V10 can receive a simulator-observed current weight that differs from its preceding requested target because of execution, risk projection, or market movement. Existing target/submission counters cannot distinguish a genuine new strategy intent from a policy following realized state or reasserting its prior requested target.
 3. Existing V7/V8 attribution uses simulator-authoritative step economics but classifies exposure using requested target paths. Stateful execution can include existing-position gap PnL, fills, and post-fill intrabar PnL inside one decision interval, so no single post-step weight can be treated as exact whole-interval exposure.
 4. V10 replay leaves did not persist enough execution-boundary evidence to audit requested/risk-constrained/realized divergence or to prove that compact diagnostics were derived from the persisted trace.
+5. The first diagnostics implementation required `current_weights` in every observation. That broke maintained flat-observation users such as the behavior-cloning capability audit even though those users previously relied on generic previous-action collapse semantics. Diagnostic truth and generic compatibility therefore need separate references.
 
 ## Architecture
 
@@ -43,13 +44,33 @@ This change does not:
 
 The trace is observational. It does not alter action generation or execution. The three V10-oriented change classifications remain in the trace/V10 diagnostics only; they are deliberately not added to generic `ActionPathCollapseEvidence`, preventing V5/V6/BC artifact schema drift.
 
+### Proposal reference versus forensic trace reference
+
+`evaluate_action_path` deliberately keeps two references because they serve different contracts.
+
+For generic proposal/submission collapse evidence:
+
+1. use observation `current_weights` when the field is present and valid;
+2. otherwise use zero on the first decision and the previously submitted action on later decisions.
+
+This preserves historical flat-observation behavior for generic evaluators and behavior-cloning audits.
+
+For forensic execution trace and V10 change classification:
+
+1. use observation `current_weights` when the field is present and valid;
+2. otherwise read the authoritative current book weight from `environment.hybrid.weights`.
+
+Post-step forensic weights follow the same rule: valid observation `current_weights` first, otherwise authoritative book weights.
+
+Absence of the optional observation field is therefore supported. A present-but-malformed `current_weights` field still fails closed. If forensic trace construction cannot obtain a valid book weight after the observation field is absent, evaluation also fails closed. This separation prevents a compatibility fallback from being mistaken for realized execution state.
+
 V10 replay leaf schema is bumped from `causal_alpha_v10_replay_leaf_v2` to `causal_alpha_v10_replay_leaf_v3`. Each leaf persists the full execution trace plus compact V10 diagnostics. Resume validates the trace digest, strict boolean types, compact-diagnostics digest, exact semantic reconciliation of every derived compact diagnostic with the persisted trace, and equality between trace `decision_count` and replay metric `decision_count`. Because the artifact store is immutable and schema-strict, an existing v2 leaf in the same output root is rejected rather than overwritten; producing v3 evidence requires a fresh output/artifact root.
 
 Canonical V7/V8 PnL attribution remains unchanged until exact bar-level exposure attribution is available.
 
 ## Change-class semantics
 
-For tolerance `tol`, let `current` be the pre-action simulator weight, `action` the current requested action, `previous_action` the preceding requested action, and `active`/`previous_active` the current/preceding active masks. Classification is decision-level over active dimensions.
+For tolerance `tol`, let `current` be the forensic pre-action simulator/book weight, `action` the current requested action, `previous_action` the preceding requested action, and `active`/`previous_active` the current/preceding active masks. Classification is decision-level over active dimensions.
 
 - First decision: if an active `action != current`, mark a strategy intent change.
 - A dimension that is active now but was inactive on the preceding decision has no valid preceding active intent. If its `action != current`, it is a fresh strategy intent change.
@@ -104,6 +125,8 @@ Resume validation does not trust a self-consistent diagnostics JSON digest alone
 - Gross returns, net returns, rewards, costs, turnover, trade count, and execution events are unchanged.
 - V8/V9/V10 strategy constants and candidate mappings are unchanged.
 - Existing generic `submitted_change_count`, `executed_change_count`, and economic gates retain their meanings.
+- Flat-observation generic proposal/submission classification retains the pre-diagnostics zero/previous-action fallback semantics.
+- Forensic trace weights never use the generic zero/previous-action fallback as if it were realized book state.
 - Generic `ActionPathCollapseEvidence` does not gain V10-specific change counters.
 - Historical V5-V8 artifacts are not silently reinterpreted under a changed schema.
 - Existing V10 v2 replay leaves are not silently accepted as v3 evidence; a fresh artifact root/replay is required to populate the new trace.
@@ -111,7 +134,9 @@ Resume validation does not trust a self-consistent diagnostics JSON digest alone
 
 ## Failure modes
 
-- Missing or malformed current-weight observation: fail closed.
+- Observation `current_weights` absent while authoritative book weights are valid: preserve generic fallback semantics and use book weights for forensic trace.
+- Observation `current_weights` present but malformed/non-finite/wrong shape: fail closed.
+- Observation `current_weights` absent and authoritative book weights missing/malformed: fail closed for forensic trace.
 - Missing/malformed `hybrid_risk.weights`: fail closed.
 - Missing/invalid applied `risk_scale`: fail closed.
 - Missing authoritative `PreTradeRisk` config: fail closed.
@@ -120,6 +145,7 @@ Resume validation does not trust a self-consistent diagnostics JSON digest alone
 - Realized-state follow miscounted as strategy change: regression test.
 - Reasserting an unchanged strategic target miscounted as new intent: regression test.
 - Newly active target misclassified using an output from a preceding inactive decision: regression test.
+- Flat-observation compatibility broken by requiring `current_weights`: regression plus full training capability audit.
 - Normal post-step price drift misclassified as a hard-risk projection violation: regression test.
 - Invalid final risk projection hidden by later post-step movement: regression test.
 - Diagnostics payload changed with a recomputed self-digest but unchanged trace: resume rejection test.
@@ -131,22 +157,25 @@ Resume validation does not trust a self-consistent diagnostics JSON digest alone
 Correctness is observed through:
 
 - exact recorded pre-action/risk-constrained/post-step weight arrays and applied risk scales;
+- flat observations retaining generic zero/previous-action proposal classification while trace weights come from the actual book;
 - hand-computable strategy-intent/realized-state-follow/reassertion event vectors, including inactive-to-active transitions;
 - hard-risk true/false from explicit `PreTradeRiskConfig`, authoritative projected weights, and applied risk scale;
 - normal post-step drift not affecting hard-risk projection status;
 - equality of performance/economics with the pre-change action path;
 - V10 leaf trace and compact diagnostics identity validation, including semantic tamper rejection and replay/trace decision-count equality;
-- unchanged V5/V6/V7/V8 replay/attribution behavior and V10 target/gate behavior.
+- unchanged V5/V6/V7/V8 replay/attribution behavior and V10 target/gate behavior;
+- full training capability audit remaining functional for maintained flat-observation consumers.
 
 ## Required Test Layers
 
-1. Unit: execution-trace validation, strict boolean validation, change classification including active-mask transitions, hard-risk projection oracle.
-2. Integration: `evaluate_action_path` with an explicit maintained-style environment exposing risk and boundary weights.
+1. Unit: execution-trace validation, strict boolean validation, change classification including active-mask transitions, flat-observation reference separation, hard-risk projection oracle.
+2. Integration: `evaluate_action_path` with both maintained-style structured observations and flat observations backed by authoritative book state.
 3. Workflow: V10 leaf write/load/resume identity, semantic-tamper rejection, and decision-count mismatch rejection.
-4. Regression: V5-V10 replay/attribution/closed-loop/gate tests.
-5. Static: Ruff, Ruff format, affected Mypy, import-linter.
-6. Repository comparison: full suite against current main with independently reproduced baseline failures handled symmetrically.
-7. Normal GitHub CI on the final PR HEAD.
+4. Regression: V5-V10 replay/attribution/closed-loop/gate tests plus flat-observation rollout compatibility.
+5. Capability: full training capability audit, including behavior cloning.
+6. Static: Ruff, Ruff format, affected Mypy, import-linter.
+7. Repository comparison: full suite against current main with independently reproduced baseline failures handled symmetrically.
+8. Normal GitHub CI on the final PR HEAD.
 
 ## Quality Gate
 
@@ -155,6 +184,7 @@ Do not mark complete unless:
 - RED tests fail for intended missing/wrong behavior before the corresponding production change;
 - all targeted and required regression tests pass after implementation;
 - explicit invariance tests show no economic output change;
+- flat-observation compatibility is covered by a regression test and the full training capability audit;
 - V10 diagnostics are persisted, strictly typed, digest-bound, semantically resume-safe, and decision-count bound to the replay metric;
 - affected static/architecture checks pass;
 - final diff contains no strategy/gate constant changes and no temporary verification helpers;

--- a/docs/implementation-plans/specs/2026-08-29-replay-diagnostics-correctness.md
+++ b/docs/implementation-plans/specs/2026-08-29-replay-diagnostics-correctness.md
@@ -43,7 +43,7 @@ This change does not:
 
 The trace is observational. It does not alter action generation or execution. The three V10-oriented change classifications remain in the trace/V10 diagnostics only; they are deliberately not added to generic `ActionPathCollapseEvidence`, preventing V5/V6/BC artifact schema drift.
 
-V10 replay leaf schema is bumped from `causal_alpha_v10_replay_leaf_v2` to `causal_alpha_v10_replay_leaf_v3`. Each leaf persists the full execution trace plus compact V10 diagnostics. Resume validates the trace digest, strict boolean types, compact-diagnostics digest, and exact semantic reconciliation of every derived compact diagnostic with the persisted trace. Because the artifact store is immutable and schema-strict, an existing v2 leaf in the same output root is rejected rather than overwritten; producing v3 evidence requires a fresh output/artifact root.
+V10 replay leaf schema is bumped from `causal_alpha_v10_replay_leaf_v2` to `causal_alpha_v10_replay_leaf_v3`. Each leaf persists the full execution trace plus compact V10 diagnostics. Resume validates the trace digest, strict boolean types, compact-diagnostics digest, exact semantic reconciliation of every derived compact diagnostic with the persisted trace, and equality between trace `decision_count` and replay metric `decision_count`. Because the artifact store is immutable and schema-strict, an existing v2 leaf in the same output root is rejected rather than overwritten; producing v3 evidence requires a fresh output/artifact root.
 
 Canonical V7/V8 PnL attribution remains unchanged until exact bar-level exposure attribution is available.
 
@@ -86,6 +86,7 @@ If the maintained replay environment does not expose authoritative risk configur
 
 Compact diagnostics are a deterministic function of `ActionPathExecutionTrace` and include:
 
+- decision count;
 - strategy-intent-change count;
 - realized-state-follow count;
 - rebalance-reassertion count;
@@ -95,7 +96,7 @@ Compact diagnostics are a deterministic function of `ActionPathExecutionTrace` a
 - maximum absolute post-step weight;
 - trace digest.
 
-Resume validation does not trust a self-consistent diagnostics JSON digest alone. It reconstructs the trace, recomputes the canonical diagnostics, and requires exact equality. Therefore changing a derived counter/metric and recomputing only the diagnostics digest is rejected.
+Resume validation does not trust a self-consistent diagnostics JSON digest alone. It reconstructs the trace, recomputes the canonical diagnostics, and requires exact equality. It also requires the reconstructed trace decision count to equal the replay metric decision count. Therefore changing a derived counter/metric and recomputing only the diagnostics digest, or substituting a self-consistent trace from a different-length replay, is rejected.
 
 ## Invariants
 
@@ -106,6 +107,7 @@ Resume validation does not trust a self-consistent diagnostics JSON digest alone
 - Generic `ActionPathCollapseEvidence` does not gain V10-specific change counters.
 - Historical V5-V8 artifacts are not silently reinterpreted under a changed schema.
 - Existing V10 v2 replay leaves are not silently accepted as v3 evidence; a fresh artifact root/replay is required to populate the new trace.
+- A V10 trace cannot be resumed against a replay with a different decision count.
 
 ## Failure modes
 
@@ -121,6 +123,7 @@ Resume validation does not trust a self-consistent diagnostics JSON digest alone
 - Normal post-step price drift misclassified as a hard-risk projection violation: regression test.
 - Invalid final risk projection hidden by later post-step movement: regression test.
 - Diagnostics payload changed with a recomputed self-digest but unchanged trace: resume rejection test.
+- Self-consistent execution trace from a different decision count accepted for a replay: resume rejection test.
 - Diagnostics changing PnL/reward/cost: regression test.
 
 ## Test Oracle
@@ -132,14 +135,14 @@ Correctness is observed through:
 - hard-risk true/false from explicit `PreTradeRiskConfig`, authoritative projected weights, and applied risk scale;
 - normal post-step drift not affecting hard-risk projection status;
 - equality of performance/economics with the pre-change action path;
-- V10 leaf trace and compact diagnostics identity validation, including semantic tamper rejection;
+- V10 leaf trace and compact diagnostics identity validation, including semantic tamper rejection and replay/trace decision-count equality;
 - unchanged V5/V6/V7/V8 replay/attribution behavior and V10 target/gate behavior.
 
 ## Required Test Layers
 
 1. Unit: execution-trace validation, strict boolean validation, change classification including active-mask transitions, hard-risk projection oracle.
 2. Integration: `evaluate_action_path` with an explicit maintained-style environment exposing risk and boundary weights.
-3. Workflow: V10 leaf write/load/resume identity and semantic-tamper rejection.
+3. Workflow: V10 leaf write/load/resume identity, semantic-tamper rejection, and decision-count mismatch rejection.
 4. Regression: V5-V10 replay/attribution/closed-loop/gate tests.
 5. Static: Ruff, Ruff format, affected Mypy, import-linter.
 6. Repository comparison: full suite against current main with independently reproduced baseline failures handled symmetrically.
@@ -152,7 +155,7 @@ Do not mark complete unless:
 - RED tests fail for intended missing/wrong behavior before the corresponding production change;
 - all targeted and required regression tests pass after implementation;
 - explicit invariance tests show no economic output change;
-- V10 diagnostics are persisted, strictly typed, digest-bound, and semantically resume-safe;
+- V10 diagnostics are persisted, strictly typed, digest-bound, semantically resume-safe, and decision-count bound to the replay metric;
 - affected static/architecture checks pass;
 - final diff contains no strategy/gate constant changes and no temporary verification helpers;
 - generic evidence schema remains unchanged;

--- a/docs/superpowers/plans/2026-08-29-replay-diagnostics-correctness.md
+++ b/docs/superpowers/plans/2026-08-29-replay-diagnostics-correctness.md
@@ -93,8 +93,11 @@ The authoritative oracle is the final risk target returned as `hybrid_risk.weigh
 - [x] Validate diagnostics content digest and trace identity.
 - [x] RED: changing a derived diagnostics counter and recomputing the diagnostics self-digest was still accepted.
 - [x] GREEN: derive compact diagnostics through one canonical trace function and require resume payload equality with recomputed values.
+- [x] Falsification RED: a self-consistent one-step trace could be resumed against a two-decision replay metric because trace length was not bound to replay identity (`1 failed / 3 passed`).
+- [x] GREEN: include canonical diagnostics `decision_count` and require equality with `metric.v6_metric.decision_count` on resume.
 
 **Compact diagnostics include:**
+- decision count;
 - strategy-intent-change count;
 - realized-state-follow count;
 - rebalance-reassertion count;
@@ -104,7 +107,7 @@ The authoritative oracle is the final risk target returned as `hybrid_risk.weigh
 - maximum absolute post-step weight;
 - trace digest.
 
-**Resume rule:** old V10 v2 leaves are not silently reused as v3 evidence. Because artifact leaves are immutable and schema-strict, a fresh v3 replay uses a new output/artifact root rather than overwriting a v2 leaf in place.
+**Resume rule:** old V10 v2 leaves are not silently reused as v3 evidence. Because artifact leaves are immutable and schema-strict, a fresh v3 replay uses a new output/artifact root rather than overwriting a v2 leaf in place. A v3 trace must also cover exactly the replay metric's decision count.
 
 ---
 
@@ -149,10 +152,12 @@ uv run lint-imports
 - [x] Mypy narrowing issues found and corrected.
 - [x] Import-layer contract verified after the implementation.
 - [x] Complete targeted/static matrix passed after the active-mask correction: 67 targeted tests plus Ruff, format, affected Mypy, import-linter, and scope invariants.
+- [x] Targeted resume/stage tests plus Ruff/format/Mypy passed after the decision-count identity correction.
 - [x] Delete temporary `.github/patch_*` helpers used before the final active-mask patch; delete the final active-mask helper before final diff verification.
 - [ ] Delete temporary verification workflow after final full comparator.
 - [ ] Verify final diff contains no `trade_rl/learning/evaluation.py` change and no temporary helper.
-- [ ] Run full-suite/build comparator against current main and classify any baseline failures symmetrically on the final source-equivalent HEAD.
+- [ ] Re-run the complete targeted/static matrix on the exact final PR HEAD including the new decision-count test.
+- [ ] Run full-suite/build comparator against current main and classify any baseline failures symmetrically on the final PR HEAD.
 - [ ] Run normal GitHub CI on final Draft PR HEAD.
 
 ---
@@ -168,6 +173,7 @@ Review from the original requirements rather than implementation assumptions:
 - [ ] Can compact diagnostics be changed and self-rehashed without changing the trace?
 - [ ] Can V10-specific counters leak into generic V5/V6/BC artifacts?
 - [ ] Can an inactive output be mistaken for prior active intent after reactivation?
+- [ ] Can a self-consistent trace with a different decision count be resumed for this replay?
 - [ ] Can a v2 leaf be mistaken for v3 evidence?
 - [ ] Did any strategy/gate constant or economic output change?
 - [ ] Are attribution limitations explicit rather than disguised as realized-PnL attribution?

--- a/docs/superpowers/plans/2026-08-29-replay-diagnostics-correctness.md
+++ b/docs/superpowers/plans/2026-08-29-replay-diagnostics-correctness.md
@@ -1,0 +1,175 @@
+# Replay Diagnostics Correctness Implementation Plan
+
+> **Execution status:** implementation complete on the working branch; final cleanup, full verification, and PR verification remain.
+
+**Goal:** Persist simulator-observed execution-boundary evidence and trustworthy V10 diagnostics without changing trading economics, generic replay artifact semantics, or fixed research gates.
+
+**Architecture:** Add an immutable execution trace to `ActionPathEvaluation`. Keep V10-oriented change classes in that trace/V10 leaf diagnostics only. Persist V10 replay leaf v3 evidence and validate compact diagnostics by recomputing them from the persisted trace. Preserve canonical V7/V8 PnL attribution because a single decision-boundary weight is not exact whole-interval exposure.
+
+**Tech Stack:** Python 3.12, NumPy, pytest, GitHub Actions, Ruff, Mypy, import-linter.
+
+**Spec:** `docs/implementation-plans/specs/2026-08-29-replay-diagnostics-correctness.md`
+
+## Global Constraints
+
+- No V8/V9/V10 strategy constants, Signal/Selection/Admission numerical gates, reward, execution, cost, or target behavior changes.
+- Do not change generic `ActionPathCollapseEvidence` or historical V5/V6/V7/V8 replay artifact schemas.
+- Do not interpret post-step weights as exact whole-interval PnL exposure.
+- Hard-risk gate evidence is about the authoritative final risk projection, not ordinary market drift after projection.
+- RED -> GREEN -> Refactor applies to each contract change.
+- Final PR remains Draft/unmerged unless explicitly authorized.
+
+---
+
+### Task 1: Execution-boundary trace and change classification
+
+**Files:**
+- `trade_rl/learning/rollout_evaluation.py`
+- `tests/learning/test_rollout_evaluation.py`
+- `tests/learning/test_rollout_risk_timing.py`
+- `tests/learning/test_rollout_active_mask_classification.py`
+
+**Implemented trace:**
+
+```python
+ActionPathExecutionTrace(
+    pre_action_weights=...,
+    risk_constrained_weights=...,
+    post_step_weights=...,
+    applied_risk_scales=...,
+    strategy_intent_changes=...,
+    realized_state_follows=...,
+    rebalance_reassertions=...,
+    hard_risk_violations=...,
+)
+```
+
+- [x] RED: prove missing execution trace.
+- [x] GREEN: record aligned immutable boundary states without changing step economics.
+- [x] RED: distinguish strategy intent, realized-state follow, and rebalance reassertion.
+- [x] GREEN: classify those events at decision level over active dimensions.
+- [x] Falsification correction: remove V10 change counters from generic `ActionPathCollapseEvidence` to prevent V5/V6/BC schema drift.
+- [x] Falsification correction: rename `passive_weight_drift` to causal-neutral `realized_state_follow`.
+- [x] RED/GREEN: reject non-boolean event arrays rather than coercing strings such as `"false"`.
+- [x] RED: a target emitted while a dimension was inactive was incorrectly reused as prior active intent when the dimension became active.
+- [x] GREEN: track `previous_active`; only continuously active dimensions compare with prior requested intent, while newly active proposed targets are fresh strategy intent.
+
+**Oracle:** evaluated actions and gross/net return, reward, cost, turnover, and execution events remain unchanged; only additional observational trace is produced.
+
+---
+
+### Task 2: Hard-risk evidence at the correct boundary
+
+**Files:**
+- `trade_rl/learning/rollout_evaluation.py`
+- `tests/learning/test_rollout_evaluation.py`
+- `tests/learning/test_rollout_risk_timing.py`
+
+The authoritative oracle is the final risk target returned as `hybrid_risk.weights` plus the `hybrid_risk.risk_scale` actually applied before execution.
+
+- [x] RED: fixed `hard_risk_violation=False` hides violations.
+- [x] GREEN: calculate violation from maintained PreTrade hard limits.
+- [x] Falsification correction: stop recomputing scale from end-of-step drawdown; use the applied risk scale from the step result.
+- [x] Falsification correction: stop gating on post-step actual weight because ordinary market movement can drift weight after a valid projection.
+- [x] RED/GREEN: a valid projected `0.05` with later post-step `0.06` at a `0.05` cap is not a hard-risk projection violation.
+- [x] RED/GREEN: an invalid projected `0.06` at a `0.05` cap is a violation even if post-step movement later returns actual weight to `0.04`.
+
+**Oracle:** hard-risk status matches the maintained risk-projection contract while post-step realized weight remains available only as diagnostic evidence.
+
+---
+
+### Task 3: Persist V10-owned trace and compact diagnostics
+
+**Files:**
+- `trade_rl/workflows/universal_causal_alpha_v10_diagnostics.py`
+- `trade_rl/workflows/universal_causal_alpha_v10_stage_entry.py`
+- `tests/workflows/test_universal_causal_alpha_v10_stage_entry.py`
+- `tests/workflows/test_universal_causal_alpha_v10_resume_identity.py`
+
+- [x] RED: V10 leaf lacked execution trace/diagnostics.
+- [x] GREEN: bump only V10 replay leaf `v2 -> v3` and persist full trace plus compact diagnostics.
+- [x] Bind trace digest to all boundary weight arrays, applied risk scales, and boolean event vectors.
+- [x] Strictly validate boolean trace fields.
+- [x] Validate diagnostics content digest and trace identity.
+- [x] RED: changing a derived diagnostics counter and recomputing the diagnostics self-digest was still accepted.
+- [x] GREEN: derive compact diagnostics through one canonical trace function and require resume payload equality with recomputed values.
+
+**Compact diagnostics include:**
+- strategy-intent-change count;
+- realized-state-follow count;
+- rebalance-reassertion count;
+- hard-risk-violation boolean;
+- minimum applied risk scale;
+- mean absolute pre-action/risk-constrained/post-step weights;
+- maximum absolute post-step weight;
+- trace digest.
+
+**Resume rule:** old V10 v2 leaves are not silently reused as v3 evidence. Because artifact leaves are immutable and schema-strict, a fresh v3 replay uses a new output/artifact root rather than overwriting a v2 leaf in place.
+
+---
+
+### Task 4: Regression and static verification
+
+**Required targeted regression surface:**
+
+```bash
+uv run pytest -q \
+  tests/learning/test_rollout_evaluation.py \
+  tests/learning/test_rollout_risk_timing.py \
+  tests/learning/test_rollout_active_mask_classification.py \
+  tests/learning/test_causal_alpha_v10_closed_loop.py \
+  tests/learning/test_causal_alpha_v10_closed_loop_falsification.py \
+  tests/learning/test_causal_alpha_v10_closed_loop_additional_falsification.py \
+  tests/learning/test_causal_alpha_v10_target_trace.py \
+  tests/workflows/test_universal_causal_alpha_v5_replay.py \
+  tests/workflows/test_universal_causal_alpha_v6_replay.py \
+  tests/workflows/test_universal_causal_alpha_v7_attribution.py \
+  tests/workflows/test_universal_causal_alpha_v8_attribution.py \
+  tests/workflows/test_universal_causal_alpha_v8_replay.py \
+  tests/workflows/test_universal_causal_alpha_v10_stage_entry.py \
+  tests/workflows/test_universal_causal_alpha_v10_resume_identity.py \
+  tests/workflows/test_universal_causal_alpha_v10_gates.py \
+  tests/simulation/test_causal_alpha_v10_execution_contract.py
+```
+
+Static checks:
+
+```bash
+uv run ruff check <changed Python files>
+uv run ruff format --check <changed Python files>
+uv run mypy \
+  trade_rl/learning/rollout_evaluation.py \
+  trade_rl/workflows/universal_causal_alpha_v10_diagnostics.py \
+  trade_rl/workflows/universal_causal_alpha_v10_stage_entry.py
+uv run lint-imports
+```
+
+- [x] Related V5-V10 regression coverage established.
+- [x] Ruff issues found and corrected.
+- [x] Mypy narrowing issues found and corrected.
+- [x] Import-layer contract verified after the implementation.
+- [x] Complete targeted/static matrix passed after the active-mask correction: 67 targeted tests plus Ruff, format, affected Mypy, import-linter, and scope invariants.
+- [x] Delete temporary `.github/patch_*` helpers used before the final active-mask patch; delete the final active-mask helper before final diff verification.
+- [ ] Delete temporary verification workflow after final full comparator.
+- [ ] Verify final diff contains no `trade_rl/learning/evaluation.py` change and no temporary helper.
+- [ ] Run full-suite/build comparator against current main and classify any baseline failures symmetrically on the final source-equivalent HEAD.
+- [ ] Run normal GitHub CI on final Draft PR HEAD.
+
+---
+
+### Task 5: Final falsification and handoff
+
+Review from the original requirements rather than implementation assumptions:
+
+- [ ] Can requested, risk-constrained, and post-step weights still be confused?
+- [ ] Can ordinary price movement falsely trip the hard-risk Selection gate?
+- [ ] Can an invalid final risk projection be hidden by later movement?
+- [ ] Can non-boolean trace payloads be coerced and accepted?
+- [ ] Can compact diagnostics be changed and self-rehashed without changing the trace?
+- [ ] Can V10-specific counters leak into generic V5/V6/BC artifacts?
+- [ ] Can an inactive output be mistaken for prior active intent after reactivation?
+- [ ] Can a v2 leaf be mistaken for v3 evidence?
+- [ ] Did any strategy/gate constant or economic output change?
+- [ ] Are attribution limitations explicit rather than disguised as realized-PnL attribution?
+
+Final evidence must record final HEAD, final diff, targeted/full tests, static checks, build, normal CI, PR status, remaining limitations, and the fact that a fresh DB-backed V10 Selection run is still required before the new diagnostics can explain real economic outcomes.

--- a/docs/superpowers/plans/2026-08-29-replay-diagnostics-correctness.md
+++ b/docs/superpowers/plans/2026-08-29-replay-diagnostics-correctness.md
@@ -1,10 +1,10 @@
 # Replay Diagnostics Correctness Implementation Plan
 
-> **Execution status:** implementation complete on the working branch; final cleanup, full verification, and PR verification remain.
+> **Execution status:** implementation and source-bearing verification are complete. Exact PR-head CI and repository cleanup evidence are tracked in PR #424 rather than encoded as transient status in this plan.
 
 **Goal:** Persist simulator-observed execution-boundary evidence and trustworthy V10 diagnostics without changing trading economics, generic replay artifact semantics, or fixed research gates.
 
-**Architecture:** Add an immutable execution trace to `ActionPathEvaluation`. Keep V10-oriented change classes in that trace/V10 leaf diagnostics only. Persist V10 replay leaf v3 evidence and validate compact diagnostics by recomputing them from the persisted trace. Preserve canonical V7/V8 PnL attribution because a single decision-boundary weight is not exact whole-interval exposure.
+**Architecture:** Add an immutable execution trace to `ActionPathEvaluation`. Keep V10-oriented change classes in that trace/V10 leaf diagnostics only. Persist V10 replay leaf v3 evidence and validate compact diagnostics by recomputing them from the persisted trace. Preserve canonical V7/V8 PnL attribution because a single decision-boundary weight is not exact whole-interval exposure. Separate generic proposal-reference compatibility from forensic book-state tracing so flat observations remain supported without fabricating realized state.
 
 **Tech Stack:** Python 3.12, NumPy, pytest, GitHub Actions, Ruff, Mypy, import-linter.
 
@@ -16,18 +16,21 @@
 - Do not change generic `ActionPathCollapseEvidence` or historical V5/V6/V7/V8 replay artifact schemas.
 - Do not interpret post-step weights as exact whole-interval PnL exposure.
 - Hard-risk gate evidence is about the authoritative final risk projection, not ordinary market drift after projection.
+- Missing optional observation `current_weights` must not break historical flat-observation generic collapse behavior; forensic trace must use authoritative book state instead.
+- Present-but-malformed observation weights, malformed risk evidence, or malformed authoritative book state fail closed.
 - RED -> GREEN -> Refactor applies to each contract change.
 - Final PR remains Draft/unmerged unless explicitly authorized.
 
 ---
 
-### Task 1: Execution-boundary trace and change classification
+### Task 1: Execution-boundary trace, change classification, and reference separation
 
 **Files:**
 - `trade_rl/learning/rollout_evaluation.py`
 - `tests/learning/test_rollout_evaluation.py`
 - `tests/learning/test_rollout_risk_timing.py`
 - `tests/learning/test_rollout_active_mask_classification.py`
+- `tests/learning/test_rollout_flat_observation_trace.py`
 
 **Implemented trace:**
 
@@ -53,8 +56,11 @@ ActionPathExecutionTrace(
 - [x] RED/GREEN: reject non-boolean event arrays rather than coercing strings such as `"false"`.
 - [x] RED: a target emitted while a dimension was inactive was incorrectly reused as prior active intent when the dimension became active.
 - [x] GREEN: track `previous_active`; only continuously active dimensions compare with prior requested intent, while newly active proposed targets are fresh strategy intent.
+- [x] Falsification RED: requiring observation `current_weights` broke the maintained flat-observation behavior-cloning audit.
+- [x] GREEN: split references. Generic proposal collapse uses valid observation weights when present, otherwise first-decision zero / later previous action. Forensic trace uses valid observation weights when present, otherwise `environment.hybrid.weights`.
+- [x] Regression: post-step forensic trace also falls back to authoritative book weights when flat observations omit `current_weights`.
 
-**Oracle:** evaluated actions and gross/net return, reward, cost, turnover, and execution events remain unchanged; only additional observational trace is produced.
+**Oracle:** evaluated actions and gross/net return, reward, cost, turnover, and execution events remain unchanged; generic flat-observation collapse semantics remain compatible; forensic trace records actual book state rather than generic fallback values.
 
 ---
 
@@ -93,30 +99,22 @@ The authoritative oracle is the final risk target returned as `hybrid_risk.weigh
 - [x] Validate diagnostics content digest and trace identity.
 - [x] RED: changing a derived diagnostics counter and recomputing the diagnostics self-digest was still accepted.
 - [x] GREEN: derive compact diagnostics through one canonical trace function and require resume payload equality with recomputed values.
-- [x] Falsification RED: a self-consistent one-step trace could be resumed against a two-decision replay metric because trace length was not bound to replay identity (`1 failed / 3 passed`).
+- [x] Falsification RED: a self-consistent one-step trace could be resumed against a two-decision replay metric because trace length was not bound to replay identity.
 - [x] GREEN: include canonical diagnostics `decision_count` and require equality with `metric.v6_metric.decision_count` on resume.
 
-**Compact diagnostics include:**
-- decision count;
-- strategy-intent-change count;
-- realized-state-follow count;
-- rebalance-reassertion count;
-- hard-risk-violation boolean;
-- minimum applied risk scale;
-- mean absolute pre-action/risk-constrained/post-step weights;
-- maximum absolute post-step weight;
-- trace digest.
+**Compact diagnostics include:** decision count; strategy-intent-change count; realized-state-follow count; rebalance-reassertion count; hard-risk-violation boolean; minimum applied risk scale; mean absolute pre-action/risk-constrained/post-step weights; maximum absolute post-step weight; trace digest.
 
 **Resume rule:** old V10 v2 leaves are not silently reused as v3 evidence. Because artifact leaves are immutable and schema-strict, a fresh v3 replay uses a new output/artifact root rather than overwriting a v2 leaf in place. A v3 trace must also cover exactly the replay metric's decision count.
 
 ---
 
-### Task 4: Regression and static verification
+### Task 4: Regression, capability, static, and repository verification
 
 **Required targeted regression surface:**
 
 ```bash
 uv run pytest -q \
+  tests/learning/test_rollout_flat_observation_trace.py \
   tests/learning/test_rollout_evaluation.py \
   tests/learning/test_rollout_risk_timing.py \
   tests/learning/test_rollout_active_mask_classification.py \
@@ -135,30 +133,33 @@ uv run pytest -q \
   tests/simulation/test_causal_alpha_v10_execution_contract.py
 ```
 
-Static checks:
+Static/capability checks:
 
 ```bash
-uv run ruff check <changed Python files>
-uv run ruff format --check <changed Python files>
+uv run ruff check <changed Python files and affected tests>
+uv run ruff format --check <changed Python files and affected tests>
 uv run mypy \
   trade_rl/learning/rollout_evaluation.py \
   trade_rl/workflows/universal_causal_alpha_v10_diagnostics.py \
   trade_rl/workflows/universal_causal_alpha_v10_stage_entry.py
 uv run lint-imports
+uv run python scripts/run_training_capability_audit.py --output <fresh-output>
+uv build
 ```
 
-- [x] Related V5-V10 regression coverage established.
-- [x] Ruff issues found and corrected.
-- [x] Mypy narrowing issues found and corrected.
-- [x] Import-layer contract verified after the implementation.
-- [x] Complete targeted/static matrix passed after the active-mask correction: 67 targeted tests plus Ruff, format, affected Mypy, import-linter, and scope invariants.
-- [x] Targeted resume/stage tests plus Ruff/format/Mypy passed after the decision-count identity correction.
-- [x] Delete temporary `.github/patch_*` helpers used before the final active-mask patch; delete the final active-mask helper before final diff verification.
-- [ ] Delete temporary verification workflow after final full comparator.
-- [ ] Verify final diff contains no `trade_rl/learning/evaluation.py` change and no temporary helper.
-- [ ] Re-run the complete targeted/static matrix on the exact final PR HEAD including the new decision-count test.
-- [ ] Run full-suite/build comparator against current main and classify any baseline failures symmetrically on the final PR HEAD.
-- [ ] Run normal GitHub CI on final Draft PR HEAD.
+Verified source-bearing head `f03c6b9e60d5452af341c3eca32302bb8c7c98a1`:
+
+- [x] 69 targeted/compatibility tests passed.
+- [x] Ruff affected surface passed.
+- [x] Ruff format affected surface passed.
+- [x] Affected Mypy passed.
+- [x] Import architecture passed: 13 kept, 0 broken.
+- [x] Full training capability audit passed, including behavior cloning.
+- [x] Package build passed.
+- [x] PR diff contained no `trade_rl/learning/evaluation.py` change and no temporary `.github` verification helper.
+- [x] Full-suite comparator used the same environment for PR and base main. PR: 4457 passed, 26 skipped, 3 failed. Main: 4444 passed, 26 skipped, 3 failed. The same three pre-existing architecture/documentation failures occurred on both sides; no PR-only full-suite failure was observed.
+
+Exact CI status for subsequent documentation-only cleanup commits is recorded in PR #424. Do not reuse an older successful run as evidence for a newer HEAD.
 
 ---
 
@@ -166,16 +167,17 @@ uv run lint-imports
 
 Review from the original requirements rather than implementation assumptions:
 
-- [ ] Can requested, risk-constrained, and post-step weights still be confused?
-- [ ] Can ordinary price movement falsely trip the hard-risk Selection gate?
-- [ ] Can an invalid final risk projection be hidden by later movement?
-- [ ] Can non-boolean trace payloads be coerced and accepted?
-- [ ] Can compact diagnostics be changed and self-rehashed without changing the trace?
-- [ ] Can V10-specific counters leak into generic V5/V6/BC artifacts?
-- [ ] Can an inactive output be mistaken for prior active intent after reactivation?
-- [ ] Can a self-consistent trace with a different decision count be resumed for this replay?
-- [ ] Can a v2 leaf be mistaken for v3 evidence?
-- [ ] Did any strategy/gate constant or economic output change?
-- [ ] Are attribution limitations explicit rather than disguised as realized-PnL attribution?
+- [x] Requested, generic proposal-reference, forensic pre-action, risk-constrained, and post-step states have distinct semantics.
+- [x] Ordinary price movement does not falsely trip the hard-risk Selection gate.
+- [x] An invalid final risk projection cannot be hidden by later movement.
+- [x] Non-boolean trace payloads are rejected rather than coerced.
+- [x] Compact diagnostics cannot be changed and self-rehashed without matching the persisted trace.
+- [x] V10-specific counters do not leak into generic V5/V6/BC collapse evidence.
+- [x] Inactive output is not treated as prior active intent after reactivation.
+- [x] A self-consistent trace with a different decision count cannot be resumed for this replay.
+- [x] A v2 leaf cannot be mistaken for v3 evidence.
+- [x] Strategy/gate constants and economic output are outside this change and no such production file appears in the final diff.
+- [x] Attribution limitations are explicit rather than disguised as realized-PnL attribution.
+- [x] Flat-observation compatibility was independently falsified by the Full training capability failure before the reference split and is covered by a dedicated regression after the fix.
 
-Final evidence must record final HEAD, final diff, targeted/full tests, static checks, build, normal CI, PR status, remaining limitations, and the fact that a fresh DB-backed V10 Selection run is still required before the new diagnostics can explain real economic outcomes.
+Final handoff evidence must record the current PR HEAD, final diff, targeted/full tests, static checks, build, normal CI, PR state, remaining limitations, and the fact that a fresh DB-backed V10 Selection run is still required before the new diagnostics can explain real economic outcomes.

--- a/tests/learning/test_rollout_active_mask_classification.py
+++ b/tests/learning/test_rollout_active_mask_classification.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from trade_rl.learning import rollout_evaluation
+from trade_rl.risk.pretrade import PreTradeRisk, PreTradeRiskConfig
+
+
+class _Trades:
+    def __init__(self, multipliers: np.ndarray) -> None:
+        del multipliers
+
+    def seed_positions(self, *, quantities: np.ndarray, prices: np.ndarray) -> None:
+        del quantities, prices
+
+    def ingest_stateful(self, execution: object) -> None:
+        del execution
+
+    def ingest_liquidation(self, liquidation: object) -> None:
+        del liquidation
+
+    def diagnostics(self) -> SimpleNamespace:
+        return SimpleNamespace(closed_trades=0, winning_trades=0)
+
+
+class _Dataset:
+    def resolved_array(self, name: str) -> np.ndarray:
+        assert name == "contract_multipliers"
+        return np.ones(1, dtype=np.float64)
+
+
+class _Environment:
+    dataset = _Dataset()
+
+    def __init__(self) -> None:
+        self.current_index = 0
+        self._offset = 0
+        self._weight = 0.0
+        self.pre_trade_risk = PreTradeRisk(
+            PreTradeRiskConfig(
+                max_gross=1.0,
+                max_abs_weight=0.5,
+                max_turnover=1.0,
+            )
+        )
+        self.hybrid = SimpleNamespace(
+            max_drawdown=0.0,
+            quantities=np.zeros(1, dtype=np.float64),
+            mark_prices=np.ones(1, dtype=np.float64),
+        )
+        self._active = (False, True, True, True)
+
+    def _observation(self) -> dict[str, np.ndarray]:
+        return {
+            "current_weights": np.asarray([self._weight], dtype=np.float32),
+            "active": np.asarray([self._active[self._offset]], dtype=np.float32),
+        }
+
+    def reset(
+        self, *, options: dict[str, object]
+    ) -> tuple[dict[str, np.ndarray], dict[str, object]]:
+        start = options["start_idx"]
+        assert isinstance(start, int)
+        self.current_index = start
+        self._offset = 0
+        self._weight = 0.0
+        return self._observation(), {}
+
+    def step(
+        self, action: np.ndarray
+    ) -> tuple[dict[str, np.ndarray], float, bool, bool, dict[str, object]]:
+        if self._offset == 0:
+            constrained = np.asarray([0.0], dtype=np.float64)
+            filled_turnover = 0.0
+        else:
+            constrained = np.asarray(action, dtype=np.float64).reshape(-1).copy()
+            filled_turnover = abs(float(action[0]) - self._weight)
+            self._weight = float(action[0])
+        execution = SimpleNamespace(
+            requested_turnover=filled_turnover,
+            filled_turnover=filled_turnover,
+            rejected_count=0,
+            order_events=(),
+        )
+        info: dict[str, object] = {
+            "hybrid_execution": execution,
+            "hybrid_risk": SimpleNamespace(
+                weights=constrained,
+                risk_scale=1.0,
+                reasons=(),
+            ),
+            "hybrid_liquidation": None,
+            "interval_gross_return": 0.0,
+            "interval_net_return": 0.0,
+            "interval_cost": 0.0,
+        }
+        self._offset += 1
+        self.current_index += 1
+        terminal = self._offset == 3
+        return self._observation(), 0.0, terminal, False, info
+
+
+def test_newly_active_target_is_fresh_intent_not_reassertion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(rollout_evaluation, "ClosedTradeTracker", _Trades)
+    result = rollout_evaluation.evaluate_action_path(
+        _Environment(),
+        evaluation_range=(0, 4),
+        actions=np.asarray([[0.4], [0.4], [0.4]], dtype=np.float32),
+    )
+
+    trace = result.execution_trace
+    assert trace is not None
+    assert trace.strategy_intent_changes.tolist() == [False, True, False]
+    assert trace.realized_state_follows.tolist() == [False, False, False]
+    assert trace.rebalance_reassertions.tolist() == [False, False, False]

--- a/tests/learning/test_rollout_evaluation.py
+++ b/tests/learning/test_rollout_evaluation.py
@@ -6,11 +6,15 @@ import numpy as np
 import pytest
 
 from trade_rl.learning import rollout_evaluation
+from trade_rl.risk.pretrade import PreTradeRisk, PreTradeRiskConfig
 
 
 class _Trades:
     def __init__(self, multipliers: np.ndarray) -> None:
         del multipliers
+
+    def seed_positions(self, *, quantities: np.ndarray, prices: np.ndarray) -> None:
+        del quantities, prices
 
     def ingest_stateful(self, execution: object) -> None:
         del execution
@@ -39,6 +43,11 @@ class _Environment:
         gross_returns: tuple[float, ...] = (0.0, 0.0, 0.0),
         net_returns: tuple[float, ...] = (0.0, 0.0, 0.0),
         costs: tuple[float, ...] = (0.0, 0.0, 0.0),
+        post_weights: tuple[tuple[float, float], ...] | None = None,
+        risk_weights: tuple[tuple[float, float], ...] | None = None,
+        risk_scales: tuple[float, ...] = (1.0, 1.0, 1.0),
+        drawdowns: tuple[float, ...] = (0.0, 0.0, 0.0),
+        risk_config: PreTradeRiskConfig | None = None,
     ) -> None:
         self.current_index = 0
         self._offset = 0
@@ -48,6 +57,23 @@ class _Environment:
         self._gross_returns = gross_returns
         self._net_returns = net_returns
         self._costs = costs
+        self._post_weights = post_weights
+        self._risk_weights = risk_weights
+        self._risk_scales = risk_scales
+        self._drawdowns = drawdowns
+        self.pre_trade_risk = PreTradeRisk(
+            risk_config
+            or PreTradeRiskConfig(
+                max_gross=1.0,
+                max_abs_weight=0.5,
+                max_turnover=2.0,
+            )
+        )
+        self.hybrid = SimpleNamespace(
+            max_drawdown=0.0,
+            quantities=np.zeros(2, dtype=np.float64),
+            mark_prices=np.ones(2, dtype=np.float64),
+        )
 
     def _observation(self) -> dict[str, np.ndarray]:
         return {
@@ -63,6 +89,7 @@ class _Environment:
         self.current_index = start_index
         self._offset = 0
         self._weights[:] = 0.0
+        self.hybrid.max_drawdown = 0.0
         return self._observation(), {}
 
     def step(
@@ -71,8 +98,18 @@ class _Environment:
         requested = 0.0 if self._offset == 0 else self._executed_turnover
         filled = 0.0 if self._offset == 0 else self._executed_turnover
         rejected = 1 if self._offset == 0 else 0
-        if filled > 0.0:
+        risk_weights = (
+            np.asarray(self._risk_weights[self._offset], dtype=np.float64)
+            if self._risk_weights is not None
+            else np.asarray(action, dtype=np.float64).copy()
+        )
+        if self._post_weights is not None:
+            self._weights[:] = np.asarray(
+                self._post_weights[self._offset], dtype=np.float32
+            )
+        elif filled > 0.0:
             self._weights[0] = float(action[0])
+        self.hybrid.max_drawdown = float(self._drawdowns[self._offset])
         execution = SimpleNamespace(
             requested_turnover=requested,
             filled_turnover=filled,
@@ -88,7 +125,9 @@ class _Environment:
         info: dict[str, object] = {
             "hybrid_execution": execution,
             "hybrid_risk": SimpleNamespace(
-                reasons=("no_trade_band",) if self._offset == 0 else ()
+                weights=risk_weights,
+                risk_scale=float(self._risk_scales[self._offset]),
+                reasons=("no_trade_band",) if self._offset == 0 else (),
             ),
             "hybrid_liquidation": None,
             "interval_gross_return": self._gross_returns[self._offset],
@@ -105,7 +144,9 @@ def test_action_path_reports_where_submitted_changes_disappear(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(rollout_evaluation, "ClosedTradeTracker", _Trades)
-    environment = _Environment()
+    environment = _Environment(
+        risk_weights=((0.4, 0.0), (0.4, 0.0), (0.0, 0.0)),
+    )
 
     result = rollout_evaluation.evaluate_action_path(
         environment,
@@ -177,6 +218,138 @@ def test_action_path_preserves_immutable_step_economics_for_attribution(
     assert economics.gross_returns.flags.writeable is False
     assert economics.net_returns.flags.writeable is False
     assert economics.costs.flags.writeable is False
+
+
+def test_action_path_records_execution_boundary_weights_without_changing_economics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(rollout_evaluation, "ClosedTradeTracker", _Trades)
+    environment = _Environment(
+        gross_returns=(0.01, -0.02, 0.03),
+        net_returns=(0.009, -0.021, 0.029),
+        costs=(0.001, 0.001, 0.001),
+        post_weights=((0.09, 0.0), (0.08, 0.0), (0.0, 0.0)),
+        risk_weights=((0.10, 0.0), (0.09, 0.0), (0.0, 0.0)),
+        risk_scales=(1.0, 0.8, 0.6),
+    )
+    actions = np.asarray([[0.10, 0.0], [0.09, 0.0], [0.0, 0.0]], dtype=np.float32)
+
+    result = rollout_evaluation.evaluate_action_path(
+        environment,
+        evaluation_range=(0, 4),
+        actions=actions,
+    )
+
+    trace = result.execution_trace
+    assert trace is not None
+    np.testing.assert_allclose(trace.pre_action_weights[:, 0], (0.0, 0.09, 0.08))
+    np.testing.assert_allclose(trace.risk_constrained_weights[:, 0], (0.10, 0.09, 0.0))
+    np.testing.assert_allclose(trace.post_step_weights[:, 0], (0.09, 0.08, 0.0))
+    np.testing.assert_allclose(trace.applied_risk_scales, (1.0, 0.8, 0.6))
+    np.testing.assert_allclose(result.actions, actions)
+    assert result.step_economics is not None
+    np.testing.assert_allclose(result.step_economics.gross_returns, (0.01, -0.02, 0.03))
+    np.testing.assert_allclose(
+        result.step_economics.net_returns, (0.009, -0.021, 0.029)
+    )
+    np.testing.assert_allclose(result.step_economics.costs, (0.001, 0.001, 0.001))
+
+
+def test_action_path_distinguishes_intent_realized_state_follow_and_reassertion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(rollout_evaluation, "ClosedTradeTracker", _Trades)
+    environment = _Environment(
+        post_weights=((0.09, 0.0), (0.08, 0.0), (0.09, 0.0)),
+    )
+
+    result = rollout_evaluation.evaluate_action_path(
+        environment,
+        evaluation_range=(0, 4),
+        actions=np.asarray([[0.10, 0.0], [0.09, 0.0], [0.09, 0.0]], dtype=np.float32),
+    )
+
+    trace = result.execution_trace
+    assert trace is not None
+    assert trace.strategy_intent_changes.tolist() == [True, False, False]
+    assert trace.realized_state_follows.tolist() == [False, True, False]
+    assert trace.rebalance_reassertions.tolist() == [False, False, True]
+
+
+def test_generic_collapse_evidence_schema_does_not_gain_v10_change_class_counts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(rollout_evaluation, "ClosedTradeTracker", _Trades)
+    result = rollout_evaluation.evaluate_action_path(
+        _Environment(post_weights=((0.09, 0.0), (0.08, 0.0), (0.09, 0.0))),
+        evaluation_range=(0, 4),
+        actions=np.asarray([[0.10, 0.0], [0.09, 0.0], [0.09, 0.0]], dtype=np.float32),
+    )
+
+    payload = result.collapse_evidence.to_dict()
+    assert "strategy_intent_change_count" not in payload
+    assert "realized_state_follow_count" not in payload
+    assert "passive_weight_drift_count" not in payload
+    assert "rebalance_reassertion_count" not in payload
+
+
+def _risk_config_for_projection_test() -> PreTradeRiskConfig:
+    return PreTradeRiskConfig(
+        max_gross=1.0,
+        max_abs_weight=0.10,
+        max_turnover=2.0,
+        drawdown_start=0.10,
+        drawdown_stop=0.20,
+    )
+
+
+def test_action_path_does_not_treat_post_step_price_drift_as_hard_risk_violation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(rollout_evaluation, "ClosedTradeTracker", _Trades)
+    environment = _Environment(
+        post_weights=((0.06, 0.0), (0.04, 0.0), (0.0, 0.0)),
+        risk_weights=((0.05, 0.0), (0.04, 0.0), (0.0, 0.0)),
+        risk_scales=(0.5, 0.5, 0.0),
+        drawdowns=(0.15, 0.15, 0.20),
+        risk_config=_risk_config_for_projection_test(),
+    )
+
+    result = rollout_evaluation.evaluate_action_path(
+        environment,
+        evaluation_range=(0, 4),
+        actions=np.asarray([[0.05, 0.0], [0.04, 0.0], [0.0, 0.0]], dtype=np.float32),
+    )
+
+    trace = result.execution_trace
+    assert trace is not None
+    np.testing.assert_allclose(trace.applied_risk_scales, (0.5, 0.5, 0.0))
+    assert trace.hard_risk_violations.tolist() == [False, False, False]
+    assert result.collapse_evidence.hard_risk_violation is False
+
+
+def test_action_path_detects_hard_risk_projection_violation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(rollout_evaluation, "ClosedTradeTracker", _Trades)
+    environment = _Environment(
+        post_weights=((0.04, 0.0), (0.04, 0.0), (0.0, 0.0)),
+        risk_weights=((0.06, 0.0), (0.04, 0.0), (0.0, 0.0)),
+        risk_scales=(0.5, 0.5, 0.0),
+        drawdowns=(0.15, 0.15, 0.20),
+        risk_config=_risk_config_for_projection_test(),
+    )
+
+    result = rollout_evaluation.evaluate_action_path(
+        environment,
+        evaluation_range=(0, 4),
+        actions=np.asarray([[0.06, 0.0], [0.04, 0.0], [0.0, 0.0]], dtype=np.float32),
+    )
+
+    trace = result.execution_trace
+    assert trace is not None
+    assert trace.hard_risk_violations.tolist() == [True, False, False]
+    assert result.collapse_evidence.hard_risk_violation is True
 
 
 def test_action_path_rejects_unreconciled_execution_rejection_events(

--- a/tests/learning/test_rollout_flat_observation_trace.py
+++ b/tests/learning/test_rollout_flat_observation_trace.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from trade_rl.learning import rollout_evaluation
+from trade_rl.risk.pretrade import PreTradeRisk, PreTradeRiskConfig
+
+
+class _Trades:
+    def __init__(self, multipliers: np.ndarray) -> None:
+        del multipliers
+
+    def seed_positions(self, *, quantities: np.ndarray, prices: np.ndarray) -> None:
+        del quantities, prices
+
+    def ingest_stateful(self, execution: object) -> None:
+        del execution
+
+    def ingest_liquidation(self, liquidation: object) -> None:
+        del liquidation
+
+    def diagnostics(self) -> SimpleNamespace:
+        return SimpleNamespace(closed_trades=0, winning_trades=0)
+
+
+class _Dataset:
+    def resolved_array(self, name: str) -> np.ndarray:
+        assert name == "contract_multipliers"
+        return np.ones(1, dtype=np.float64)
+
+
+class _Environment:
+    dataset = _Dataset()
+
+    def __init__(self) -> None:
+        self.current_index = 0
+        self._offset = 0
+        self.hybrid = SimpleNamespace(
+            weights=np.asarray([0.0], dtype=np.float64),
+            quantities=np.asarray([0.0], dtype=np.float64),
+            mark_prices=np.asarray([1.0], dtype=np.float64),
+            max_drawdown=0.0,
+        )
+        self.pre_trade_risk = PreTradeRisk(
+            PreTradeRiskConfig(
+                max_gross=1.0,
+                max_abs_weight=0.5,
+                max_turnover=1.0,
+            )
+        )
+
+    def reset(
+        self, *, options: dict[str, object]
+    ) -> tuple[np.ndarray, dict[str, object]]:
+        start = options["start_idx"]
+        assert isinstance(start, int)
+        self.current_index = start
+        self._offset = 0
+        self.hybrid.weights = np.asarray([0.0], dtype=np.float64)
+        return np.asarray([1.0, 2.0], dtype=np.float32), {}
+
+    def step(
+        self, action: np.ndarray
+    ) -> tuple[np.ndarray, float, bool, bool, dict[str, object]]:
+        target = np.asarray(action, dtype=np.float64).reshape(-1)
+        before = self.hybrid.weights.copy()
+        # First fill undershoots the requested target; the second decision repeats
+        # the same strategic target and should therefore be a trace reassertion.
+        post = np.asarray([0.09 if self._offset == 0 else float(target[0])])
+        self.hybrid.weights = post
+        execution = SimpleNamespace(
+            requested_turnover=float(np.abs(target - before).sum()),
+            filled_turnover=float(np.abs(post - before).sum()),
+            rejected_count=0,
+            order_events=(),
+        )
+        info: dict[str, object] = {
+            "hybrid_execution": execution,
+            "hybrid_risk": SimpleNamespace(
+                proposal_weights=target.copy(),
+                weights=target.copy(),
+                risk_scale=1.0,
+                reasons=(),
+            ),
+            "hybrid_liquidation": None,
+            "interval_gross_return": 0.0,
+            "interval_net_return": 0.0,
+            "interval_cost": 0.0,
+        }
+        self._offset += 1
+        self.current_index += 1
+        terminal = self._offset == 2
+        return np.asarray([3.0, 4.0], dtype=np.float32), 0.0, terminal, False, info
+
+
+def test_flat_observation_keeps_generic_evidence_and_records_book_trace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(rollout_evaluation, "ClosedTradeTracker", _Trades)
+    result = rollout_evaluation.evaluate_action_path(
+        _Environment(),
+        evaluation_range=(0, 3),
+        actions=np.asarray([[0.10], [0.10]], dtype=np.float32),
+    )
+
+    # Main's generic collapse contract treats the repeated raw action as unchanged
+    # when a flat observation carries no explicit current-weight field.
+    assert result.collapse_evidence.submitted_change_count == 1
+
+    trace = result.execution_trace
+    assert trace is not None
+    np.testing.assert_allclose(trace.pre_action_weights[:, 0], (0.0, 0.09))
+    np.testing.assert_allclose(trace.risk_constrained_weights[:, 0], (0.10, 0.10))
+    np.testing.assert_allclose(trace.post_step_weights[:, 0], (0.09, 0.10))
+    assert trace.strategy_intent_changes.tolist() == [True, False]
+    assert trace.realized_state_follows.tolist() == [False, False]
+    assert trace.rebalance_reassertions.tolist() == [False, True]

--- a/tests/learning/test_rollout_risk_timing.py
+++ b/tests/learning/test_rollout_risk_timing.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+
+from trade_rl.learning import rollout_evaluation
+from trade_rl.risk.pretrade import PreTradeRisk, PreTradeRiskConfig
+
+
+def _environment() -> object:
+    return SimpleNamespace(
+        pre_trade_risk=PreTradeRisk(
+            PreTradeRiskConfig(
+                max_gross=1.0,
+                max_abs_weight=0.10,
+                max_turnover=2.0,
+                drawdown_start=0.10,
+                drawdown_stop=0.20,
+            )
+        ),
+        # The environment may have a worse end-of-step drawdown after market
+        # movement. The projection oracle uses the risk scale applied before
+        # execution, not a retroactive cap derived from this later state.
+        hybrid=SimpleNamespace(max_drawdown=0.20),
+    )
+
+
+def test_hard_risk_projection_uses_applied_pretrade_scale() -> None:
+    environment = _environment()
+    projected_weights = np.asarray([0.06], dtype=np.float64)
+
+    assert not rollout_evaluation._hard_risk_projection_violation(
+        environment,
+        projected_weights,
+        applied_risk_scale=1.0,
+    )
+    assert rollout_evaluation._hard_risk_projection_violation(
+        environment,
+        projected_weights,
+        applied_risk_scale=0.5,
+    )

--- a/tests/workflows/test_universal_causal_alpha_v10_resume_identity.py
+++ b/tests/workflows/test_universal_causal_alpha_v10_resume_identity.py
@@ -3,16 +3,37 @@ from __future__ import annotations
 from pathlib import Path
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
 import trade_rl.workflows.universal_causal_alpha_v10_stage_entry as stage_entry
+from trade_rl.artifacts.hashing import content_digest
 from trade_rl.learning.causal_alpha_v10 import CausalAlphaV10Candidate
+from trade_rl.learning.rollout_evaluation import ActionPathExecutionTrace
 
 
-def test_v10_resume_rejects_stale_hierarchy_policy_input_digest(monkeypatch) -> None:
-    candidate = CausalAlphaV10Candidate.HIERARCHICAL_WAVE
-    final_target_digest = "t" * 64
-    metric = SimpleNamespace(
+def _execution_evidence() -> tuple[dict[str, object], dict[str, object]]:
+    trace = ActionPathExecutionTrace(
+        pre_action_weights=np.asarray([[0.0], [0.1]]),
+        risk_constrained_weights=np.asarray([[0.1], [0.0]]),
+        post_step_weights=np.asarray([[0.1], [0.0]]),
+        applied_risk_scales=np.asarray([1.0, 1.0]),
+        strategy_intent_changes=np.asarray([True, True]),
+        realized_state_follows=np.asarray([False, False]),
+        rebalance_reassertions=np.asarray([False, False]),
+        hard_risk_violations=np.asarray([False, False]),
+    )
+    evaluation = SimpleNamespace(
+        execution_trace=trace,
+        collapse_evidence=SimpleNamespace(hard_risk_violation=False),
+    )
+    trace_payload = stage_entry._execution_trace_payload(evaluation)
+    diagnostics = stage_entry._execution_diagnostics(evaluation, trace_payload)
+    return trace_payload, diagnostics
+
+
+def _metric(candidate: CausalAlphaV10Candidate, final_target_digest: str) -> object:
+    return SimpleNamespace(
         candidate=stage_entry.V8_CANDIDATE_BY_V10[candidate],
         v8_target_path_digest=final_target_digest,
         v8_config_digest="c" * 64,
@@ -20,10 +41,69 @@ def test_v10_resume_rejects_stale_hierarchy_policy_input_digest(monkeypatch) -> 
             symbol="BTCUSDT",
             episode_index=8,
             contract_digest="d" * 64,
+            hard_risk_violation=False,
         ),
         calibration_fit_digest="f" * 64,
         digest="m" * 64,
     )
+
+
+def _load_leaf(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    execution_trace: dict[str, object],
+    execution_diagnostics: dict[str, object],
+) -> None:
+    candidate = CausalAlphaV10Candidate.HIERARCHICAL_WAVE
+    final_target_digest = "t" * 64
+    metric = _metric(candidate, final_target_digest)
+
+    class MetricFactory:
+        @staticmethod
+        def from_payload(_payload: object) -> object:
+            return metric
+
+    monkeypatch.setattr(stage_entry, "CausalAlphaV8ReplayMetric", MetricFactory)
+    input_digest = "n" * 64
+    leaf = {
+        "candidate": candidate.value,
+        "candidate_input_digest": input_digest,
+        "execution_trace": execution_trace,
+        "execution_diagnostics": execution_diagnostics,
+        "replay": {},
+        "replay_digest": metric.digest,
+        "target_path_digest": final_target_digest,
+        "target": {
+            "artifact_digest": final_target_digest,
+            "candidate": candidate.value,
+            "hierarchy_input_digest": input_digest,
+        },
+    }
+
+    class Store:
+        config_digest = "c" * 64
+
+        def load_leaf(self, _path: Path, *, expected_schema: str) -> dict[str, object]:
+            assert expected_schema == "causal_alpha_v10_replay_leaf_v3"
+            return leaf
+
+    stage_entry._load(
+        Store(),
+        path=Path("selection/replays/08/BTCUSDT/hierarchical_wave.json"),
+        candidate=candidate,
+        candidate_input_digest=input_digest,
+        expected_fast_fit_digest="f" * 64,
+        expected_target_digest=None,
+        symbol="BTCUSDT",
+        episode=8,
+        contract_digest="d" * 64,
+    )
+
+
+def test_v10_resume_rejects_stale_hierarchy_policy_input_digest(monkeypatch) -> None:
+    candidate = CausalAlphaV10Candidate.HIERARCHICAL_WAVE
+    final_target_digest = "t" * 64
+    metric = _metric(candidate, final_target_digest)
 
     class MetricFactory:
         @staticmethod
@@ -33,9 +113,12 @@ def test_v10_resume_rejects_stale_hierarchy_policy_input_digest(monkeypatch) -> 
     monkeypatch.setattr(stage_entry, "CausalAlphaV8ReplayMetric", MetricFactory)
 
     stale_input_digest = "o" * 64
+    execution_trace, execution_diagnostics = _execution_evidence()
     leaf = {
         "candidate": candidate.value,
         "candidate_input_digest": stale_input_digest,
+        "execution_trace": execution_trace,
+        "execution_diagnostics": execution_diagnostics,
         "replay": {},
         "replay_digest": metric.digest,
         "target_path_digest": final_target_digest,
@@ -50,7 +133,7 @@ def test_v10_resume_rejects_stale_hierarchy_policy_input_digest(monkeypatch) -> 
         config_digest = "c" * 64
 
         def load_leaf(self, _path: Path, *, expected_schema: str) -> dict[str, object]:
-            assert expected_schema == "causal_alpha_v10_replay_leaf_v2"
+            assert expected_schema == "causal_alpha_v10_replay_leaf_v3"
             return leaf
 
     with pytest.raises(ValueError, match="resumed replay identity drifted"):
@@ -64,4 +147,34 @@ def test_v10_resume_rejects_stale_hierarchy_policy_input_digest(monkeypatch) -> 
             symbol="BTCUSDT",
             episode=8,
             contract_digest="d" * 64,
+        )
+
+
+def test_v10_resume_rejects_tampered_execution_diagnostics(monkeypatch) -> None:
+    execution_trace, execution_diagnostics = _execution_evidence()
+    execution_diagnostics = dict(execution_diagnostics)
+    execution_diagnostics["artifact_digest"] = "0" * 64
+
+    with pytest.raises(ValueError, match="execution diagnostics digest drifted"):
+        _load_leaf(
+            monkeypatch,
+            execution_trace=execution_trace,
+            execution_diagnostics=execution_diagnostics,
+        )
+
+
+def test_v10_resume_rejects_semantically_tampered_execution_diagnostics(
+    monkeypatch,
+) -> None:
+    execution_trace, execution_diagnostics = _execution_evidence()
+    tampered = dict(execution_diagnostics)
+    tampered["strategy_intent_change_count"] = 0
+    body = {key: value for key, value in tampered.items() if key != "artifact_digest"}
+    tampered["artifact_digest"] = content_digest(body)
+
+    with pytest.raises(ValueError, match="do not reconcile with execution trace"):
+        _load_leaf(
+            monkeypatch,
+            execution_trace=execution_trace,
+            execution_diagnostics=tampered,
         )

--- a/tests/workflows/test_universal_causal_alpha_v10_resume_identity.py
+++ b/tests/workflows/test_universal_causal_alpha_v10_resume_identity.py
@@ -12,16 +12,20 @@ from trade_rl.learning.causal_alpha_v10 import CausalAlphaV10Candidate
 from trade_rl.learning.rollout_evaluation import ActionPathExecutionTrace
 
 
-def _execution_evidence() -> tuple[dict[str, object], dict[str, object]]:
+def _execution_evidence(
+    *, steps: int = 2
+) -> tuple[dict[str, object], dict[str, object]]:
+    if steps not in (1, 2):
+        raise ValueError("test execution evidence supports one or two steps")
     trace = ActionPathExecutionTrace(
-        pre_action_weights=np.asarray([[0.0], [0.1]]),
-        risk_constrained_weights=np.asarray([[0.1], [0.0]]),
-        post_step_weights=np.asarray([[0.1], [0.0]]),
-        applied_risk_scales=np.asarray([1.0, 1.0]),
-        strategy_intent_changes=np.asarray([True, True]),
-        realized_state_follows=np.asarray([False, False]),
-        rebalance_reassertions=np.asarray([False, False]),
-        hard_risk_violations=np.asarray([False, False]),
+        pre_action_weights=np.asarray([[0.0], [0.1]])[:steps],
+        risk_constrained_weights=np.asarray([[0.1], [0.0]])[:steps],
+        post_step_weights=np.asarray([[0.1], [0.0]])[:steps],
+        applied_risk_scales=np.asarray([1.0, 1.0])[:steps],
+        strategy_intent_changes=np.asarray([True, True])[:steps],
+        realized_state_follows=np.asarray([False, False])[:steps],
+        rebalance_reassertions=np.asarray([False, False])[:steps],
+        hard_risk_violations=np.asarray([False, False])[:steps],
     )
     evaluation = SimpleNamespace(
         execution_trace=trace,
@@ -32,7 +36,12 @@ def _execution_evidence() -> tuple[dict[str, object], dict[str, object]]:
     return trace_payload, diagnostics
 
 
-def _metric(candidate: CausalAlphaV10Candidate, final_target_digest: str) -> object:
+def _metric(
+    candidate: CausalAlphaV10Candidate,
+    final_target_digest: str,
+    *,
+    decision_count: int = 2,
+) -> object:
     return SimpleNamespace(
         candidate=stage_entry.V8_CANDIDATE_BY_V10[candidate],
         v8_target_path_digest=final_target_digest,
@@ -41,6 +50,7 @@ def _metric(candidate: CausalAlphaV10Candidate, final_target_digest: str) -> obj
             symbol="BTCUSDT",
             episode_index=8,
             contract_digest="d" * 64,
+            decision_count=decision_count,
             hard_risk_violation=False,
         ),
         calibration_fit_digest="f" * 64,
@@ -53,10 +63,11 @@ def _load_leaf(
     *,
     execution_trace: dict[str, object],
     execution_diagnostics: dict[str, object],
+    decision_count: int = 2,
 ) -> None:
     candidate = CausalAlphaV10Candidate.HIERARCHICAL_WAVE
     final_target_digest = "t" * 64
-    metric = _metric(candidate, final_target_digest)
+    metric = _metric(candidate, final_target_digest, decision_count=decision_count)
 
     class MetricFactory:
         @staticmethod
@@ -177,4 +188,18 @@ def test_v10_resume_rejects_semantically_tampered_execution_diagnostics(
             monkeypatch,
             execution_trace=execution_trace,
             execution_diagnostics=tampered,
+        )
+
+
+def test_v10_resume_rejects_execution_trace_with_wrong_decision_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    execution_trace, execution_diagnostics = _execution_evidence(steps=1)
+
+    with pytest.raises(ValueError, match="resumed replay identity drifted"):
+        _load_leaf(
+            monkeypatch,
+            execution_trace=execution_trace,
+            execution_diagnostics=execution_diagnostics,
+            decision_count=2,
         )

--- a/tests/workflows/test_universal_causal_alpha_v10_stage_entry.py
+++ b/tests/workflows/test_universal_causal_alpha_v10_stage_entry.py
@@ -7,6 +7,7 @@ import pytest
 
 import trade_rl.workflows.universal_causal_alpha_v10_stage_entry as stage_entry
 from trade_rl.learning.causal_alpha_v10 import CausalAlphaV10Candidate
+from trade_rl.learning.rollout_evaluation import ActionPathExecutionTrace
 from trade_rl.risk.pretrade import PreTradeRiskConfig
 from trade_rl.workflows.universal_causal_alpha_v10_stage_entry import (
     _execution_rebalance_contract,
@@ -144,7 +145,64 @@ def test_v10_replay_rejects_execution_contract_drift_in_exit_threshold() -> None
 
 
 def test_v10_closed_loop_replay_uses_new_leaf_schema() -> None:
-    assert stage_entry._REPLAY_LEAF_SCHEMA == "causal_alpha_v10_replay_leaf_v2"
+    assert stage_entry._REPLAY_LEAF_SCHEMA == "causal_alpha_v10_replay_leaf_v3"
+
+
+def test_v10_execution_diagnostics_persist_reconciled_boundary_trace() -> None:
+    trace = ActionPathExecutionTrace(
+        pre_action_weights=np.asarray([[0.0], [0.09], [0.08]]),
+        risk_constrained_weights=np.asarray([[0.10], [0.09], [0.0]]),
+        post_step_weights=np.asarray([[0.09], [0.08], [0.0]]),
+        applied_risk_scales=np.asarray([1.0, 0.8, 0.5]),
+        strategy_intent_changes=np.asarray([True, False, True]),
+        realized_state_follows=np.asarray([False, True, False]),
+        rebalance_reassertions=np.asarray([False, False, False]),
+        hard_risk_violations=np.asarray([False, True, False]),
+    )
+    evaluation = SimpleNamespace(
+        execution_trace=trace,
+        collapse_evidence=SimpleNamespace(hard_risk_violation=True),
+    )
+
+    trace_payload = stage_entry._execution_trace_payload(evaluation)
+    diagnostics = stage_entry._execution_diagnostics(evaluation, trace_payload)
+
+    assert trace_payload["schema_version"] == "causal_alpha_v10_execution_trace_v1"
+    assert trace_payload["pre_action_weights"] == [[0.0], [0.09], [0.08]]
+    assert trace_payload["applied_risk_scales"] == [1.0, 0.8, 0.5]
+    assert trace_payload["hard_risk_violations"] == [False, True, False]
+    assert diagnostics["schema_version"] == "causal_alpha_v10_execution_diagnostics_v1"
+    assert diagnostics["trace_digest"] == trace_payload["artifact_digest"]
+    assert diagnostics["strategy_intent_change_count"] == 2
+    assert diagnostics["realized_state_follow_count"] == 1
+    assert diagnostics["rebalance_reassertion_count"] == 0
+    assert diagnostics["hard_risk_violation"] is True
+    assert diagnostics["minimum_applied_risk_scale"] == pytest.approx(0.5)
+    assert diagnostics["pre_action_mean_abs_weight"] == pytest.approx(0.17 / 3.0)
+    assert diagnostics["risk_constrained_mean_abs_weight"] == pytest.approx(0.19 / 3.0)
+    assert diagnostics["post_step_mean_abs_weight"] == pytest.approx(0.17 / 3.0)
+
+
+def test_v10_execution_trace_rejects_string_boolean_tampering() -> None:
+    trace = ActionPathExecutionTrace(
+        pre_action_weights=np.asarray([[0.0], [0.09], [0.08]]),
+        risk_constrained_weights=np.asarray([[0.10], [0.09], [0.0]]),
+        post_step_weights=np.asarray([[0.09], [0.08], [0.0]]),
+        applied_risk_scales=np.asarray([1.0, 0.8, 0.5]),
+        strategy_intent_changes=np.asarray([True, False, True]),
+        realized_state_follows=np.asarray([False, True, False]),
+        rebalance_reassertions=np.asarray([False, False, False]),
+        hard_risk_violations=np.asarray([False, True, False]),
+    )
+    evaluation = SimpleNamespace(
+        execution_trace=trace,
+        collapse_evidence=SimpleNamespace(hard_risk_violation=True),
+    )
+    payload = stage_entry._execution_trace_payload(evaluation)
+    payload["hard_risk_violations"] = [False, "false", False]
+
+    with pytest.raises(ValueError, match="boolean"):
+        stage_entry._validate_execution_trace_payload(payload)
 
 
 def test_v10_hierarchical_replay_has_dedicated_closed_loop_path() -> None:

--- a/trade_rl/learning/rollout_evaluation.py
+++ b/trade_rl/learning/rollout_evaluation.py
@@ -44,7 +44,9 @@ class ActionPathStepEconomics:
         for name in ("gross_returns", "net_returns", "costs", "turnover"):
             array = np.asarray(getattr(self, name), dtype=np.float64).reshape(-1).copy()
             if array.size == 0 or not np.isfinite(array).all():
-                raise ValueError("action path step economics must be non-empty and finite")
+                raise ValueError(
+                    "action path step economics must be non-empty and finite"
+                )
             array.setflags(write=False)
             arrays[name] = array
         if len({array.size for array in arrays.values()}) != 1:
@@ -60,11 +62,72 @@ class ActionPathStepEconomics:
 
 
 @dataclass(frozen=True, slots=True)
+class ActionPathExecutionTrace:
+    """Decision-boundary execution state retained without reassigning interval PnL."""
+
+    pre_action_weights: np.ndarray
+    risk_constrained_weights: np.ndarray
+    post_step_weights: np.ndarray
+    applied_risk_scales: np.ndarray
+    strategy_intent_changes: np.ndarray
+    realized_state_follows: np.ndarray
+    rebalance_reassertions: np.ndarray
+    hard_risk_violations: np.ndarray
+
+    def __post_init__(self) -> None:
+        weight_arrays: dict[str, np.ndarray] = {}
+        for name in (
+            "pre_action_weights",
+            "risk_constrained_weights",
+            "post_step_weights",
+        ):
+            array = np.asarray(getattr(self, name), dtype=np.float64).copy(order="C")
+            if array.ndim != 2 or array.shape[0] == 0 or array.shape[1] == 0:
+                raise ValueError("action path execution weights must be rank-two")
+            if not np.isfinite(array).all():
+                raise ValueError("action path execution weights must be finite")
+            weight_arrays[name] = array
+        shapes = {array.shape for array in weight_arrays.values()}
+        if len(shapes) != 1:
+            raise ValueError("action path execution weight traces are not aligned")
+        steps = next(iter(weight_arrays.values())).shape[0]
+        risk_scales = (
+            np.asarray(self.applied_risk_scales, dtype=np.float64).reshape(-1).copy()
+        )
+        if (
+            risk_scales.shape != (steps,)
+            or not np.isfinite(risk_scales).all()
+            or np.any((risk_scales < 0.0) | (risk_scales > 1.0))
+        ):
+            raise ValueError("action path applied risk scales are invalid")
+        boolean_arrays: dict[str, np.ndarray] = {}
+        for name in (
+            "strategy_intent_changes",
+            "realized_state_follows",
+            "rebalance_reassertions",
+            "hard_risk_violations",
+        ):
+            raw_boolean = np.asarray(getattr(self, name))
+            if raw_boolean.dtype.kind != "b":
+                raise ValueError("action path execution event traces must be boolean")
+            boolean_array = raw_boolean.reshape(-1).astype(np.bool_, copy=True)
+            if boolean_array.shape != (steps,):
+                raise ValueError("action path execution event traces are not aligned")
+            boolean_arrays[name] = boolean_array
+        risk_scales.setflags(write=False)
+        object.__setattr__(self, "applied_risk_scales", risk_scales)
+        for name, array in {**weight_arrays, **boolean_arrays}.items():
+            array.setflags(write=False)
+            object.__setattr__(self, name, array)
+
+
+@dataclass(frozen=True, slots=True)
 class ActionPathEvaluation:
     actions: np.ndarray
     performance: PathPerformanceMetrics
     collapse_evidence: ActionPathCollapseEvidence
     step_economics: ActionPathStepEconomics | None = None
+    execution_trace: ActionPathExecutionTrace | None = None
 
     def __post_init__(self) -> None:
         actions = np.asarray(self.actions, dtype=np.float32).copy(order="C")
@@ -88,6 +151,12 @@ class ActionPathEvaluation:
                 raise TypeError("step_economics must be ActionPathStepEconomics")
             if len(self.step_economics.gross_returns) != self.performance.step_count:
                 raise ValueError("step economics do not cover evaluated path")
+        trace = self.execution_trace
+        if trace is not None:
+            if not isinstance(trace, ActionPathExecutionTrace):
+                raise TypeError("execution_trace must be ActionPathExecutionTrace")
+            if trace.pre_action_weights.shape != actions.shape:
+                raise ValueError("execution trace does not match evaluated actions")
         actions.setflags(write=False)
         object.__setattr__(self, "actions", actions)
 
@@ -110,6 +179,88 @@ def _liquidation_metric(info: Mapping[str, object], name: str) -> float:
     if isinstance(value, bool) or not isinstance(value, int | float):
         raise ValueError(f"liquidation is missing numeric {name}")
     return float(value)
+
+
+def _observation_weights(
+    observation: object,
+    *,
+    shape: tuple[int, ...],
+    field: str,
+) -> np.ndarray:
+    if not isinstance(observation, Mapping) or "current_weights" not in observation:
+        raise ValueError(f"{field} is missing current_weights")
+    weights = np.asarray(observation["current_weights"], dtype=np.float64).reshape(-1)
+    if weights.shape != shape or not np.isfinite(weights).all():
+        raise ValueError(f"{field} current_weights do not match evaluation action")
+    return weights
+
+
+def _risk_constrained_weights(
+    info: Mapping[str, object], *, shape: tuple[int, ...]
+) -> np.ndarray:
+    risk = info.get("hybrid_risk")
+    if risk is None:
+        raise ValueError("evaluation info is missing hybrid risk")
+    weights = np.asarray(getattr(risk, "weights", None), dtype=np.float64).reshape(-1)
+    if weights.shape != shape or not np.isfinite(weights).all():
+        raise ValueError("hybrid risk weights do not match evaluation action")
+    return weights
+
+
+def _applied_risk_scale(info: Mapping[str, object]) -> float:
+    risk = info.get("hybrid_risk")
+    if risk is None:
+        raise ValueError("evaluation info is missing hybrid risk")
+    value = getattr(risk, "risk_scale", None)
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int | float)
+        or not np.isfinite(float(value))
+        or not 0.0 <= float(value) <= 1.0
+    ):
+        raise ValueError("hybrid risk is missing a valid applied risk scale")
+    return float(value)
+
+
+def _hard_risk_projection_violation(
+    environment: EvaluationEnvironment,
+    projected_weights: np.ndarray,
+    *,
+    applied_risk_scale: float,
+) -> bool:
+    risk_engine = getattr(environment, "pre_trade_risk", None)
+    config = getattr(risk_engine, "config", None)
+    if config is None:
+        raise ValueError(
+            "evaluation environment is missing authoritative pre-trade risk"
+        )
+    max_abs_weight = getattr(config, "max_abs_weight", None)
+    max_gross = getattr(config, "max_gross", None)
+    tolerance = getattr(config, "fail_closed_tolerance", None)
+    for value in (max_abs_weight, max_gross, tolerance):
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, int | float)
+            or not np.isfinite(float(value))
+        ):
+            raise ValueError("evaluation pre-trade risk limits are invalid")
+    assert isinstance(max_abs_weight, int | float) and not isinstance(
+        max_abs_weight, bool
+    )
+    assert isinstance(max_gross, int | float) and not isinstance(max_gross, bool)
+    assert isinstance(tolerance, int | float) and not isinstance(tolerance, bool)
+    scale_value = float(applied_risk_scale)
+    max_abs_value = float(max_abs_weight)
+    max_gross_value = float(max_gross)
+    tolerance_value = float(tolerance)
+    if not 0.0 <= scale_value <= 1.0 or tolerance_value < 0.0:
+        raise ValueError("evaluation pre-trade risk limits are invalid")
+    absolute = np.abs(projected_weights)
+    return bool(
+        np.max(absolute) > max_abs_value * scale_value + tolerance_value
+        or np.sum(absolute) > max_gross_value * scale_value + tolerance_value
+        or (scale_value == 0.0 and np.any(absolute > tolerance_value))
+    )
 
 
 def evaluate_action_path(
@@ -178,6 +329,14 @@ def evaluate_action_path(
     rewards: list[float] = []
     turnover: list[float] = []
     costs: list[float] = []
+    pre_action_weights: list[np.ndarray] = []
+    risk_constrained_weights: list[np.ndarray] = []
+    post_step_weights: list[np.ndarray] = []
+    applied_risk_scales: list[float] = []
+    strategy_intent_changes: list[bool] = []
+    realized_state_follows: list[bool] = []
+    rebalance_reassertions: list[bool] = []
+    hard_risk_violations: list[bool] = []
     active_dimension_count = 0
     inactive_dimension_count = 0
     proposal_distance_count = 0
@@ -188,6 +347,7 @@ def evaluate_action_path(
     risk_projection_reasons: Counter[str] = Counter()
     executed_change_count = 0
     previous_submitted: np.ndarray | None = None
+    previous_active: np.ndarray | None = None
     action_dimension_count: int | None = None
     for offset in range(expected_count):
         if environment.current_index != start + offset:
@@ -205,30 +365,55 @@ def evaluate_action_path(
             raise ValueError("evaluation action dimensions changed within path")
         if not np.isfinite(action).all():
             raise ValueError("evaluation action contains non-finite values")
-        reference = (
-            np.zeros_like(action) if previous_submitted is None else previous_submitted
+        reference = _observation_weights(
+            observation,
+            shape=action.shape,
+            field="pre-action observation",
         )
         active = np.ones(action.shape, dtype=np.bool_)
-        if isinstance(observation, Mapping):
-            if "current_weights" in observation:
-                reference = np.asarray(
-                    observation["current_weights"], dtype=np.float32
-                ).reshape(-1)
-                if reference.shape != action.shape or not np.isfinite(reference).all():
-                    raise ValueError("current weights do not match evaluation action")
-            if "active" in observation:
-                active_values = np.asarray(observation["active"]).reshape(-1)
-                if active_values.shape != action.shape:
-                    raise ValueError("active mask does not match evaluation action")
-                active = active_values > 0.5
+        if isinstance(observation, Mapping) and "active" in observation:
+            active_values = np.asarray(observation["active"]).reshape(-1)
+            if active_values.shape != action.shape:
+                raise ValueError("active mask does not match evaluation action")
+            active = active_values > 0.5
         proposed = active & (np.abs(action - reference) > action_change_tolerance)
+        if previous_submitted is None or previous_active is None:
+            strategy_intent_change = bool(np.any(proposed))
+            realized_state_follow = False
+            rebalance_reassertion = False
+        else:
+            continuously_active = active & previous_active
+            newly_active = active & ~previous_active
+            drifted = continuously_active & (
+                np.abs(reference - previous_submitted) > action_change_tolerance
+            )
+            matches_current = np.abs(action - reference) <= action_change_tolerance
+            matches_previous = (
+                np.abs(action - previous_submitted) <= action_change_tolerance
+            )
+            changed_from_previous = (
+                np.abs(action - previous_submitted) > action_change_tolerance
+            )
+            realized_state_follow = bool(np.any(drifted & matches_current))
+            rebalance_reassertion = bool(np.any(drifted & matches_previous & proposed))
+            strategy_intent_change = bool(
+                np.any(
+                    (continuously_active & changed_from_previous & ~matches_current)
+                    | (newly_active & proposed)
+                )
+            )
         active_dimension_count += int(np.count_nonzero(active))
         inactive_dimension_count += int(np.count_nonzero(~active))
         proposal_distance_count += int(np.count_nonzero(proposed))
         submitted_change = bool(np.any(proposed))
         submitted_change_count += int(submitted_change)
         evaluated_actions.append(action.copy())
+        pre_action_weights.append(reference.copy())
+        strategy_intent_changes.append(strategy_intent_change)
+        realized_state_follows.append(realized_state_follow)
+        rebalance_reassertions.append(rebalance_reassertion)
         previous_submitted = action.copy()
+        previous_active = active.copy()
         observation, reward, terminated, truncated, raw_info = environment.step(action)
         if not isinstance(raw_info, Mapping):
             raise ValueError("evaluation environment info must be a mapping")
@@ -240,6 +425,23 @@ def evaluate_action_path(
         liquidation = info.get("hybrid_liquidation")
         if liquidation is not None:
             trades.ingest_liquidation(liquidation)
+        constrained = _risk_constrained_weights(info, shape=action.shape)
+        post_weights = _observation_weights(
+            observation,
+            shape=action.shape,
+            field="post-step observation",
+        )
+        applied_risk_scale = _applied_risk_scale(info)
+        risk_constrained_weights.append(constrained.copy())
+        post_step_weights.append(post_weights.copy())
+        applied_risk_scales.append(applied_risk_scale)
+        hard_risk_violations.append(
+            _hard_risk_projection_violation(
+                environment,
+                constrained,
+                applied_risk_scale=applied_risk_scale,
+            )
+        )
         gross = _metric(info, "interval_gross_return")
         net = _metric(info, "interval_net_return")
         liquidation_gross = _liquidation_metric(info, "interval_gross_return")
@@ -309,6 +511,16 @@ def evaluate_action_path(
     )
     if action_dimension_count is None:
         raise RuntimeError("evaluation produced no action dimensions")
+    trace = ActionPathExecutionTrace(
+        pre_action_weights=np.stack(pre_action_weights, axis=0),
+        risk_constrained_weights=np.stack(risk_constrained_weights, axis=0),
+        post_step_weights=np.stack(post_step_weights, axis=0),
+        applied_risk_scales=np.asarray(applied_risk_scales, dtype=np.float64),
+        strategy_intent_changes=np.asarray(strategy_intent_changes, dtype=np.bool_),
+        realized_state_follows=np.asarray(realized_state_follows, dtype=np.bool_),
+        rebalance_reassertions=np.asarray(rebalance_reassertions, dtype=np.bool_),
+        hard_risk_violations=np.asarray(hard_risk_violations, dtype=np.bool_),
+    )
     evidence = ActionPathCollapseEvidence(
         decision_count=expected_count,
         action_dimension_count=action_dimension_count,
@@ -325,7 +537,7 @@ def evaluate_action_path(
             sorted(execution_rejection_reasons.items())
         ),
         risk_projection_reason_counts=tuple(sorted(risk_projection_reasons.items())),
-        hard_risk_violation=False,
+        hard_risk_violation=bool(np.any(trace.hard_risk_violations)),
     )
     return ActionPathEvaluation(
         actions=np.stack(evaluated_actions, axis=0),
@@ -337,11 +549,13 @@ def evaluate_action_path(
             costs=np.asarray(costs, dtype=np.float64),
             turnover=np.asarray(turnover, dtype=np.float64),
         ),
+        execution_trace=trace,
     )
 
 
 __all__ = [
     "ActionPathEvaluation",
+    "ActionPathExecutionTrace",
     "ActionPathStepEconomics",
     "EvaluationEnvironment",
     "evaluate_action_path",

--- a/trade_rl/learning/rollout_evaluation.py
+++ b/trade_rl/learning/rollout_evaluation.py
@@ -186,12 +186,25 @@ def _observation_weights(
     *,
     shape: tuple[int, ...],
     field: str,
-) -> np.ndarray:
+) -> np.ndarray | None:
     if not isinstance(observation, Mapping) or "current_weights" not in observation:
-        raise ValueError(f"{field} is missing current_weights")
+        return None
     weights = np.asarray(observation["current_weights"], dtype=np.float64).reshape(-1)
     if weights.shape != shape or not np.isfinite(weights).all():
         raise ValueError(f"{field} current_weights do not match evaluation action")
+    return weights
+
+
+def _book_weights(
+    environment: EvaluationEnvironment,
+    *,
+    shape: tuple[int, ...],
+    field: str,
+) -> np.ndarray:
+    book = getattr(environment, "hybrid", None)
+    weights = np.asarray(getattr(book, "weights", None), dtype=np.float64).reshape(-1)
+    if weights.shape != shape or not np.isfinite(weights).all():
+        raise ValueError(f"{field} book weights do not match evaluation action")
     return weights
 
 
@@ -365,10 +378,26 @@ def evaluate_action_path(
             raise ValueError("evaluation action dimensions changed within path")
         if not np.isfinite(action).all():
             raise ValueError("evaluation action contains non-finite values")
-        reference = _observation_weights(
+        observed_reference = _observation_weights(
             observation,
             shape=action.shape,
             field="pre-action observation",
+        )
+        proposal_reference = observed_reference
+        if proposal_reference is None:
+            proposal_reference = (
+                np.zeros(action.shape, dtype=np.float64)
+                if previous_submitted is None
+                else previous_submitted.astype(np.float64, copy=False)
+            )
+        trace_reference = (
+            observed_reference
+            if observed_reference is not None
+            else _book_weights(
+                environment,
+                shape=action.shape,
+                field="pre-action",
+            )
         )
         active = np.ones(action.shape, dtype=np.bool_)
         if isinstance(observation, Mapping) and "active" in observation:
@@ -376,18 +405,25 @@ def evaluate_action_path(
             if active_values.shape != action.shape:
                 raise ValueError("active mask does not match evaluation action")
             active = active_values > 0.5
-        proposed = active & (np.abs(action - reference) > action_change_tolerance)
+        proposed = active & (
+            np.abs(action - proposal_reference) > action_change_tolerance
+        )
+        trace_proposed = active & (
+            np.abs(action - trace_reference) > action_change_tolerance
+        )
         if previous_submitted is None or previous_active is None:
-            strategy_intent_change = bool(np.any(proposed))
+            strategy_intent_change = bool(np.any(trace_proposed))
             realized_state_follow = False
             rebalance_reassertion = False
         else:
             continuously_active = active & previous_active
             newly_active = active & ~previous_active
             drifted = continuously_active & (
-                np.abs(reference - previous_submitted) > action_change_tolerance
+                np.abs(trace_reference - previous_submitted) > action_change_tolerance
             )
-            matches_current = np.abs(action - reference) <= action_change_tolerance
+            matches_current = (
+                np.abs(action - trace_reference) <= action_change_tolerance
+            )
             matches_previous = (
                 np.abs(action - previous_submitted) <= action_change_tolerance
             )
@@ -395,7 +431,9 @@ def evaluate_action_path(
                 np.abs(action - previous_submitted) > action_change_tolerance
             )
             realized_state_follow = bool(np.any(drifted & matches_current))
-            rebalance_reassertion = bool(np.any(drifted & matches_previous & proposed))
+            rebalance_reassertion = bool(
+                np.any(drifted & matches_previous & trace_proposed)
+            )
             strategy_intent_change = bool(
                 np.any(
                     (continuously_active & changed_from_previous & ~matches_current)
@@ -408,7 +446,7 @@ def evaluate_action_path(
         submitted_change = bool(np.any(proposed))
         submitted_change_count += int(submitted_change)
         evaluated_actions.append(action.copy())
-        pre_action_weights.append(reference.copy())
+        pre_action_weights.append(trace_reference.copy())
         strategy_intent_changes.append(strategy_intent_change)
         realized_state_follows.append(realized_state_follow)
         rebalance_reassertions.append(rebalance_reassertion)
@@ -426,10 +464,19 @@ def evaluate_action_path(
         if liquidation is not None:
             trades.ingest_liquidation(liquidation)
         constrained = _risk_constrained_weights(info, shape=action.shape)
-        post_weights = _observation_weights(
+        observed_post_weights = _observation_weights(
             observation,
             shape=action.shape,
             field="post-step observation",
+        )
+        post_weights = (
+            observed_post_weights
+            if observed_post_weights is not None
+            else _book_weights(
+                environment,
+                shape=action.shape,
+                field="post-step",
+            )
         )
         applied_risk_scale = _applied_risk_scale(info)
         risk_constrained_weights.append(constrained.copy())

--- a/trade_rl/workflows/universal_causal_alpha_v10_diagnostics.py
+++ b/trade_rl/workflows/universal_causal_alpha_v10_diagnostics.py
@@ -103,6 +103,7 @@ def _diagnostics_body(trace: ActionPathExecutionTrace) -> dict[str, object]:
     return {
         "schema_version": EXECUTION_DIAGNOSTICS_SCHEMA,
         "trace_digest": _trace_digest(trace),
+        "decision_count": int(trace.pre_action_weights.shape[0]),
         "strategy_intent_change_count": int(
             np.count_nonzero(trace.strategy_intent_changes)
         ),
@@ -164,6 +165,7 @@ def validate_execution_diagnostics(
     if payload.get("trace_digest") != trace_payload.get("artifact_digest"):
         raise ValueError("V10 replay execution diagnostics trace identity drifted")
     for field in (
+        "decision_count",
         "strategy_intent_change_count",
         "realized_state_follow_count",
         "rebalance_reassertion_count",

--- a/trade_rl/workflows/universal_causal_alpha_v10_diagnostics.py
+++ b/trade_rl/workflows/universal_causal_alpha_v10_diagnostics.py
@@ -1,0 +1,213 @@
+"""V10-owned execution-boundary diagnostics for replay forensics."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import numpy as np
+
+from trade_rl.artifacts.hashing import content_digest
+from trade_rl.data.identity import content_and_arrays_digest
+from trade_rl.learning.rollout_evaluation import (
+    ActionPathEvaluation,
+    ActionPathExecutionTrace,
+)
+
+EXECUTION_TRACE_SCHEMA = "causal_alpha_v10_execution_trace_v1"
+EXECUTION_DIAGNOSTICS_SCHEMA = "causal_alpha_v10_execution_diagnostics_v1"
+
+
+def _trace_digest(trace: ActionPathExecutionTrace) -> str:
+    return content_and_arrays_digest(
+        {"schema_version": EXECUTION_TRACE_SCHEMA},
+        (
+            ("pre_action_weights", trace.pre_action_weights),
+            ("risk_constrained_weights", trace.risk_constrained_weights),
+            ("post_step_weights", trace.post_step_weights),
+            ("applied_risk_scales", trace.applied_risk_scales),
+            ("strategy_intent_changes", trace.strategy_intent_changes),
+            ("realized_state_follows", trace.realized_state_follows),
+            ("rebalance_reassertions", trace.rebalance_reassertions),
+            ("hard_risk_violations", trace.hard_risk_violations),
+        ),
+    )
+
+
+def _trace_payload(trace: ActionPathExecutionTrace) -> dict[str, object]:
+    return {
+        "schema_version": EXECUTION_TRACE_SCHEMA,
+        "pre_action_weights": trace.pre_action_weights.tolist(),
+        "risk_constrained_weights": trace.risk_constrained_weights.tolist(),
+        "post_step_weights": trace.post_step_weights.tolist(),
+        "applied_risk_scales": trace.applied_risk_scales.tolist(),
+        "strategy_intent_changes": trace.strategy_intent_changes.tolist(),
+        "realized_state_follows": trace.realized_state_follows.tolist(),
+        "rebalance_reassertions": trace.rebalance_reassertions.tolist(),
+        "hard_risk_violations": trace.hard_risk_violations.tolist(),
+        "artifact_digest": _trace_digest(trace),
+    }
+
+
+def execution_trace_payload(evaluation: ActionPathEvaluation) -> dict[str, object]:
+    """Serialize the exact decision-boundary trace retained by the evaluator."""
+
+    trace = evaluation.execution_trace
+    if not isinstance(trace, ActionPathExecutionTrace):
+        raise ValueError("V10 replay requires execution-boundary trace evidence")
+    return _trace_payload(trace)
+
+
+def _trace_from_payload(value: object) -> ActionPathExecutionTrace:
+    if not isinstance(value, Mapping):
+        raise ValueError("V10 replay execution trace is invalid")
+    if value.get("schema_version") != EXECUTION_TRACE_SCHEMA:
+        raise ValueError("V10 replay execution trace schema drifted")
+    for field in (
+        "strategy_intent_changes",
+        "realized_state_follows",
+        "rebalance_reassertions",
+        "hard_risk_violations",
+    ):
+        if field not in value:
+            raise ValueError("V10 replay execution trace is invalid")
+        raw_boolean = np.asarray(value[field])
+        if raw_boolean.dtype.kind != "b":
+            raise ValueError("V10 replay execution trace boolean fields are invalid")
+    try:
+        trace = ActionPathExecutionTrace(
+            pre_action_weights=value["pre_action_weights"],
+            risk_constrained_weights=value["risk_constrained_weights"],
+            post_step_weights=value["post_step_weights"],
+            applied_risk_scales=value["applied_risk_scales"],
+            strategy_intent_changes=value["strategy_intent_changes"],
+            realized_state_follows=value["realized_state_follows"],
+            rebalance_reassertions=value["rebalance_reassertions"],
+            hard_risk_violations=value["hard_risk_violations"],
+        )
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError("V10 replay execution trace is invalid") from error
+    if value.get("artifact_digest") != _trace_digest(trace):
+        raise ValueError("V10 replay execution trace digest drifted")
+    return trace
+
+
+def validate_execution_trace_payload(value: object) -> dict[str, object]:
+    """Validate a persisted trace and return its canonical JSON-safe payload."""
+
+    return _trace_payload(_trace_from_payload(value))
+
+
+def _diagnostics_body(trace: ActionPathExecutionTrace) -> dict[str, object]:
+    """Derive the only valid compact diagnostics for one execution trace."""
+
+    return {
+        "schema_version": EXECUTION_DIAGNOSTICS_SCHEMA,
+        "trace_digest": _trace_digest(trace),
+        "strategy_intent_change_count": int(
+            np.count_nonzero(trace.strategy_intent_changes)
+        ),
+        "realized_state_follow_count": int(
+            np.count_nonzero(trace.realized_state_follows)
+        ),
+        "rebalance_reassertion_count": int(
+            np.count_nonzero(trace.rebalance_reassertions)
+        ),
+        "hard_risk_violation": bool(np.any(trace.hard_risk_violations)),
+        "minimum_applied_risk_scale": float(np.min(trace.applied_risk_scales)),
+        "pre_action_mean_abs_weight": float(np.mean(np.abs(trace.pre_action_weights))),
+        "risk_constrained_mean_abs_weight": float(
+            np.mean(np.abs(trace.risk_constrained_weights))
+        ),
+        "post_step_mean_abs_weight": float(np.mean(np.abs(trace.post_step_weights))),
+        "maximum_post_step_abs_weight": float(np.max(np.abs(trace.post_step_weights))),
+    }
+
+
+def execution_diagnostics(
+    evaluation: ActionPathEvaluation,
+    trace_payload: Mapping[str, object],
+) -> dict[str, object]:
+    """Summarize V10 execution-boundary facts without changing generic evidence."""
+
+    trace = evaluation.execution_trace
+    if not isinstance(trace, ActionPathExecutionTrace):
+        raise ValueError("V10 replay requires execution-boundary trace evidence")
+    trace_digest = _trace_digest(trace)
+    if trace_payload.get("artifact_digest") != trace_digest:
+        raise ValueError("V10 replay trace payload does not match evaluation")
+    body = _diagnostics_body(trace)
+    hard_risk = body["hard_risk_violation"]
+    if (
+        getattr(evaluation.collapse_evidence, "hard_risk_violation", None)
+        is not hard_risk
+    ):
+        raise ValueError(
+            "V10 hard-risk diagnostics do not reconcile with collapse evidence"
+        )
+    return {**body, "artifact_digest": content_digest(body)}
+
+
+def validate_execution_diagnostics(
+    value: object,
+    trace_payload: Mapping[str, object],
+) -> dict[str, object]:
+    """Validate compact diagnostics and prove every derived value matches its trace."""
+
+    if not isinstance(value, Mapping):
+        raise ValueError("V10 replay execution diagnostics are invalid")
+    payload = {str(key): item for key, item in value.items()}
+    if payload.get("schema_version") != EXECUTION_DIAGNOSTICS_SCHEMA:
+        raise ValueError("V10 replay execution diagnostics schema drifted")
+    artifact_digest = payload.pop("artifact_digest", None)
+    if artifact_digest != content_digest(payload):
+        raise ValueError("V10 replay execution diagnostics digest drifted")
+    if payload.get("trace_digest") != trace_payload.get("artifact_digest"):
+        raise ValueError("V10 replay execution diagnostics trace identity drifted")
+    for field in (
+        "strategy_intent_change_count",
+        "realized_state_follow_count",
+        "rebalance_reassertion_count",
+    ):
+        count = payload.get(field)
+        if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+            raise ValueError("V10 replay execution diagnostics counts are invalid")
+    if not isinstance(payload.get("hard_risk_violation"), bool):
+        raise ValueError("V10 replay hard-risk diagnostics are invalid")
+    bounded_scale = payload.get("minimum_applied_risk_scale")
+    if (
+        isinstance(bounded_scale, bool)
+        or not isinstance(bounded_scale, int | float)
+        or not np.isfinite(float(bounded_scale))
+        or not 0.0 <= float(bounded_scale) <= 1.0
+    ):
+        raise ValueError("V10 replay applied risk scale diagnostics are invalid")
+    for field in (
+        "pre_action_mean_abs_weight",
+        "risk_constrained_mean_abs_weight",
+        "post_step_mean_abs_weight",
+        "maximum_post_step_abs_weight",
+    ):
+        metric = payload.get(field)
+        if (
+            isinstance(metric, bool)
+            or not isinstance(metric, int | float)
+            or not np.isfinite(float(metric))
+            or float(metric) < 0.0
+        ):
+            raise ValueError("V10 replay execution diagnostics weights are invalid")
+    expected = _diagnostics_body(_trace_from_payload(trace_payload))
+    if payload != expected:
+        raise ValueError(
+            "V10 replay execution diagnostics do not reconcile with execution trace"
+        )
+    return {**expected, "artifact_digest": artifact_digest}
+
+
+__all__ = [
+    "EXECUTION_DIAGNOSTICS_SCHEMA",
+    "EXECUTION_TRACE_SCHEMA",
+    "execution_diagnostics",
+    "execution_trace_payload",
+    "validate_execution_diagnostics",
+    "validate_execution_trace_payload",
+]

--- a/trade_rl/workflows/universal_causal_alpha_v10_stage_entry.py
+++ b/trade_rl/workflows/universal_causal_alpha_v10_stage_entry.py
@@ -80,6 +80,18 @@ from trade_rl.workflows.universal_causal_alpha_v9_stage_entry import (
 from trade_rl.workflows.universal_causal_alpha_v9_stage_entry import (
     _wave_rows as _v9_wave_rows,
 )
+from trade_rl.workflows.universal_causal_alpha_v10_diagnostics import (
+    execution_diagnostics as _execution_diagnostics,
+)
+from trade_rl.workflows.universal_causal_alpha_v10_diagnostics import (
+    execution_trace_payload as _execution_trace_payload,
+)
+from trade_rl.workflows.universal_causal_alpha_v10_diagnostics import (
+    validate_execution_diagnostics as _validate_execution_diagnostics,
+)
+from trade_rl.workflows.universal_causal_alpha_v10_diagnostics import (
+    validate_execution_trace_payload as _validate_execution_trace_payload,
+)
 from trade_rl.workflows.universal_causal_alpha_v10_gates import (
     V8_CANDIDATE_BY_V10,
     CausalAlphaV10SelectionEvidence,
@@ -87,7 +99,7 @@ from trade_rl.workflows.universal_causal_alpha_v10_gates import (
     evaluate_causal_alpha_v10_selection,
 )
 
-_REPLAY_LEAF_SCHEMA: Final = "causal_alpha_v10_replay_leaf_v2"
+_REPLAY_LEAF_SCHEMA: Final = "causal_alpha_v10_replay_leaf_v3"
 _RESULT_SCHEMA: Final = "causal_alpha_v10_terminal_result_v1"
 
 
@@ -420,7 +432,7 @@ def _build_replay(
     config_digest: str,
     boundaries: Any,
     execution_rebalance_contract: CausalAlphaV10ExecutionContract,
-) -> CausalAlphaV8ReplayMetric:
+) -> tuple[CausalAlphaV8ReplayMetric, dict[str, object], dict[str, object]]:
     environment = _environment(prepared, symbol)
     try:
         _require_execution_rebalance_contract(
@@ -432,7 +444,7 @@ def _build_replay(
             evaluation_range=(contract.start, contract.stop),
             actions=target.v6_target_path.targets[:, None].astype(np.float32),
         )
-        return _metric_from_evaluation(
+        metric = _metric_from_evaluation(
             prepared=prepared,
             resolved=resolved,
             symbol=symbol,
@@ -446,6 +458,9 @@ def _build_replay(
             boundaries=boundaries,
             environment=environment,
         )
+        execution_trace = _execution_trace_payload(evaluation)
+        execution_diagnostics = _execution_diagnostics(evaluation, execution_trace)
+        return metric, execution_trace, execution_diagnostics
     finally:
         environment.close()
 
@@ -465,7 +480,12 @@ def _build_hierarchical_replay(
     config_digest: str,
     boundaries: Any,
     execution_rebalance_contract: CausalAlphaV10ExecutionContract,
-) -> tuple[CausalAlphaV10TargetPath, CausalAlphaV8ReplayMetric]:
+) -> tuple[
+    CausalAlphaV10TargetPath,
+    CausalAlphaV8ReplayMetric,
+    dict[str, object],
+    dict[str, object],
+]:
     environment = _environment(prepared, symbol)
     try:
         _require_execution_rebalance_contract(
@@ -504,7 +524,9 @@ def _build_hierarchical_replay(
             boundaries=boundaries,
             environment=environment,
         )
-        return target, metric
+        execution_trace = _execution_trace_payload(evaluation)
+        execution_diagnostics = _execution_diagnostics(evaluation, execution_trace)
+        return target, metric, execution_trace, execution_diagnostics
     finally:
         environment.close()
 
@@ -516,6 +538,8 @@ def _leaf(
     *,
     target: CausalAlphaV10TargetPath,
     candidate_input_digest: str,
+    execution_trace: dict[str, object],
+    execution_diagnostics: dict[str, object],
 ) -> dict[str, object]:
     base = metric.v6_metric
     body: dict[str, object] = {
@@ -524,6 +548,8 @@ def _leaf(
         "config_digest": store.config_digest,
         "contract_digest": base.contract_digest,
         "episode_index": base.episode_index,
+        "execution_diagnostics": execution_diagnostics,
+        "execution_trace": execution_trace,
         "generator_code_digest": store.generator_code_digest,
         "replay": metric.to_payload(),
         "replay_digest": metric.digest,
@@ -566,6 +592,10 @@ def _load(
     target_payload = leaf.get("target")
     if not isinstance(target_payload, dict):
         raise ValueError("V10 resumed replay target evidence is invalid")
+    execution_trace = _validate_execution_trace_payload(leaf.get("execution_trace"))
+    execution_diagnostics = _validate_execution_diagnostics(
+        leaf.get("execution_diagnostics"), execution_trace
+    )
     hierarchy_input_digest = target_payload.get("hierarchy_input_digest")
     hierarchical = candidate is CausalAlphaV10Candidate.HIERARCHICAL_WAVE
     if (
@@ -581,6 +611,8 @@ def _load(
         or leaf.get("target_path_digest") != metric.v8_target_path_digest
         or target_payload.get("artifact_digest") != metric.v8_target_path_digest
         or target_payload.get("candidate") != candidate.value
+        or metric.v6_metric.hard_risk_violation
+        != execution_diagnostics["hard_risk_violation"]
         or (
             expected_target_digest is not None
             and metric.v8_target_path_digest != expected_target_digest
@@ -678,7 +710,12 @@ def selection_stage(
                     )
                     if metric is None:
                         if candidate is CausalAlphaV10Candidate.HIERARCHICAL_WAVE:
-                            target, metric = _build_hierarchical_replay(
+                            (
+                                target,
+                                metric,
+                                execution_trace,
+                                execution_diagnostics,
+                            ) = _build_hierarchical_replay(
                                 prepared=prepared,
                                 resolved=resolved,
                                 symbol=symbol,
@@ -691,13 +728,17 @@ def selection_stage(
                                 v10_config=v10_config,
                                 config_digest=config_digest,
                                 boundaries=resolved.boundaries,
-                                execution_rebalance_contract=(
-                                    execution_contracts[symbol]
-                                ),
+                                execution_rebalance_contract=execution_contracts[
+                                    symbol
+                                ],
                             )
                         else:
                             assert target is not None
-                            metric = _build_replay(
+                            (
+                                metric,
+                                execution_trace,
+                                execution_diagnostics,
+                            ) = _build_replay(
                                 prepared=prepared,
                                 resolved=resolved,
                                 symbol=symbol,
@@ -708,9 +749,9 @@ def selection_stage(
                                 target=target,
                                 config_digest=config_digest,
                                 boundaries=resolved.boundaries,
-                                execution_rebalance_contract=(
-                                    execution_contracts[symbol]
-                                ),
+                                execution_rebalance_contract=execution_contracts[
+                                    symbol
+                                ],
                             )
                         assert target is not None
                         store.write_leaf(
@@ -721,6 +762,8 @@ def selection_stage(
                                 metric,
                                 target=target,
                                 candidate_input_digest=candidate_input_digest,
+                                execution_trace=execution_trace,
+                                execution_diagnostics=execution_diagnostics,
                             ),
                         )
                     records.append(metric)

--- a/trade_rl/workflows/universal_causal_alpha_v10_stage_entry.py
+++ b/trade_rl/workflows/universal_causal_alpha_v10_stage_entry.py
@@ -611,6 +611,7 @@ def _load(
         or leaf.get("target_path_digest") != metric.v8_target_path_digest
         or target_payload.get("artifact_digest") != metric.v8_target_path_digest
         or target_payload.get("candidate") != candidate.value
+        or execution_diagnostics["decision_count"] != metric.v6_metric.decision_count
         or metric.v6_metric.hard_risk_violation
         != execution_diagnostics["hard_risk_violation"]
         or (


### PR DESCRIPTION
## What

- add immutable execution-boundary trace evidence to simulator rollouts: pre-action, risk-constrained, post-step weights, applied risk scale, intent/follow/reassertion classes, and hard-risk projection violations
- make hard-risk evidence inspect the authoritative final risk projection instead of a fixed `False` or post-step price-drifted exposure
- separate generic proposal/submission collapse reference from forensic book-state trace reference so flat observations remain backward compatible without fabricating realized state
- add V10-owned execution diagnostics and bump only the V10 replay leaf schema to `causal_alpha_v10_replay_leaf_v3`
- make resume validation strict for boolean trace fields, trace digests, decision counts, and diagnostics values recomputed canonically from the persisted trace
- keep V10-specific change counters out of generic `ActionPathCollapseEvidence`
- treat inactive -> active target transitions as fresh intent rather than reasserting an output emitted while inactive

## Why

V10 replay diagnostics could not reliably distinguish requested target state from constrained/realized state. `hard_risk_violation` was also effectively unobserved, and V10 replay leaves lacked enough boundary evidence for forensic analysis or trustworthy resume validation.

A falsification pass also found that the first diagnostics implementation required `current_weights` in every observation and broke the maintained flat-observation behavior-cloning capability audit. The final design therefore separates generic collapse compatibility from forensic state tracing instead of weakening either contract.

## Acceptance Criteria

- requested, final risk-constrained, and post-step weights are separately observable
- actual applied PreTrade risk scale is persisted
- strategy intent change, realized-state follow, and rebalance reassertion are distinguishable, including inactive -> active transitions
- hard-risk violations are detected at the final risk-projection boundary; ordinary post-step market drift does not create false violations
- flat-observation consumers retain historical generic zero/previous-action proposal-collapse semantics while forensic trace uses authoritative book state
- a present-but-malformed `current_weights` field still fails closed
- V10 v3 replay leaves bind the full trace and compact diagnostics; semantic diagnostics tampering is rejected even if the diagnostics self-digest is recomputed
- generic collapse evidence and historical V5-V8 replay artifact schemas are unchanged
- simulator action/economic outputs are unchanged by the diagnostic additions

## Design decisions

- `post_step_weights` remain diagnostic only. A decision interval can contain existing-position gap PnL, fills, and post-fill intrabar PnL, so one post-step weight is not exact whole-interval exposure attribution.
- hard-risk evidence uses `hybrid_risk.weights` plus the `hybrid_risk.risk_scale` actually applied for the decision and the maintained `PreTradeRiskConfig` hard limits.
- generic proposal/submission collapse uses valid observation `current_weights` when available; when that optional field is absent it preserves the historical first-decision-zero / later-previous-action reference.
- forensic trace uses valid observation `current_weights` when available; when absent it reads authoritative `environment.hybrid.weights`. Missing/malformed authoritative book state fails closed.
- compact V10 diagnostics are a deterministic function of the persisted trace; resume recomputes and compares them exactly.
- V10-specific change classifications live in V10 trace/diagnostics, not generic `ActionPathCollapseEvidence`.
- V10 v2 leaves are not overwritten in place; a fresh artifact/output root is required to generate v3 evidence under the immutable artifact-store contract.

## Scope

Production changes are limited to:

- `trade_rl/learning/rollout_evaluation.py`
- `trade_rl/workflows/universal_causal_alpha_v10_diagnostics.py`
- `trade_rl/workflows/universal_causal_alpha_v10_stage_entry.py`

The PR currently contains 8 commits and 11 changed files including tests/spec/plan. The final cleanup commit changes only the two diagnostics spec/plan Markdown files. No temporary `.github` verification helper, strategy target-generation module, numerical gate module, or `trade_rl/learning/evaluation.py` change is present in the PR diff.

## Non-goals

- no V8/V9/V10 strategy constant or target-generation changes
- no Signal/Selection/Admission threshold changes
- no reward, cost, execution, or PreTrade behavior changes
- no one-minute data, BC, RL, or profitability retuning
- no claim that V10 r5 passed or became profitable
- no exact realized-exposure PnL attribution redesign in this PR

## Tests

TDD/falsification cases cover:

- missing execution trace
- strict boolean trace validation (`"false"` is rejected)
- intent vs realized-state-follow vs reassertion
- inactive -> active fresh intent
- flat-observation generic-collapse compatibility with forensic book-state tracing
- valid risk projection followed by market-weight drift
- invalid final risk projection hidden by later market movement
- V10 leaf v3 trace/diagnostic persistence and stale identity rejection
- semantic diagnostics tampering with recomputed self-digest
- replay/trace decision-count mismatch
- V5-V10 replay/attribution/closed-loop/gate regressions

Exact source-bearing head `f03c6b9e60d5452af341c3eca32302bb8c7c98a1` passed:

- 69 targeted/compatibility tests
- affected Ruff
- affected Ruff format
- affected Mypy: 3 source files, 0 issues
- import-linter: 13 contracts kept, 0 broken
- full training capability audit, including behavior cloning
- `uv build`

The final cleanup commit `3ffcc53fd6202e1b753a38b2cb30b19d4ec9c7fa` is docs-only relative to `f03c6b9e`.

## Full-suite comparison

The source-bearing final tree and exact base main were tested in the same verification environment with coverage non-gating for comparison:

- PR source-bearing tree: `4457 passed, 26 skipped, 3 failed`
- base main: `4444 passed, 26 skipped, 3 failed`

The same three pre-existing repository failures occurred on both sides; the PR added 13 passing tests and no PR-only full-suite failure was observed.

## Verification

Current PR head: `3ffcc53fd6202e1b753a38b2cb30b19d4ec9c7fa`

Exact base main: `827e36383c33fd5dbbde3541c5da3395b17e8dd4`

Normal GitHub CI was re-run on the current PR head and compared against normal CI on that exact base main SHA:

- PostgreSQL Catalog: **PASS** on current PR head
- Full training capability gate: **PASS** on current PR head
- Training image: **PASS** on current PR head
- Compatibility / Ubuntu: **FAIL**, `1096 passed / 2 failed`; the exact base main run fails the same two tests (`V4 authored example hash`, `docs/superpowers ownership`)
- Compatibility / Windows: **FAIL**, `1097 passed / 1 failed`; the exact base main run fails the same `docs/superpowers ownership` test
- Rebuilt Core: **FAIL** at the repository-wide Ruff format gate before Mypy/import/full tests. Exact base main reports 40 files needing reformat; current PR reports 39. The PR does not introduce additional global format debt; downstream checks are skipped by this pre-existing gate failure.

Therefore the overall GitHub CI status remains red. This PR does **not** claim all required checks are green; it claims only that the observed normal-CI failures on the current head were reproduced on the exact base main and no PR-only failure was found in the compared checks.

## Falsification / independent review

- reproduced the flat-observation regression before fixing it: Full training capability/BC failed with `pre-action observation is missing current_weights`
- added a dedicated regression and restored compatibility by separating generic proposal reference from forensic trace reference
- verified malformed present observation weights still fail closed rather than silently falling back
- verified ordinary post-step market drift cannot create a false hard-risk violation
- verified an invalid final risk projection cannot be hidden by later market movement
- verified V10-specific counters do not leak into generic collapse evidence
- verified semantic diagnostics tampering and mismatched decision-count traces are rejected
- inspected the final PR file list: no strategy/gate production file or temporary verification workflow is included
- compared normal Ubuntu, Windows, and Rebuilt Core failures against the exact base-main CI rather than labeling them baseline by assumption

## Risks

- the new trace increases V10 replay artifact size
- existing V10 v2 replay leaves cannot be resumed as v3 diagnostics in the same immutable artifact root; a fresh root/replay is required
- trustworthy forensic tracing requires authoritative book/risk evidence. Optional observation `current_weights` may be absent, but malformed observed or authoritative state fails closed

## Remaining limitations

- no fresh DB-backed V10 Selection run has been executed with the new v3 diagnostics yet
- exact PnL-by-realized-exposure attribution remains unresolved because the simulator interval can contain multiple exposure phases
- repository-wide CI still has pre-existing architecture/documentation and formatting failures on base main; this PR does not repair unrelated repository debt
- this PR improves diagnostic correctness and safety evidence; it does not establish strategy profitability

## Follow-up

After repository cleanup, rerun V10 Selection into a fresh artifact root and inspect the requested -> risk-constrained -> post-step funnel before making strategy changes.

The PR remains **Draft / unmerged**. No main merge or history rewrite is part of this work.