### PR TITLE
test: repair base oracle drift

### DIFF
--- a/docs/implementation-plans/plans/2026-08-31-base-hygiene-oracle-repair.md
+++ b/docs/implementation-plans/plans/2026-08-31-base-hygiene-oracle-repair.md
@@ -2,13 +2,13 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Restore trustworthy cross-platform and V10 execution test oracles without changing production behavior.
+**Goal:** Restore trustworthy cross-platform, package-surface, and V10 execution test oracles without changing production behavior.
 
-**Architecture:** Keep this repair test-only. Normalize the authored V4 configuration through Python text-mode newline handling before hashing, and align V10 risk-reduction assertions with the existing execution-eligibility contract introduced after the V11 research run. Keep repository-wide formatting cleanup and U0 comparator changes out of this branch.
+**Architecture:** Keep this repair test-only. Normalize the authored V4 configuration through Python text-mode newline handling before hashing, align V10 risk-reduction assertions with the existing execution-eligibility contract introduced after the V11 research run, and explicitly include the maintained V7 research CLI in the package-surface allowlist. Keep repository-wide formatting cleanup, coverage debt, and U0 comparator changes out of this branch.
 
 **Tech Stack:** Python 3.12, pytest, NumPy, GitHub Actions, Ruff.
 
-**Spec:** Existing V10 execution contract in `trade_rl/learning/causal_alpha_v10_hierarchy.py` and V11 consolidated research report.
+**Spec:** Existing V10 execution contract in `trade_rl/learning/causal_alpha_v10_hierarchy.py`, maintained `[project.scripts]` in `pyproject.toml`, and V11 consolidated research report.
 
 ## Global Constraints
 
@@ -17,7 +17,8 @@
 - Preserve executable partial risk reduction when the cap satisfies entry/no-trade constraints.
 - Require explicit reduce-only flattening when a partial risk reduction cannot execute under the current contract.
 - Make the V4 authored-config identity independent of CRLF versus LF checkout policy only; preserve sensitivity to all other text changes.
-- Keep repository-wide Ruff formatting cleanup in a separate change.
+- Preserve exact package-script allowlisting; do not weaken the architecture test to accept arbitrary future entry points.
+- Keep repository-wide Ruff formatting cleanup and global coverage debt in separate changes.
 
 ---
 
@@ -38,9 +39,9 @@ Ubuntu CI at `dd0c4b7` reports the raw-byte digest `a5369a00...` while the test 
 
 Read the file with `Path.read_text(encoding="utf-8")`, hash the resulting normalized text bytes, and assert the normalized digest `a5369a00d3862fec96ba2ffb74d2b745c3829a0801464fac5052536c34be2c51`.
 
-- [ ] **Step 3: Verify on Linux and Windows CI**
+- [x] **Step 3: Verify on Linux and Windows CI**
 
-Expected: the architecture compatibility test passes on both platforms.
+Observed on the first #427 head: both Ubuntu and Windows compatibility jobs passed.
 
 ### Task 2: Non-executable V10 hard-risk reduction oracle
 
@@ -53,7 +54,7 @@ Expected: the architecture compatibility test passes on both platforms.
 
 - [x] **Step 1: Establish failing evidence**
 
-Full-suite evidence at the current U0 head, which does not modify V10 production code, shows stale expectations for a `0.04` cap under `entry_threshold=0.10` and `no_trade_band=0.05`.
+Full-suite evidence at the U0 head, which did not modify V10 production code, showed stale expectations for a `0.04` cap under `entry_threshold=0.10` and `no_trade_band=0.05`.
 
 - [x] **Step 2: Correct non-executable assertions**
 
@@ -63,9 +64,9 @@ Require a requested target of `0.0`, `risk_projection` path reason, `risk_cap_fl
 
 Keep the existing `0.05` cap case with `entry_threshold=0.05` and `no_trade_band=0.05` asserting a partial target of `0.05`.
 
-- [ ] **Step 4: Run focused V10 tests**
+- [x] **Step 4: Run focused V10 tests**
 
-Expected: `tests/learning/test_causal_alpha_v10_closed_loop.py` passes.
+Independent verification branch executed the three changed test modules: `16 passed`; changed-file Ruff and format checks also passed.
 
 ### Task 3: Micro-risk reduce-only oracle
 
@@ -78,17 +79,38 @@ Expected: `tests/learning/test_causal_alpha_v10_closed_loop.py` passes.
 
 - [x] **Step 1: Establish failing evidence**
 
-The stale test expects `0.1004 -> 0.10`; current production contract rejects the `0.0004` delta because it is below the `0.05` no-trade band.
+The stale test expected `0.1004 -> 0.10`; current production contract rejects the `0.0004` delta because it is below the `0.05` no-trade band.
 
 - [x] **Step 2: Correct the assertion**
 
 Require target `0.0`, hierarchy reason `risk_cap_flatten`, and `reduce_only=True`.
 
-- [ ] **Step 3: Run focused reduce-only tests**
+- [x] **Step 3: Run focused reduce-only tests**
 
-Expected: `tests/learning/test_causal_alpha_v10_reduce_only.py` passes.
+Covered by the independent targeted run above.
 
-### Task 4: Verification and review
+### Task 4: Maintained V7 package-script oracle
+
+**Files:**
+- Modify: `tests/test_architecture_contract.py`
+
+**Interfaces:**
+- Consumes: `[project.scripts]` in `pyproject.toml`
+- Produces: exact allowlist containing the maintained base CLI plus Causal Alpha V5, V6, and V7 research runners
+
+- [x] **Step 1: Establish failing evidence**
+
+The exact combined-head full suite reached this previously hidden test and reported one failure because the allowlist omitted `trade-rl-causal-alpha-v7`, while `pyproject.toml` has exposed that maintained runner since commit `a4dd11f7` (`feat: run causal alpha v7 research`).
+
+- [x] **Step 2: Correct the exact allowlist without weakening it**
+
+Add only `trade-rl-causal-alpha-v7 = trade_rl.workflows.universal_causal_alpha_v7_runner:cli_main` to the expected scripts mapping.
+
+- [ ] **Step 3: Verify the updated final #427 head**
+
+Expected: package-surface architecture test passes while an unlisted additional entry point would still fail exact equality.
+
+### Task 5: Verification and review
 
 **Files:**
 - No production changes expected.
@@ -99,12 +121,12 @@ Expected: `tests/learning/test_causal_alpha_v10_reduce_only.py` passes.
 
 - [ ] **Step 1: Verify diff scope**
 
-Expected: only the three test files plus this plan document differ from `main`.
+Expected: only the four test files plus this plan document differ from `main`; no production file is modified.
 
-- [ ] **Step 2: Run compatibility and relevant CI**
+- [ ] **Step 2: Run compatibility and relevant CI on the final #427 HEAD**
 
-Expected: Linux/Windows compatibility no longer disagree on the V4 authored example; focused V10 regressions pass.
+Expected: Linux/Windows compatibility pass, focused V10 regressions pass, and the maintained package-script test passes.
 
 - [ ] **Step 3: Record remaining repository-wide failures separately**
 
-Expected: existing Ruff format drift remains explicitly out of scope and is not hidden by weakening checks.
+Expected: Ruff format drift is handled in stacked #428; global coverage debt remains a separate quality concern and is not hidden by lowering `fail_under=80`.

--- a/docs/implementation-plans/plans/2026-08-31-base-hygiene-oracle-repair.md
+++ b/docs/implementation-plans/plans/2026-08-31-base-hygiene-oracle-repair.md
@@ -1,0 +1,110 @@
+# Base Hygiene Oracle Repair Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore trustworthy cross-platform and V10 execution test oracles without changing production behavior.
+
+**Architecture:** Keep this repair test-only. Normalize the authored V4 configuration through Python text-mode newline handling before hashing, and align V10 risk-reduction assertions with the existing execution-eligibility contract introduced after the V11 research run. Keep repository-wide formatting cleanup and U0 comparator changes out of this branch.
+
+**Tech Stack:** Python 3.12, pytest, NumPy, GitHub Actions, Ruff.
+
+**Spec:** Existing V10 execution contract in `trade_rl/learning/causal_alpha_v10_hierarchy.py` and V11 consolidated research report.
+
+## Global Constraints
+
+- Do not change production code or economic behavior.
+- Do not change V9/V10/V11 research artifacts or run identity.
+- Preserve executable partial risk reduction when the cap satisfies entry/no-trade constraints.
+- Require explicit reduce-only flattening when a partial risk reduction cannot execute under the current contract.
+- Make the V4 authored-config identity independent of CRLF versus LF checkout policy only; preserve sensitivity to all other text changes.
+- Keep repository-wide Ruff formatting cleanup in a separate change.
+
+---
+
+### Task 1: Cross-platform V4 authored-config oracle
+
+**Files:**
+- Modify: `tests/architecture/test_causal_alpha_v5_boundaries.py`
+
+**Interfaces:**
+- Consumes: `examples/binance/universal-causal-alpha-v4-research.json`
+- Produces: newline-stable SHA-256 assertion over UTF-8 text content
+
+- [x] **Step 1: Establish failing evidence**
+
+Ubuntu CI at `dd0c4b7` reports the raw-byte digest `a5369a00...` while the test expects the CRLF digest `560e08e0...`; Windows passes the same test.
+
+- [x] **Step 2: Correct the oracle**
+
+Read the file with `Path.read_text(encoding="utf-8")`, hash the resulting normalized text bytes, and assert the normalized digest `a5369a00d3862fec96ba2ffb74d2b745c3829a0801464fac5052536c34be2c51`.
+
+- [ ] **Step 3: Verify on Linux and Windows CI**
+
+Expected: the architecture compatibility test passes on both platforms.
+
+### Task 2: Non-executable V10 hard-risk reduction oracle
+
+**Files:**
+- Modify: `tests/learning/test_causal_alpha_v10_closed_loop.py`
+
+**Interfaces:**
+- Consumes: `CausalAlphaV10ExecutionContract`, `_partial_risk_reduction_executable`
+- Produces: assertions that distinguish executable partial reduction from fail-closed flattening
+
+- [x] **Step 1: Establish failing evidence**
+
+Full-suite evidence at the current U0 head, which does not modify V10 production code, shows stale expectations for a `0.04` cap under `entry_threshold=0.10` and `no_trade_band=0.05`.
+
+- [x] **Step 2: Correct non-executable assertions**
+
+Require a requested target of `0.0`, `risk_projection` path reason, `risk_cap_flatten` hierarchy reason, and `reduce_only=True` when the cap cannot execute.
+
+- [x] **Step 3: Preserve executable partial-reduction coverage**
+
+Keep the existing `0.05` cap case with `entry_threshold=0.05` and `no_trade_band=0.05` asserting a partial target of `0.05`.
+
+- [ ] **Step 4: Run focused V10 tests**
+
+Expected: `tests/learning/test_causal_alpha_v10_closed_loop.py` passes.
+
+### Task 3: Micro-risk reduce-only oracle
+
+**Files:**
+- Modify: `tests/learning/test_causal_alpha_v10_reduce_only.py`
+
+**Interfaces:**
+- Consumes: V10 risk-cap projection and no-trade-band behavior
+- Produces: explicit fail-closed flatten assertion for sub-band micro reductions
+
+- [x] **Step 1: Establish failing evidence**
+
+The stale test expects `0.1004 -> 0.10`; current production contract rejects the `0.0004` delta because it is below the `0.05` no-trade band.
+
+- [x] **Step 2: Correct the assertion**
+
+Require target `0.0`, hierarchy reason `risk_cap_flatten`, and `reduce_only=True`.
+
+- [ ] **Step 3: Run focused reduce-only tests**
+
+Expected: `tests/learning/test_causal_alpha_v10_reduce_only.py` passes.
+
+### Task 4: Verification and review
+
+**Files:**
+- No production changes expected.
+
+**Interfaces:**
+- Consumes: final branch diff and CI evidence
+- Produces: reviewable Draft PR
+
+- [ ] **Step 1: Verify diff scope**
+
+Expected: only the three test files plus this plan document differ from `main`.
+
+- [ ] **Step 2: Run compatibility and relevant CI**
+
+Expected: Linux/Windows compatibility no longer disagree on the V4 authored example; focused V10 regressions pass.
+
+- [ ] **Step 3: Record remaining repository-wide failures separately**
+
+Expected: existing Ruff format drift remains explicitly out of scope and is not hidden by weakening checks.

--- a/tests/architecture/test_causal_alpha_v5_boundaries.py
+++ b/tests/architecture/test_causal_alpha_v5_boundaries.py
@@ -94,10 +94,12 @@ def test_v4_schema_constants_and_authored_example_are_unchanged() -> None:
         "causal_alpha_v4_target_v1",
     ):
         assert value in source
+    # Text mode normalizes CRLF/LF so the contract tracks authored content,
+    # not the checkout platform's line-ending policy.
     payload = (
         _ROOT / "examples/binance/universal-causal-alpha-v4-research.json"
-    ).read_bytes()
+    ).read_text(encoding="utf-8")
     assert (
-        hashlib.sha256(payload).hexdigest()
-        == "560e08e00b44b6cf559c5451eb7dd368f6006ed118979f80b44d2fe982c495dc"
+        hashlib.sha256(payload.encode("utf-8")).hexdigest()
+        == "a5369a00d3862fec96ba2ffb74d2b745c3829a0801464fac5052536c34be2c51"
     )

--- a/tests/learning/test_causal_alpha_v10_closed_loop.py
+++ b/tests/learning/test_causal_alpha_v10_closed_loop.py
@@ -107,7 +107,7 @@ def test_v10_fast_cadence_is_bound_to_absolute_decision_index() -> None:
     assert path.targets[31] == 0.10
 
 
-def test_v10_micro_hard_risk_reduction_projects_to_cap() -> None:
+def test_v10_non_executable_hard_risk_reduction_flattens() -> None:
     decisions = np.arange(49, dtype=np.int64)
     risk_caps = np.full(49, 0.25)
     risk_caps[32] = 0.04
@@ -119,11 +119,11 @@ def test_v10_micro_hard_risk_reduction_projects_to_cap() -> None:
     )
 
     assert path.targets[16] == 0.10
-    assert path.targets[32] == 0.04
+    assert path.targets[32] == 0.0
     assert path.reasons[32] == "risk_projection"
 
 
-def test_v10_risk_projection_releases_once_realized_exposure_is_within_cap() -> None:
+def test_v10_risk_flatten_latch_releases_once_realized_exposure_is_within_cap() -> None:
     rows = 2
     policy = hierarchy.prepare_causal_alpha_v10_hierarchy_policy(
         decision_indices=np.asarray([0, 1], dtype=np.int64),
@@ -148,8 +148,8 @@ def test_v10_risk_projection_releases_once_realized_exposure_is_within_cap() -> 
     )
 
     first, _ = policy.predict({"current_weights": np.asarray([0.10], dtype=np.float32)})
-    assert float(first[0]) == np.float32(0.04)
-    assert policy.last_step_trace_metadata["hierarchy_reason"] == "risk_cap_projection"
+    assert float(first[0]) == 0.0
+    assert policy.last_step_trace_metadata["hierarchy_reason"] == "risk_cap_flatten"
     assert policy.last_step_trace_metadata["reduce_only"] is True
 
     second, _ = policy.predict(

--- a/tests/learning/test_causal_alpha_v10_reduce_only.py
+++ b/tests/learning/test_causal_alpha_v10_reduce_only.py
@@ -46,16 +46,16 @@ def _policy(
     )
 
 
-def test_v10_micro_risk_reduction_requests_cap_with_reduce_only_intent() -> None:
+def test_v10_micro_risk_reduction_below_no_trade_band_flattens_reduce_only() -> None:
     policy = _policy(initial_weight=0.1004, risk_cap=0.10)
 
     action, _ = policy.predict(
         {"current_weights": np.asarray([0.1004], dtype=np.float64)}
     )
 
-    assert float(action[0]) == np.float32(0.10)
+    assert float(action[0]) == 0.0
     metadata = policy.last_step_trace_metadata
-    assert metadata["hierarchy_reason"] == "risk_cap_projection"
+    assert metadata["hierarchy_reason"] == "risk_cap_flatten"
     assert metadata["reduce_only"] is True
 
 

--- a/tests/test_architecture_contract.py
+++ b/tests/test_architecture_contract.py
@@ -26,6 +26,9 @@ def test_only_trade_rl_is_packaged() -> None:
         "trade-rl-causal-alpha-v6": (
             "trade_rl.workflows.universal_causal_alpha_v6_runner:cli_main"
         ),
+        "trade-rl-causal-alpha-v7": (
+            "trade_rl.workflows.universal_causal_alpha_v7_runner:cli_main"
+        ),
     }
 
 


### PR DESCRIPTION
## What

Repairs stale test oracles on top of current `main` without changing production code:

- makes the frozen V4 authored-config hash independent of CRLF vs LF checkout policy while preserving other text sensitivity;
- aligns V10 hard-risk/reduce-only assertions with the existing execution-eligibility contract: non-executable partial reductions flatten fail-closed, executable reductions still project to the cap;
- updates the exact package-script allowlist to include the maintained `trade-rl-causal-alpha-v7` entry point already present in `pyproject.toml` since commit `a4dd11f7`.

Also records the implementation/verification plan in `docs/implementation-plans/plans/2026-08-31-base-hygiene-oracle-repair.md`.

## Why

Current `main` has multiple stale or platform-dependent oracles:

- Ubuntu fails the V4 raw-byte hash while Windows passes because checkout line endings differ.
- Full-suite comparison exposed V10 tests that still expect pre-`dcf7a877` partial-risk behavior even though production intentionally fail-closes non-executable partial reductions.
- Once the format barrier was removed on an exact combined-head verification, the full suite exposed an exact package-script allowlist that omitted the already-maintained V7 research CLI.

## Acceptance Criteria

- V4 authored-config contract yields the same result on Linux and Windows.
- A V10 risk cap below execution threshold/no-trade constraints produces explicit `risk_cap_flatten` with `reduce_only=True`.
- An executable V10 risk reduction still projects partially to the cap.
- Ordinary holds do not claim reduce-only intent.
- Package scripts remain an exact allowlist and explicitly include V5/V6/V7 maintained research runners.
- No production code or economic behavior changes.

## Design decisions

- Use Python text-mode newline normalization instead of replacing the raw-byte hash with one platform's line-ending digest.
- Correct stale V10 test oracles rather than weakening the production risk/execution contract.
- Add only the known V7 entry point to the exact scripts map; do not loosen equality.
- Keep repository-wide Ruff formatting drift and global coverage debt out of this PR.

## Scope

Modified tests:
- `tests/architecture/test_causal_alpha_v5_boundaries.py`
- `tests/learning/test_causal_alpha_v10_closed_loop.py`
- `tests/learning/test_causal_alpha_v10_reduce_only.py`
- `tests/test_architecture_contract.py`

Plan:
- `docs/implementation-plans/plans/2026-08-31-base-hygiene-oracle-repair.md`

## Non-goals

- No strategy profitability changes.
- No V9/V10/V11 production behavior changes.
- No RL/BC/1m/horizon work.
- No U0 implementation changes.
- No repository-wide formatting cleanup.
- No lowering of the configured 80% global coverage gate.

## Verification at current HEAD `c04d2c76`

Normal CI run `33357122015`:

- Ubuntu compatibility: **success**.
- Windows compatibility: **success**.
- Full training capability gate: **success**.
- Training image build / identity / non-root probe: **success**.
- Rebuilt Core reaches and fails only at the known repository-wide `ruff format --check` drift intentionally handled by stacked #428; downstream steps are therefore skipped on this PR alone.

Independent targeted verification before the V7 add executed the three V4/V10 test modules: **16 passed**, changed-file Ruff passed, changed-file format check passed. The V7 package-surface correction is being revalidated on the final combined stack because normal #427 CI cannot proceed past the inherited format barrier.

## Risks / Remaining limitations

- #427 alone cannot make Rebuilt Core fully green because the pre-existing 40-file Ruff format drift is deliberately isolated in stacked #428.
- Removing that format barrier exposes a separate repository-wide global coverage debt (~79.18% vs configured 80%). The coverage threshold is not weakened here and requires a separate evidence-driven remediation.
- PR #426's U0 comparator has been independently corrected to compare against current `origin/main`; that workflow-only change remains in #426, not this PR.