### PR TITLE
ci: split core and Nautilus coverage gates

### DIFF
--- a/.coveragerc.nautilus
+++ b/.coveragerc.nautilus
@@ -1,0 +1,16 @@
+[run]
+source =
+    trade_rl/integrations/nautilus
+branch = True
+parallel = True
+concurrency = multiprocessing,thread
+sigterm = True
+patch =
+    subprocess
+    _exit
+data_file = .coverage.nautilus
+
+[report]
+show_missing = True
+skip_covered = False
+precision = 2

--- a/.github/workflows/nautilus-capability.yml
+++ b/.github/workflows/nautilus-capability.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "pyproject.toml"
+      - ".coveragerc.nautilus"
       - "uv.lock"
       - "trade_rl/integrations/nautilus/**"
       - "trade_rl/workflows/stage_a_historical_interval_evidence.py"
@@ -37,6 +38,7 @@ on:
     branches: [main]
     paths:
       - "pyproject.toml"
+      - ".coveragerc.nautilus"
       - "uv.lock"
       - "trade_rl/integrations/nautilus/**"
       - "trade_rl/workflows/stage_a_historical_interval_evidence.py"
@@ -99,53 +101,53 @@ jobs:
           PY
       - name: Exercise import-safe Nautilus adapters
         run: |
-          uv run pytest -q -m nautilus \
+          uv run coverage run --rcfile=.coveragerc.nautilus -m pytest -q -m nautilus \
             tests/integrations/test_nautilus_instrument.py \
             tests/integrations/test_nautilus_quote_projection.py \
             tests/integrations/test_nautilus_derivative_data.py \
             tests/integrations/test_nautilus_order_adapter.py
       - name: Probe BacktestEngine in isolated process
-        run: uv run pytest -q -m nautilus tests/integrations/test_nautilus_capability.py
+        run: uv run coverage run --rcfile=.coveragerc.nautilus -m pytest -q -m nautilus tests/integrations/test_nautilus_capability.py
       - name: Replay projected quotes in isolated process
-        run: uv run pytest -q -m nautilus tests/integrations/test_nautilus_quote_replay.py
+        run: uv run coverage run --rcfile=.coveragerc.nautilus -m pytest -q -m nautilus tests/integrations/test_nautilus_quote_replay.py
       - name: Exercise order lifecycle in isolated process
-        run: uv run pytest -q -m nautilus tests/integrations/test_nautilus_order_lifecycle.py
+        run: uv run coverage run --rcfile=.coveragerc.nautilus -m pytest -q -m nautilus tests/integrations/test_nautilus_order_lifecycle.py
       - name: Probe streaming execution state across batches
-        run: uv run pytest -q -m nautilus tests/integrations/test_nautilus_streaming_execution.py
+        run: uv run coverage run --rcfile=.coveragerc.nautilus -m pytest -q -m nautilus tests/integrations/test_nautilus_streaming_execution.py
       - name: Prove persistent streaming worker parity
-        run: uv run pytest -q -m nautilus tests/integrations/test_nautilus_streaming_worker.py
+        run: uv run coverage run --rcfile=.coveragerc.nautilus -m pytest -q -m nautilus tests/integrations/test_nautilus_streaming_worker.py
       - name: Exercise partial-fill stale-working cancellation evidence in isolated process
-        run: uv run pytest -q -m nautilus tests/integrations/test_nautilus_partial_fill_cancel.py
+        run: uv run coverage run --rcfile=.coveragerc.nautilus -m pytest -q -m nautilus tests/integrations/test_nautilus_partial_fill_cancel.py
       - name: Lock Binance funding reference to mark-price notional
         run: uv run pytest -q tests/simulation/test_funding_mark_price.py
       - name: Exercise canonical funding evidence and lock native limitation
         run: |
-          uv run pytest -q \
+          uv run coverage run --rcfile=.coveragerc.nautilus -m pytest -q \
             tests/integrations/test_nautilus_funding_adapter.py \
             tests/integrations/test_nautilus_funding_settlement.py
       - name: Bind factual Stage A historical replay intervals
         run: |
-          uv run pytest -q \
+          uv run coverage run --rcfile=.coveragerc.nautilus -m pytest -q \
             tests/workflows/test_stage_a_nautilus_historical_replay.py \
             tests/workflows/test_stage_a_nautilus_historical_timeline.py \
             tests/workflows/test_stage_a_nautilus_historical_differential.py
       - name: Record execution accounting in isolated process
-        run: uv run pytest -q -m nautilus tests/integrations/test_nautilus_execution_probe.py
+        run: uv run coverage run --rcfile=.coveragerc.nautilus -m pytest -q -m nautilus tests/integrations/test_nautilus_execution_probe.py
       - name: Replay historical targets in isolated process
-        run: uv run pytest -q -m nautilus tests/integrations/test_nautilus_historical_execution.py
+        run: uv run coverage run --rcfile=.coveragerc.nautilus -m pytest -q -m nautilus tests/integrations/test_nautilus_historical_execution.py
       - name: Replay representative real BTCUSDT windows in fresh children
-        run: uv run pytest -q -m nautilus tests/integrations/test_nautilus_real_market_windows.py
+        run: uv run coverage run --rcfile=.coveragerc.nautilus -m pytest -q -m nautilus tests/integrations/test_nautilus_real_market_windows.py
       - name: Execute factual Stage A historical replay in isolated process
-        run: uv run pytest -q -m nautilus tests/workflows/test_stage_a_nautilus_historical_execution.py
+        run: uv run coverage run --rcfile=.coveragerc.nautilus -m pytest -q -m nautilus tests/workflows/test_stage_a_nautilus_historical_execution.py
       - name: Exercise RL dual-shadow observer contract
         run: |
-          uv run pytest -q \
+          uv run coverage run --rcfile=.coveragerc.nautilus -m pytest -q \
             tests/rl/test_environment_execution_dual_shadow.py \
             tests/rl/test_environment_dual_shadow_wiring.py
       - name: Stream RL dual-shadow through one episode child
-        run: uv run pytest -q -m nautilus tests/integrations/test_nautilus_rl_dual_shadow.py
+        run: uv run coverage run --rcfile=.coveragerc.nautilus -m pytest -q -m nautilus tests/integrations/test_nautilus_rl_dual_shadow.py
       - name: Run three-step PPO and Lagrangian smokes on dual-shadow runtime
-        run: uv run pytest -q -m nautilus tests/integrations/test_nautilus_training_smoke.py
+        run: uv run coverage run --rcfile=.coveragerc.nautilus -m pytest -q -m nautilus tests/integrations/test_nautilus_training_smoke.py
       - name: Record isolated legacy versus streaming throughput and memory
         run: |
           uv run python scripts/nautilus_training_throughput_benchmark.py \
@@ -164,17 +166,32 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
-          uv run pytest -q -m nautilus tests/integrations/test_nautilus_dual_shadow.py 2>&1 | tee nautilus-dual-shadow.log
+          uv run coverage run --rcfile=.coveragerc.nautilus -m pytest -q -m nautilus tests/integrations/test_nautilus_dual_shadow.py 2>&1 | tee nautilus-dual-shadow.log
       - name: Compare safe sign reversal in isolated process
         shell: bash
         run: |
           set -o pipefail
-          uv run pytest -q -m nautilus tests/integrations/test_nautilus_sign_flip_conformance.py 2>&1 | tee -a nautilus-dual-shadow.log
+          uv run coverage run --rcfile=.coveragerc.nautilus -m pytest -q -m nautilus tests/integrations/test_nautilus_sign_flip_conformance.py 2>&1 | tee -a nautilus-dual-shadow.log
       - name: Compare same-side target changes in isolated process
         shell: bash
         run: |
           set -o pipefail
-          uv run pytest -q -m nautilus tests/integrations/test_nautilus_target_change_conformance.py 2>&1 | tee -a nautilus-dual-shadow.log
+          uv run coverage run --rcfile=.coveragerc.nautilus -m pytest -q -m nautilus tests/integrations/test_nautilus_target_change_conformance.py 2>&1 | tee -a nautilus-dual-shadow.log
+      - name: Combine and record Nautilus coverage
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run coverage combine --rcfile=.coveragerc.nautilus
+          uv run coverage json --rcfile=.coveragerc.nautilus -o nautilus-coverage.json
+          uv run coverage report --rcfile=.coveragerc.nautilus
+      - name: Upload Nautilus coverage evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: nautilus-coverage-evidence
+          path: nautilus-coverage.json
+          if-no-files-found: warn
+          retention-days: 14
       - name: Upload dual-shadow diagnostics
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
@@ -193,3 +210,6 @@ jobs:
           test "$second" = "$third"
           test "${#first}" -eq 64
           printf 'execution_digest=%s\n' "$first"
+      - name: Enforce Nautilus coverage ratchet
+        if: always()
+        run: uv run coverage report --rcfile=.coveragerc.nautilus --fail-under=81.21

--- a/docs/implementation-plans/plans/2026-08-31-coverage-layer-contract.md
+++ b/docs/implementation-plans/plans/2026-08-31-coverage-layer-contract.md
@@ -1,0 +1,130 @@
+# Coverage Layer Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore the configured 80% core coverage gate without weakening it by separating exact-optional NautilusTrader coverage into its existing isolated capability layer and adding a dedicated Nautilus coverage ratchet.
+
+**Architecture:** Keep `Rebuilt Core` responsible for code executable under its declared dependency set and exclude only `trade_rl/integrations/nautilus/**`, which requires the exact optional `nautilus_trader` runtime. Measure that adapter package separately inside `Nautilus Capability`, preserving its current one-test-group-per-process topology and its existing `-m nautilus` selection semantics. Use coverage.py subprocess/multiprocessing support so native kernel tests remain isolated. No production or trading behavior changes.
+
+**Tech Stack:** Python 3.12, pytest, coverage.py 7.15.x, GitHub Actions, TOML/INI coverage configuration.
+
+**Spec:** Existing `pyproject.toml` coverage gate, `.github/workflows/ci.yml`, and `.github/workflows/nautilus-capability.yml` contracts plus the 2026-08-31 exact-head coverage diagnostics.
+
+## Baseline Evidence
+
+- Exact core coverage before the split: `79.18290882942891%`.
+- The same artifact excluding only `trade_rl/integrations/nautilus/**`: `80.09797033943163%`.
+- Exploratory isolated Nautilus run `33359438890` executed every test in the selected files without the maintained `-m nautilus` filter and therefore measured `81.32361189007291%` combined coverage.
+- The actual maintained Nautilus selection (`-m nautilus` where the existing workflow uses it) was measured in exact-head run `33360536942` at `81.21144139091419%` combined coverage, `87.45414526779163%` statement coverage, and `60.95238095238095%` branch coverage.
+- The exploratory/maintained delta is attributable to unmarked tests that the maintained workflow deliberately deselects; for example, `test_child_order_probes_reject_non_reduce_cross_through` exercises an additional rejection path in `conformance_probe.py` but is not marked `nautilus`.
+- Dedicated Nautilus combined-coverage ratchet: `81.21%`, with report precision `2`, so the ratchet freezes the exact maintained selection rather than the broader exploratory selection.
+
+## Global Constraints
+
+- Keep `[tool.coverage.report].fail_under = 80` unchanged.
+- Keep all existing critical-coverage file/group thresholds unchanged.
+- Do not modify trading, simulation, reward, policy, data, or research behavior.
+- Do not run all Nautilus capability tests in one pytest process; the native runtime aborts under that topology.
+- Exclude only the exact optional Nautilus adapter package from the core coverage source set.
+- Add a dedicated Nautilus coverage measurement and fail-closed ratchet before considering the scope split complete.
+- Preserve existing Nautilus test selection semantics, including `-m nautilus`; do not broaden the maintained CI selection merely to raise coverage.
+- Keep all existing Nautilus capability tests and assertions; coverage instrumentation must not replace or weaken them.
+- Keep the existing deterministic execution-digest gate observable even if the new coverage ratchet fails.
+
+---
+
+### Task 1: Lock the two-layer coverage contract with a failing architecture test
+
+**Files:**
+- Create: `tests/architecture/test_coverage_layer_contract.py`
+- Modify later: `pyproject.toml`
+- Create later: `.coveragerc.nautilus`
+- Modify later: `.github/workflows/nautilus-capability.yml`
+
+**Interfaces:**
+- Consumes: repository TOML/config/workflow text.
+- Produces: exact assertions for core omit scope, unchanged 80% threshold, dedicated Nautilus config, isolated coverage workflow wiring, maintained marker selection, and gate ordering.
+
+- [x] **Step 1: Write the failing test**
+
+Assert that:
+
+```python
+core = config["tool"]["coverage"]["run"]
+assert core["omit"] == ["trade_rl/integrations/nautilus/*"]
+assert config["tool"]["coverage"]["report"]["fail_under"] == 80
+assert (ROOT / ".coveragerc.nautilus").is_file()
+```
+
+Also assert the dedicated config measures `trade_rl/integrations/nautilus`, enables branch/parallel coverage, uses precision `2`, preserves isolated `-m nautilus` commands, binds the `81.21%` maintained-selection ratchet, and evaluates the pre-existing deterministic digest before enforcing that ratchet.
+
+- [x] **Step 2: Run RED verification**
+
+RED evidence was established in dedicated verification runs for the missing coverage split, missing decimal precision, stale ratchet baseline, and gate-ordering regression.
+
+### Task 2: Split core and Nautilus coverage responsibilities
+
+**Files:**
+- Modify: `pyproject.toml`
+- Create: `.coveragerc.nautilus`
+- Modify: `.github/workflows/nautilus-capability.yml`
+- Test: `tests/architecture/test_coverage_layer_contract.py`
+
+**Interfaces:**
+- Core coverage: unchanged global threshold, omits only `trade_rl/integrations/nautilus/*`.
+- Nautilus coverage: source `trade_rl/integrations/nautilus`, branch coverage, parallel data, subprocess + multiprocessing support, report precision `2`, maintained-selection ratchet `81.21%`.
+
+- [x] **Step 1: Add the exact core omit**
+
+Add only:
+
+```toml
+omit = ["trade_rl/integrations/nautilus/*"]
+```
+
+under `[tool.coverage.run]`. Do not change `fail_under` or critical coverage tables.
+
+- [x] **Step 2: Add dedicated coverage config**
+
+Create `.coveragerc.nautilus` with source restricted to the Nautilus adapter package, branch coverage enabled, parallel data enabled, `multiprocessing,thread` concurrency, `sigterm = True`, `patch = subprocess,_exit`, and precision `2` so child processes save evidence and decimal fail-under is interpreted correctly.
+
+- [x] **Step 3: Instrument the existing capability workflow without changing test grouping**
+
+Keep each existing pytest invocation separate and preserve its existing marker selection. Start each applicable invocation under the dedicated coverage config, combine/report after all capability tests, upload `nautilus-coverage.json`, preserve the deterministic execution-digest gate, then enforce the `81.21%` maintained-selection ratchet independently.
+
+- [ ] **Step 4: Verify GREEN targeted**
+
+Run:
+
+```bash
+uv run pytest -q tests/architecture/test_coverage_layer_contract.py
+uv run ruff check .
+uv run ruff format --check .
+uv run python .github/check_workflow_security.py .
+```
+
+Expected: PASS.
+
+### Task 3: Verify both quality layers on one exact head
+
+**Files:** no production changes expected.
+
+**Interfaces:**
+- Core oracle: full pytest + global combined coverage >= 80%.
+- Nautilus oracle: existing maintained capability selection + throughput/deterministic-digest gates + dedicated combined coverage >= 81.21%.
+
+- [ ] **Step 1: Run exact-head core quality**
+
+Expected: full suite passes, global coverage is at least 80%, critical coverage remains green, Mypy/import-linter/package identity remain green.
+
+- [ ] **Step 2: Run exact-head Nautilus capability**
+
+Expected: all existing capability probes remain green under isolated process topology and dedicated Nautilus coverage meets or exceeds `81.21%` without broadening the marker selection.
+
+- [ ] **Step 3: Falsification review**
+
+Confirm no broader core omit pattern was introduced, no Nautilus tests were removed/skipped relative to the maintained workflow, core fail-under remains `80`, the Nautilus ratchet matches the maintained-selection baseline rather than exploratory extra tests, no coverage failure is hidden by `continue-on-error`, the deterministic digest remains independently observable, and both reports are generated from the same final tree.
+
+- [ ] **Step 4: Review final diff and residual risk**
+
+Expected: only coverage/test/workflow/docs changes; no production source changes. Record that coverage proves execution of paths, not economic correctness or production readiness.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,7 @@ markers = [
 [tool.coverage.run]
 source = ["trade_rl"]
 branch = true
+omit = ["trade_rl/integrations/nautilus/*"]
 
 [tool.coverage.report]
 show_missing = true

--- a/tests/architecture/test_coverage_layer_contract.py
+++ b/tests/architecture/test_coverage_layer_contract.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import configparser
+import tomllib
+
+from tests.architecture.repository_paths import REPOSITORY_ROOT
+
+ROOT = REPOSITORY_ROOT
+
+
+def test_core_and_nautilus_coverage_have_separate_fail_closed_scopes() -> None:
+    project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    coverage = project["tool"]["coverage"]
+
+    assert coverage["report"]["fail_under"] == 80
+    assert coverage["run"]["branch"] is True
+    assert coverage["run"]["source"] == ["trade_rl"]
+    assert coverage["run"]["omit"] == ["trade_rl/integrations/nautilus/*"]
+
+    dedicated_path = ROOT / ".coveragerc.nautilus"
+    assert dedicated_path.is_file()
+    dedicated = configparser.ConfigParser()
+    dedicated.read(dedicated_path, encoding="utf-8")
+
+    run = dedicated["run"]
+    assert run.getboolean("branch") is True
+    assert run.getboolean("parallel") is True
+    assert run.getboolean("sigterm") is True
+    assert run["source"].split() == ["trade_rl/integrations/nautilus"]
+    assert {value.strip() for value in run["concurrency"].split(",")} == {
+        "multiprocessing",
+        "thread",
+    }
+    assert set(run["patch"].split()) == {"subprocess", "_exit"}
+
+    report = dedicated["report"]
+    assert report.getint("precision") == 2
+
+
+def test_nautilus_capability_keeps_native_probes_isolated_under_coverage() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "nautilus-capability.yml").read_text(
+        encoding="utf-8"
+    )
+
+    coverage_prefix = "coverage run --rcfile=.coveragerc.nautilus -m pytest"
+    assert workflow.count(coverage_prefix) >= 10
+    assert "coverage combine --rcfile=.coveragerc.nautilus" in workflow
+    assert "coverage json --rcfile=.coveragerc.nautilus" in workflow
+    assert (
+        "coverage report --rcfile=.coveragerc.nautilus --fail-under=81.21" in workflow
+    )
+    assert "nautilus-coverage.json" in workflow
+
+    for path in (
+        "tests/integrations/test_nautilus_dual_shadow.py",
+        "tests/integrations/test_nautilus_sign_flip_conformance.py",
+        "tests/integrations/test_nautilus_target_change_conformance.py",
+    ):
+        command = (
+            "coverage run --rcfile=.coveragerc.nautilus -m pytest -q -m nautilus "
+            + path
+        )
+        assert command in workflow
+
+    deterministic_gate = (
+        "      - name: Verify deterministic execution digest across fresh processes\n"
+    )
+    coverage_gate = "      - name: Enforce Nautilus coverage ratchet\n"
+    assert workflow.index(deterministic_gate) < workflow.index(coverage_gate)


### PR DESCRIPTION
## Status

**Contained in `main` at exact commit `8571b3f5d362bd4e64b3989411668e545f1acd24`.**

This Draft is closed without invoking a PR merge to avoid duplicate application. Its one commit / five-file tree is already the current `main` tree for this change.

## What

Splits the repository coverage responsibility into two explicit quality layers without changing production code:

- `Rebuilt Core` keeps the existing global `80%` threshold but omits only `trade_rl/integrations/nautilus/*`, because that adapter package requires the exact optional `nautilus_trader` runtime that Core does not install.
- `Nautilus Capability` measures the omitted adapter package separately under its existing isolated-process topology and enforces a dedicated `81.21%` combined-coverage ratchet.
- adds an architecture contract that locks the exact omit, unchanged core threshold, dedicated coverage config, maintained `-m nautilus` selection semantics, decimal precision, and deterministic-digest-before-coverage ordering.
- records the evidence and failure analysis in an implementation plan.

No production source file is changed.

## Why

The exact combined-head diagnostic after the base-hygiene stack showed all functional/critical gates green but global combined coverage at `79.18290882942891% < 80%`.

Root cause: Core counted optional Nautilus adapters in `source = ["trade_rl"]` while Core does not install the Nautilus runtime. Installing Nautilus into the same monolithic pytest process is not a valid replacement: the native Nautilus kernel can abort that process during dual-shadow execution. The maintained Nautilus workflow already uses isolated pytest processes.

The same Core coverage artifact excluding only `trade_rl/integrations/nautilus/**` measures `80.09797033943161%`, so the Core threshold remains unchanged.

## Acceptance Criteria and final evidence

- Core `fail_under` remains exactly `80`: **met**.
- Core omit is exactly `trade_rl/integrations/nautilus/*`: **met**.
- Existing critical file/group thresholds unchanged: **met**.
- Maintained Nautilus marker/group selection preserved: **met**.
- Dedicated Nautilus decimal coverage config uses `precision = 2`: **met**.
- Existing deterministic execution-digest gate runs before the new coverage ratchet: **met**.
- No production/trading/economic behavior changes: **met; five changed files are coverage config/workflow/docs/test/pyproject only**.

### Exact clean-head Core verification

Run `33362088282` explicitly checked out `8571b3f5d362bd4e64b3989411668e545f1acd24` and completed successfully:

- coverage architecture contract: pass;
- workflow security: pass;
- Ruff check / Ruff format: pass;
- Mypy: pass;
- import-linter: pass;
- vulture: pass;
- recovery / structured-serving smoke: pass;
- full suite: **4518 passed / 26 skipped**;
- Core combined coverage: **80.09797033943161%** (`80.10%` displayed), threshold `80%`: pass;
- critical branch coverage ratchets: pass;
- package build: pass;
- package / CLI / uv identity: pass.

### Exact clean-head Nautilus verification

Run `33361858491` explicitly checked out the same clean commit and completed successfully:

- runtime/coverage identity: pass;
- maintained isolated capability selection: pass;
- throughput benchmark: pass;
- deterministic execution digest across fresh processes: pass;
- dedicated combined coverage: **81.21144139091419%**;
- statement coverage: **87.45414526779163%**;
- branch coverage: **60.95238095238095%**;
- `81.21%` dedicated ratchet: pass;
- evidence upload: pass.

### Exact clean-head platform/training verification

Run `33361682766` explicitly checked out the same clean commit:

- Ubuntu compatibility: pass;
- Windows compatibility: pass;
- training image build: pass;
- packaged non-root runtime probe: pass;
- full training capability audit: pass.

Normal commit-triggered PostgreSQL Catalog run `33361778763` also passed.

## TDD / Falsification review

Dedicated RED tests demonstrated detection of:

- missing Core/Nautilus scope split;
- missing decimal coverage precision;
- a coverage gate masking the existing deterministic-digest gate;
- an incorrect `81.3%` ratchet based on a broader exploratory test population rather than the maintained `-m nautilus` population.

The final `81.21%` ratchet is bound to the maintained selection measured at `81.21144139091419%`; the Core `80%` threshold was not reduced.

## Scope

Changed files only:

- `.coveragerc.nautilus`
- `.github/workflows/nautilus-capability.yml`
- `docs/implementation-plans/plans/2026-08-31-coverage-layer-contract.md`
- `pyproject.toml`
- `tests/architecture/test_coverage_layer_contract.py`

## Remaining limitations

Coverage proves path execution, not economic correctness, profitability, market realism, or production readiness. This infrastructure repair does not open BC/RL, 1m research, or Admission.

## Follow-up

`#426` Universal Trade RL U0 is now stale relative to current `main` and must be synchronized before its exact-base comparator can be considered current.