### PR TITLE
docs: design evaluation/runs capability facade

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,9 +12,7 @@
 - [`architecture/controlled-experiment-loop.md`](architecture/controlled-experiment-loop.md) — development Study、Canonical M2 bootstrap preparation、EvidenceSet、controlled factor、lineage、FAILED/INVALID、freezeの恒久契約
 - [`research/current-status.md`](research/current-status.md) — 現在の研究目的、比較候補、M1/M2/M3の状態、canonical bootstrap、development/final評価手順と未検証事項
 
-現在Activeなspecは [`specs/2026-09-11-runs-capability-facade-design.md`](specs/2026-09-11-runs-capability-facade-design.md) である。`evaluation/runs` のTier-2 capability facadeとdependency ruleをreview中で、実装完了後は耐久契約を `architecture/package-boundaries.md` に反映してspecをcurrent treeから削除する。Active planはない。
-
-Canonical M2 Study Bootstrapの実装済み耐久契約は `architecture/controlled-experiment-loop.md`、package責務は `architecture/package-boundaries.md`、研究上の現在地は `research/current-status.md` を正本とする。
+現在Activeなspecは [`specs/2026-09-11-runs-capability-facade-design.md`](specs/2026-09-11-runs-capability-facade-design.md) である。実装計画は設計承認後に `plans/` へ置く。
 
 Rootの `README.md` はRepository概要と実行入口、rootの `AGENTS.md` はAgentの最短routingを担当する。詳細な現行契約はこの `docs/` 以下を正本とする。
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@
 - [`architecture/controlled-experiment-loop.md`](architecture/controlled-experiment-loop.md) — development Study、Canonical M2 bootstrap preparation、EvidenceSet、controlled factor、lineage、FAILED/INVALID、freezeの恒久契約
 - [`research/current-status.md`](research/current-status.md) — 現在の研究目的、比較候補、M1/M2/M3の状態、canonical bootstrap、development/final評価手順と未検証事項
 
-現在Activeなspecは [`specs/2026-09-11-runs-capability-facade-design.md`](specs/2026-09-11-runs-capability-facade-design.md) である。実装計画は設計承認後に `plans/` へ置く。
+現在Activeな設計は [`specs/2026-09-11-runs-capability-facade-design.md`](specs/2026-09-11-runs-capability-facade-design.md)、実装計画は [`plans/2026-09-11-runs-capability-facade-implementation.md`](plans/2026-09-11-runs-capability-facade-implementation.md) である。
 
 Rootの `README.md` はRepository概要と実行入口、rootの `AGENTS.md` はAgentの最短routingを担当する。詳細な現行契約はこの `docs/` 以下を正本とする。
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,9 @@
 - [`architecture/controlled-experiment-loop.md`](architecture/controlled-experiment-loop.md) — development Study、Canonical M2 bootstrap preparation、EvidenceSet、controlled factor、lineage、FAILED/INVALID、freezeの恒久契約
 - [`research/current-status.md`](research/current-status.md) — 現在の研究目的、比較候補、M1/M2/M3の状態、canonical bootstrap、development/final評価手順と未検証事項
 
-現在Activeなspec/planはない。Canonical M2 Study Bootstrapの実装済み耐久契約は `architecture/controlled-experiment-loop.md`、package責務は `architecture/package-boundaries.md`、研究上の現在地は `research/current-status.md` を正本とする。
+現在Activeなspecは [`specs/2026-09-11-runs-capability-facade-design.md`](specs/2026-09-11-runs-capability-facade-design.md) である。`evaluation/runs` のTier-2 capability facadeとdependency ruleをreview中で、実装完了後は耐久契約を `architecture/package-boundaries.md` に反映してspecをcurrent treeから削除する。Active planはない。
+
+Canonical M2 Study Bootstrapの実装済み耐久契約は `architecture/controlled-experiment-loop.md`、package責務は `architecture/package-boundaries.md`、研究上の現在地は `research/current-status.md` を正本とする。
 
 Rootの `README.md` はRepository概要と実行入口、rootの `AGENTS.md` はAgentの最短routingを担当する。詳細な現行契約はこの `docs/` 以下を正本とする。
 

--- a/docs/plans/2026-09-11-runs-capability-facade-implementation.md
+++ b/docs/plans/2026-09-11-runs-capability-facade-implementation.md
@@ -1,44 +1,45 @@
 # evaluation/runs Capability Facade Implementation Plan
 
+Status: Active
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Make `trade_rl.evaluation.runs` the single Tier-2 cross-capability entry point for Run Core contracts while preserving existing implementation owners, runtime behavior, persisted artifacts, CLI behavior, and top-level evaluation API.
 
-**Architecture:** Keep `runs/artifact.py`, `candidate_suite.py`, `config.py`, `execute.py`, and `provenance.py` as implementation owners. Add a pure re-export facade in `runs/__init__.py`, migrate production callers outside `runs/` to that facade, and add a direct-import AST contract that distinguishes import spelling from the existing re-export-aware semantic dependency collector.
+**Architecture:** Keep `runs/artifact.py`, `candidate_suite.py`, `config.py`, `execute.py`, and `provenance.py` as implementation owners. Add a pure re-export facade in `runs/__init__.py`, migrate production callers outside `runs/` to that facade, and add a direct-import AST contract that is separate from the existing re-export-aware semantic dependency collector.
 
-**Tech Stack:** Python 3.12, dataclasses, NumPy, pytest, Ruff, Mypy, existing `tests.architecture.imports.ImportCollector`, GitHub Actions CI, uv packaging.
+**Tech Stack:** Python 3.12, NumPy, pytest, Ruff, Mypy, `tests.architecture.imports.ImportCollector`, GitHub Actions, uv.
 
 **Spec:** `docs/specs/2026-09-11-runs-capability-facade-design.md`
 
 ## Global Constraints
 
 - Do not move, merge, rename, or delete existing `evaluation/runs/` owner modules.
-- Do not add business logic, wrappers, adapters, error translation, or side effects to `runs/__init__.py`.
+- Do not add business logic, wrappers, error translation, or side effects to `runs/__init__.py`.
 - Do not expand `trade_rl.evaluation.__all__`.
 - Do not expose `load_candidate_run_config`, `runtime_environment_manifest`, `PROVENANCE_SCHEMA`, CLI `main`, or `run_candidate_artifact` through the Tier-2 facade.
-- Preserve candidate result schema, candidate artifact identity schema, provenance schema, exact-file evidence, semantic artifact digest, CLI behavior, and historical readers.
-- Preserve existing `ImportCollector.collect()` re-export-aware semantics exactly; add `collect_direct()` as a separate contract.
+- Preserve candidate result/artifact/provenance schemas, exact-file evidence, semantic artifact digest, CLI behavior, and historical readers.
+- Preserve existing `ImportCollector.collect()` semantics; add `collect_direct()` separately.
 - Production source outside `trade_rl/evaluation/runs/` must not directly import `runs.artifact`, `runs.candidate_suite`, `runs.config`, `runs.execute`, or `runs.provenance` after migration.
 - Tests may still import internal owner modules for implementation-level verification.
-- New source bytes legitimately change candidate-run implementation provenance; do not normalize or weaken provenance to hide this.
-- Use TDD: establish RED before production facade/import migration.
-- `docs/specs/` and `docs/plans/` remain current only while this work is Active; remove both completed files after durable architecture documentation is updated.
+- New source bytes legitimately change implementation provenance; do not weaken provenance to hide this.
+- Use TDD and keep spec/plan Active only while this work is in progress.
 
 ---
 
-### Task 1: Add a direct-import inspection contract without changing semantic import analysis
+### Task 1: Direct-import inspection contract
 
 **Files:**
 - Modify: `tests/architecture/imports.py`
 - Modify: `tests/architecture/test_import_collector_contract.py`
 
 **Interfaces:**
-- Consumes: existing `ImportCollector._base()`, `ImportCollector.modules`, and `ImportCollector.collect()` semantics.
 - Produces: `ImportCollector.collect_direct(path: Path) -> set[str]`.
+- Preserves: `ImportCollector.collect(path: Path) -> set[str]` exactly.
 
-- [ ] **Step 1: Add failing direct-import contract tests**
+- [ ] **Step 1: Add RED tests**
 
-Append tests that import `ImportCollector` directly and prove direct spelling does not follow re-exports:
+Add:
 
 ```python
 from tests.architecture.imports import ImportCollector
@@ -63,8 +64,11 @@ def test_direct_collection_detects_physical_child_module_import(source_tree: Pat
 
 
 def test_direct_collection_resolves_relative_child_import(source_tree: Path) -> None:
-    relative = "trade_rl/evaluation/robustness/walk_forward/client.py"
-    path = _write(source_tree, relative, "from . import sealed_test\n")
+    path = _write(
+        source_tree,
+        "trade_rl/evaluation/robustness/walk_forward/client.py",
+        "from . import sealed_test\n",
+    )
     direct = ImportCollector(source_tree / "trade_rl").collect_direct(path)
     assert SEALED in direct
 
@@ -79,9 +83,7 @@ def test_direct_collection_includes_local_scope_imports(source_tree: Path) -> No
     assert SEALED in direct
 ```
 
-- [ ] **Step 2: Run the new tests to establish RED**
-
-Run:
+- [ ] **Step 2: Verify RED**
 
 ```bash
 uv run pytest -q \
@@ -91,11 +93,11 @@ uv run pytest -q \
   tests/architecture/test_import_collector_contract.py::test_direct_collection_includes_local_scope_imports
 ```
 
-Expected: fail because `ImportCollector` has no `collect_direct` method.
+Expected: failure because `collect_direct` is absent.
 
-- [ ] **Step 3: Implement the minimal `collect_direct()` API**
+- [ ] **Step 3: Implement the minimal API**
 
-Add this method without modifying `_export()`, `_star_names()`, or `collect()`:
+Add to `ImportCollector`:
 
 ```python
     def collect_direct(self, path: Path) -> set[str]:
@@ -115,11 +117,9 @@ Add this method without modifying `_export()`, `_star_names()`, or `collect()`:
         return result
 ```
 
-This deliberately records physical child modules while refusing to trace named symbol re-exports.
+Do not modify `_export`, `_star_names`, or `collect`.
 
-- [ ] **Step 4: Verify direct and legacy semantic collector contracts**
-
-Run:
+- [ ] **Step 4: Verify Task 1 GREEN**
 
 ```bash
 uv run pytest -q tests/architecture/test_import_collector_contract.py
@@ -128,9 +128,7 @@ uv run ruff check tests/architecture/imports.py tests/architecture/test_import_c
 uv run ruff format --check tests/architecture/imports.py tests/architecture/test_import_collector_contract.py
 ```
 
-Expected: all pass; existing re-export/star/cycle tests remain unchanged and green.
-
-- [ ] **Step 5: Commit Task 1**
+- [ ] **Step 5: Commit**
 
 ```bash
 git add tests/architecture/imports.py tests/architecture/test_import_collector_contract.py
@@ -139,19 +137,18 @@ git commit -m "test: distinguish direct and semantic imports"
 
 ---
 
-### Task 2: Define the Run Core facade and dependency boundary as RED architecture contracts
+### Task 2: Run Core facade architecture RED
 
 **Files:**
 - Create: `tests/architecture/test_runs_capability_facade.py`
-- No production files modified in this task.
 
 **Interfaces:**
-- Consumes: `ImportCollector.collect_direct()` from Task 1.
-- Produces: exact Tier-2 facade surface, exact top-level evaluation API snapshot, and forbidden direct-owner dependency rule.
+- Consumes: `collect_direct()` from Task 1.
+- Produces: exact Tier-2 surface, direct-owner dependency boundary, and Tier-1 API snapshot.
 
-- [ ] **Step 1: Add the exact facade surface and owner-identity contract**
+- [ ] **Step 1: Add exact Tier-2 and direct-import contracts**
 
-Create the following constants and test structure:
+Use:
 
 ```python
 from __future__ import annotations
@@ -189,11 +186,8 @@ FORBIDDEN_OWNER_MODULES = (
     "trade_rl.evaluation.runs.execute",
     "trade_rl.evaluation.runs.provenance",
 )
-```
 
-Use runtime imports only for identity checks:
 
-```python
 def test_runs_facade_exports_exact_surface_and_owner_identity() -> None:
     import trade_rl.evaluation.runs as facade
     from trade_rl.evaluation.runs import artifact, candidate_suite, config, execute, provenance
@@ -216,13 +210,8 @@ def test_runs_facade_exports_exact_surface_and_owner_identity() -> None:
     assert facade.build_candidate_run_provenance is provenance.build_candidate_run_provenance
     assert not hasattr(facade, "load_candidate_run_config")
     assert not hasattr(facade, "PROVENANCE_SCHEMA")
-```
 
-- [ ] **Step 2: Add the production direct-import boundary test**
 
-Use `collect_direct()` and skip only the owner package itself:
-
-```python
 def test_production_outside_runs_imports_run_core_through_facade() -> None:
     collector = ImportCollector(PACKAGE)
     offenders: list[tuple[str, str]] = []
@@ -235,77 +224,19 @@ def test_production_outside_runs_imports_run_core_through_facade() -> None:
     assert offenders == []
 ```
 
-This intentionally ignores tests and allows internal `runs/` modules to keep direct owner imports.
+- [ ] **Step 2: Snapshot current `trade_rl.evaluation.__all__`**
 
-- [ ] **Step 3: Snapshot the existing Tier-1 evaluation public API**
+Use the exact current set from `trade_rl/evaluation/__init__.py`; it must continue to contain `LeanCandidateConfig` and `run_lean_candidate_suite` but gain no new names.
 
-Hard-code the current `trade_rl.evaluation.__all__` set so a facade refactor cannot silently broaden Tier 1:
-
-```python
-EVALUATION_EXPORTS = {
-    "BootstrapResult",
-    "CapacityCurve",
-    "CapacityPoint",
-    "ClosedTradeDiagnostics",
-    "ClosedTradeTracker",
-    "ExecutionDiagnostics",
-    "IndependentFoldSummary",
-    "LeanCandidateConfig",
-    "PERFECT_INFORMATION_BOUND_SCHEMA",
-    "PairedComparison",
-    "PerformanceMetrics",
-    "PerfectInformationBoundConfig",
-    "PerfectInformationBoundResult",
-    "ReplayDecision",
-    "ReturnKind",
-    "ReturnSeries",
-    "SeedEvaluation",
-    "SeedResult",
-    "SeedRobustnessSummary",
-    "SingleSymbolReplayResult",
-    "StrategyComparison",
-    "StrategyComparisonEntry",
-    "SymbolStrategyComparison",
-    "UniversalStrategyComparison",
-    "compare_paired_returns",
-    "compare_strategies",
-    "compare_strategies_by_symbol",
-    "compound_return",
-    "evaluate_capacity_grid",
-    "evaluate_performance",
-    "moving_block_mean_test",
-    "resolve_gate",
-    "run_lean_candidate_suite",
-    "run_single_symbol_replay",
-    "solve_perfect_information_bound",
-    "summarize_independent_folds",
-    "summarize_seed_robustness",
-}
-
-
-def test_evaluation_tier1_public_api_is_unchanged() -> None:
-    import trade_rl.evaluation as evaluation
-
-    assert set(evaluation.__all__) == EVALUATION_EXPORTS
-```
-
-- [ ] **Step 4: Run architecture RED**
-
-Run:
+- [ ] **Step 3: Verify architecture RED**
 
 ```bash
 uv run pytest -q tests/architecture/test_runs_capability_facade.py
 ```
 
-Expected failures:
+Expected: facade-surface and direct-import tests fail; Tier-1 API snapshot passes.
 
-- `trade_rl.evaluation.runs` has no required Tier-2 `__all__`/exports yet.
-- external production files still directly import owner submodules.
-- Tier-1 snapshot should already pass.
-
-If failures occur outside these expected contracts, stop and debug before production changes.
-
-- [ ] **Step 5: Commit Task 2 RED**
+- [ ] **Step 4: Commit RED**
 
 ```bash
 git add tests/architecture/test_runs_capability_facade.py
@@ -314,7 +245,7 @@ git commit -m "test: define runs capability facade boundary"
 
 ---
 
-### Task 3: Implement the pure facade and migrate cross-capability callers
+### Task 3: Pure facade and caller migration
 
 **Files:**
 - Modify: `trade_rl/evaluation/runs/__init__.py`
@@ -328,12 +259,9 @@ git commit -m "test: define runs capability facade boundary"
 - Modify: `trade_rl/evaluation/experiments/bootstrap/workflow.py`
 
 **Interfaces:**
-- Consumes: existing owner symbols unchanged.
-- Produces: the exact `RUNS_EXPORTS` surface from Task 2; all external production callers use `from trade_rl.evaluation.runs import ...`.
+- Produces: the exact 15-name `RUNS_EXPORTS` contract from Task 2.
 
-- [ ] **Step 1: Replace the empty facade with direct owner re-exports**
-
-Use only re-exports; no wrappers:
+- [ ] **Step 1: Implement `runs/__init__.py` as direct re-exports only**
 
 ```python
 """Tier-2 public facade for immutable candidate-run contracts and execution."""
@@ -378,58 +306,46 @@ __all__ = [
 ]
 ```
 
-Do not import `candidate.py`; importing the facade must not pull in the CLI adapter.
+Do not import `candidate.py`.
 
-- [ ] **Step 2: Migrate each external production caller to the facade**
-
-Apply only import-path changes, preserving every imported symbol and all executable code below the imports.
+- [ ] **Step 2: Migrate only cross-capability production imports**
 
 Replacement inventory:
 
 ```text
 trade_rl/evaluation/__init__.py
-  runs.candidate_suite -> runs
-  symbols: LeanCandidateConfig, run_lean_candidate_suite
+  LeanCandidateConfig, run_lean_candidate_suite
 
 trade_rl/evaluation/experiments/analysis.py
-  runs.artifact -> runs
-  symbols: LoadedCandidateRun
+  LoadedCandidateRun
 
 trade_rl/evaluation/experiments/delta.py
-  runs.artifact -> runs
-  symbols: LoadedCandidateRun
+  LoadedCandidateRun
 
 trade_rl/evaluation/experiments/codec.py
-  runs.config -> runs
-  symbols: CandidateRunConfig, ResolvedCandidateRunSpec
+  CandidateRunConfig, ResolvedCandidateRunSpec
 
 trade_rl/evaluation/experiments/evidence.py
-  runs.artifact + runs.config + runs.execute + runs.provenance -> one runs import
-  symbols: LoadedCandidateRun, inspect_candidate_run_artifact,
-           load_candidate_run_artifact, publish_candidate_run,
-           CandidateRunConfig, ResolvedCandidateRunSpec,
-           resolve_candidate_run_spec, execute_candidate_run,
-           build_candidate_run_provenance
+  LoadedCandidateRun, inspect_candidate_run_artifact,
+  load_candidate_run_artifact, publish_candidate_run,
+  CandidateRunConfig, ResolvedCandidateRunSpec,
+  resolve_candidate_run_spec, execute_candidate_run,
+  build_candidate_run_provenance
 
 trade_rl/evaluation/experiments/workflow.py
-  runs.config + runs.provenance -> one runs import
-  symbols: CandidateRunConfig, resolve_candidate_run_spec,
-           build_candidate_run_provenance
+  CandidateRunConfig, resolve_candidate_run_spec,
+  build_candidate_run_provenance
 
 trade_rl/evaluation/experiments/bootstrap/config.py
-  runs.config -> runs
-  symbols: CandidateRunConfig, parse_candidate_run_config
+  CandidateRunConfig, parse_candidate_run_config
 
 trade_rl/evaluation/experiments/bootstrap/workflow.py
-  runs.config -> runs
-  symbols: ResolvedCandidateRunSpec, resolve_candidate_run_spec
+  ResolvedCandidateRunSpec, resolve_candidate_run_spec
 ```
 
-Do not change direct owner imports inside `trade_rl/evaluation/runs/` itself.
+Every listed file must import these names from `trade_rl.evaluation.runs`. Do not change call sites, arguments, returns, or exception handling. Do not change direct owner imports inside `trade_rl/evaluation/runs/`.
 
-- [ ] **Step 3: Run targeted GREEN checks**
-
-Run:
+- [ ] **Step 3: Verify targeted GREEN**
 
 ```bash
 uv run pytest -q \
@@ -437,25 +353,17 @@ uv run pytest -q \
   tests/architecture/test_runs_capability_facade.py \
   tests/evaluation \
   tests/architecture/test_experiment_workflow_boundaries.py
-uv run ruff check trade_rl/evaluation tests/architecture/test_import_collector_contract.py tests/architecture/test_runs_capability_facade.py
-uv run ruff format --check trade_rl/evaluation tests/architecture/test_import_collector_contract.py tests/architecture/test_runs_capability_facade.py
+uv run ruff check trade_rl/evaluation tests/architecture
+uv run ruff format --check trade_rl/evaluation tests/architecture
 uv run mypy trade_rl/evaluation
 uv run mypy tests/architecture/imports.py
 ```
 
-Expected: all green.
+- [ ] **Step 4: Re-run production import inventory**
 
-- [ ] **Step 4: Re-run repository-wide production import inventory**
+Search all `trade_rl.evaluation.runs.` occurrences. Production owner-submodule imports outside `trade_rl/evaluation/runs/` must be absent. CLI module path text and package-internal owner imports remain valid.
 
-Search and inspect every `trade_rl.evaluation.runs.` occurrence. Allowed production occurrences after migration are:
-
-- inside `trade_rl/evaluation/runs/` owner modules;
-- CLI module path text such as `python -m trade_rl.evaluation.runs.candidate` in docs/README;
-- no direct owner-submodule import outside `runs/`.
-
-The architecture test must independently enforce this; search output is a review signal, not the sole oracle.
-
-- [ ] **Step 5: Commit Task 3**
+- [ ] **Step 5: Commit**
 
 ```bash
 git add trade_rl/evaluation tests/architecture
@@ -464,41 +372,35 @@ git commit -m "refactor: expose candidate run capability facade"
 
 ---
 
-### Task 4: Promote the durable boundary and remove completed Active docs
+### Task 4: Durable docs and Active-doc cleanup
 
 **Files:**
 - Modify: `docs/architecture/package-boundaries.md`
 - Modify: `docs/README.md`
 - Delete: `docs/specs/2026-09-11-runs-capability-facade-design.md`
 - Delete: `docs/plans/2026-09-11-runs-capability-facade-implementation.md`
-- Verify: `tests/architecture/test_current_docs_layout.py`
 
-**Interfaces:**
-- Consumes: verified implementation from Tasks 1-3.
-- Produces: durable current architecture only; Git history retains completed spec/plan.
+- [ ] **Step 1: Promote the durable rule**
 
-- [ ] **Step 1: Add the durable Run Core boundary to `package-boundaries.md`**
-
-Document these current-state rules, not implementation history:
+Add to `package-boundaries.md`:
 
 ```text
-- `trade_rl.evaluation.runs` is the Tier-2 public facade for candidate-run contracts,
-  execution, artifact inspection/publication, and provenance construction.
+- `trade_rl.evaluation.runs` is the Tier-2 public facade for candidate-run
+  contracts, execution, artifact inspection/publication, and provenance construction.
 - `runs/config.py`, `candidate_suite.py`, `execute.py`, `artifact.py`, and
   `provenance.py` remain implementation owners.
 - production code outside `evaluation/runs/` imports Run Core through the facade;
-  package-internal code may import owner modules directly to avoid facade cycles.
-- `trade_rl.evaluation` remains the existing Tier-1 surface and is not expanded by
-  this capability rule.
+  package-internal code may import owner modules directly.
+- `trade_rl.evaluation` remains the existing Tier-1 surface and is not expanded.
 - persisted candidate-run schemas are independent compatibility contracts and are
   not inferred from Python import paths.
+- architecture tooling distinguishes direct import spelling from semantic
+  re-export ownership.
 ```
 
-Also note that architecture tooling distinguishes direct import spelling from semantic re-export ownership.
+- [ ] **Step 2: Remove completed Active docs and restore README**
 
-- [ ] **Step 2: Remove completed spec/plan and restore README current-only state**
-
-Delete both Active files after durable docs are updated. Change `docs/README.md` back to a truthful no-active-work statement:
+Delete the spec and this plan. Set the README current-state sentence to:
 
 ```text
 現在Activeなspec/planはない。
@@ -506,49 +408,36 @@ Delete both Active files after durable docs are updated. Change `docs/README.md`
 
 Do not create `docs/history` or `docs/archive`.
 
-- [ ] **Step 3: Run docs retention/link tests**
-
-Run:
+- [ ] **Step 3: Verify docs policy**
 
 ```bash
 uv run pytest -q tests/architecture/test_current_docs_layout.py
 ```
 
-Expected: current authorities present, no inactive/completed ephemeral docs, no broken links, old bootstrap docs still absent.
-
-- [ ] **Step 4: Commit Task 4**
+- [ ] **Step 4: Commit**
 
 ```bash
-git add docs tests/architecture/test_current_docs_layout.py
+git add docs
 git commit -m "docs: promote runs capability boundary"
 ```
 
 ---
 
-### Task 5: Falsification review and full hardened verification
+### Task 5: Falsification and full hardened verification
 
-**Files:**
-- Review final diff only; no planned production files beyond Tasks 1-4.
+- [ ] **Step 1: Execute falsification probes, restoring the tree after each**
 
-**Interfaces:**
-- Consumes: complete implementation.
-- Produces: objective evidence for merge/closure.
+Prove these mistakes are detected:
 
-- [ ] **Step 1: Run focused falsification probes**
+1. Reintroduce one external `runs.config` import; the direct-owner architecture test must fail.
+2. Make `collect_direct()` follow `_export()` for named symbols; the facade-symbol direct-collection test must fail.
+3. Replace one facade re-export with a wrapper; the owner-identity test must fail.
+4. Add a new name to `trade_rl.evaluation.__all__`; the Tier-1 snapshot must fail.
+5. Confirm a test-only direct owner import is not flagged by the production scan.
 
-Use temporary local/worktree edits or equivalent non-final changes and prove the tests kill these mistakes, restoring the tree after each probe:
-
-1. Change one external facade import back to `from trade_rl.evaluation.runs.config import CandidateRunConfig`; `test_production_outside_runs_imports_run_core_through_facade` must fail.
-2. Change `collect_direct()` to call `_export()` for named symbols; the facade-symbol direct-collection test must fail.
-3. Replace one facade re-export with a wrapper function/class; owner-identity test must fail.
-4. Add an extra name such as `CandidateRunConfig` to `trade_rl.evaluation.__all__`; Tier-1 snapshot must fail.
-5. Verify a test-only direct internal import is not flagged by the production dependency scan.
-
-Record which probes were actually executed and their observed failures; do not claim unexecuted probes.
+Record only probes actually executed.
 
 - [ ] **Step 2: Run full repository checks**
-
-Run exactly:
 
 ```bash
 uv run ruff check trade_rl tests
@@ -560,11 +449,11 @@ uv build
 uv run python -m tests.architecture.distribution dist/*.tar.gz dist/*.whl
 ```
 
-Then rebuild a wheel from the produced sdist and run the distribution closure check against that rebuilt wheel, matching `.github/workflows/ci.yml`.
+Rebuild a wheel from the sdist and run the same distribution closure check against it.
 
-- [ ] **Step 3: Run clean-installed package smoke outside the checkout**
+- [ ] **Step 3: Clean-installed smoke outside the checkout**
 
-Create a fresh Python 3.12 virtual environment, install the built wheel, change working directory outside the repository, and verify:
+Install the built wheel into a fresh Python 3.12 venv, change to a directory outside the repository, and verify:
 
 ```python
 import trade_rl
@@ -573,7 +462,7 @@ import trade_rl.evaluation.runs
 from trade_rl.evaluation.runs import CandidateRunConfig, load_candidate_run_artifact
 ```
 
-Verify package version/installation origin and run:
+Then run:
 
 ```bash
 python -I -m trade_rl.evaluation.runs.candidate --help
@@ -582,49 +471,14 @@ python -I -m trade_rl.evaluation.experiments.bootstrap.cli --help
 
 - [ ] **Step 4: Final diff/self-review**
 
-Check:
-
 ```bash
 git diff --check main...HEAD
 git status --short
 git diff --name-status main...HEAD
 ```
 
-Review requirement compliance, owner boundaries, cycles, public API, error behavior, artifact/provenance compatibility, dead helpers, temporary workflows, generated files, and unrelated changes.
+Verify no temporary workflows, generated artifacts, wrappers, unrelated refactors, or completed spec/plan remain.
 
-Expected final source/doc intent:
+- [ ] **Step 5: Exact-head CI and merge gate**
 
-- `tests/architecture/imports.py` + import contract tests;
-- new facade architecture test;
-- `runs/__init__.py` re-exports;
-- cross-capability import-path migration only;
-- durable `package-boundaries.md` update;
-- completed Active spec/plan absent from final tree.
-
-- [ ] **Step 5: Push final head and require exact-head CI**
-
-Open/update the implementation PR as Draft until local/targeted gates are green. Then require the GitHub Actions CI for the exact final PR head to succeed through:
-
-- Ruff
-- Format
-- production Mypy
-- architecture-tooling Mypy
-- full pytest
-- Build
-- distribution source closure and sdist rebuild
-- clean installed core smoke
-- package identity
-
-Do not use a successful run from an older commit as evidence for the final head.
-
-- [ ] **Step 6: Independent-equivalent review and merge**
-
-If a separate reviewer/subagent is available, give it the original spec, Acceptance Criteria, final diff, tests, and exact CI evidence and ask it to search for violations rather than confirm the implementation. If no independent agent is available, reconstruct the checks from the spec and review the final diff without relying on implementation conclusions.
-
-Only after this gate is green:
-
-```bash
-# Merge the PR using an expected-head SHA guard.
-```
-
-Then verify the resulting `main` merge commit has its own successful push CI before declaring the change complete.
+Require final PR HEAD CI to pass Ruff, Format, production Mypy, architecture-tooling Mypy, full pytest, Build, distribution source closure/rebuild, clean installed smoke, and package identity. Check review comments/threads. Merge with an expected-head SHA guard only after all gates are green, then require the resulting `main` merge commit to pass its own push CI.

--- a/docs/plans/2026-09-11-runs-capability-facade-implementation.md
+++ b/docs/plans/2026-09-11-runs-capability-facade-implementation.md
@@ -1,0 +1,630 @@
+# evaluation/runs Capability Facade Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `trade_rl.evaluation.runs` the single Tier-2 cross-capability entry point for Run Core contracts while preserving existing implementation owners, runtime behavior, persisted artifacts, CLI behavior, and top-level evaluation API.
+
+**Architecture:** Keep `runs/artifact.py`, `candidate_suite.py`, `config.py`, `execute.py`, and `provenance.py` as implementation owners. Add a pure re-export facade in `runs/__init__.py`, migrate production callers outside `runs/` to that facade, and add a direct-import AST contract that distinguishes import spelling from the existing re-export-aware semantic dependency collector.
+
+**Tech Stack:** Python 3.12, dataclasses, NumPy, pytest, Ruff, Mypy, existing `tests.architecture.imports.ImportCollector`, GitHub Actions CI, uv packaging.
+
+**Spec:** `docs/specs/2026-09-11-runs-capability-facade-design.md`
+
+## Global Constraints
+
+- Do not move, merge, rename, or delete existing `evaluation/runs/` owner modules.
+- Do not add business logic, wrappers, adapters, error translation, or side effects to `runs/__init__.py`.
+- Do not expand `trade_rl.evaluation.__all__`.
+- Do not expose `load_candidate_run_config`, `runtime_environment_manifest`, `PROVENANCE_SCHEMA`, CLI `main`, or `run_candidate_artifact` through the Tier-2 facade.
+- Preserve candidate result schema, candidate artifact identity schema, provenance schema, exact-file evidence, semantic artifact digest, CLI behavior, and historical readers.
+- Preserve existing `ImportCollector.collect()` re-export-aware semantics exactly; add `collect_direct()` as a separate contract.
+- Production source outside `trade_rl/evaluation/runs/` must not directly import `runs.artifact`, `runs.candidate_suite`, `runs.config`, `runs.execute`, or `runs.provenance` after migration.
+- Tests may still import internal owner modules for implementation-level verification.
+- New source bytes legitimately change candidate-run implementation provenance; do not normalize or weaken provenance to hide this.
+- Use TDD: establish RED before production facade/import migration.
+- `docs/specs/` and `docs/plans/` remain current only while this work is Active; remove both completed files after durable architecture documentation is updated.
+
+---
+
+### Task 1: Add a direct-import inspection contract without changing semantic import analysis
+
+**Files:**
+- Modify: `tests/architecture/imports.py`
+- Modify: `tests/architecture/test_import_collector_contract.py`
+
+**Interfaces:**
+- Consumes: existing `ImportCollector._base()`, `ImportCollector.modules`, and `ImportCollector.collect()` semantics.
+- Produces: `ImportCollector.collect_direct(path: Path) -> set[str]`.
+
+- [ ] **Step 1: Add failing direct-import contract tests**
+
+Append tests that import `ImportCollector` directly and prove direct spelling does not follow re-exports:
+
+```python
+from tests.architecture.imports import ImportCollector
+
+
+def test_direct_collection_does_not_follow_symbol_reexports(source_tree: Path) -> None:
+    path = _write(source_tree, CLIENT, "from ..facade import Ledger\n")
+    direct = ImportCollector(source_tree / "trade_rl").collect_direct(path)
+    assert direct == {"trade_rl.evaluation.facade"}
+    assert SEALED not in direct
+
+
+def test_direct_collection_detects_physical_child_module_import(source_tree: Path) -> None:
+    path = _write(
+        source_tree,
+        CLIENT,
+        "from ..robustness.walk_forward import sealed_test\n",
+    )
+    direct = ImportCollector(source_tree / "trade_rl").collect_direct(path)
+    assert "trade_rl.evaluation.robustness.walk_forward" in direct
+    assert SEALED in direct
+
+
+def test_direct_collection_resolves_relative_child_import(source_tree: Path) -> None:
+    relative = "trade_rl/evaluation/robustness/walk_forward/client.py"
+    path = _write(source_tree, relative, "from . import sealed_test\n")
+    direct = ImportCollector(source_tree / "trade_rl").collect_direct(path)
+    assert SEALED in direct
+
+
+def test_direct_collection_includes_local_scope_imports(source_tree: Path) -> None:
+    path = _write(
+        source_tree,
+        CLIENT,
+        "def deferred():\n    from ..robustness.walk_forward import sealed_test\n",
+    )
+    direct = ImportCollector(source_tree / "trade_rl").collect_direct(path)
+    assert SEALED in direct
+```
+
+- [ ] **Step 2: Run the new tests to establish RED**
+
+Run:
+
+```bash
+uv run pytest -q \
+  tests/architecture/test_import_collector_contract.py::test_direct_collection_does_not_follow_symbol_reexports \
+  tests/architecture/test_import_collector_contract.py::test_direct_collection_detects_physical_child_module_import \
+  tests/architecture/test_import_collector_contract.py::test_direct_collection_resolves_relative_child_import \
+  tests/architecture/test_import_collector_contract.py::test_direct_collection_includes_local_scope_imports
+```
+
+Expected: fail because `ImportCollector` has no `collect_direct` method.
+
+- [ ] **Step 3: Implement the minimal `collect_direct()` API**
+
+Add this method without modifying `_export()`, `_star_names()`, or `collect()`:
+
+```python
+    def collect_direct(self, path: Path) -> set[str]:
+        result: set[str] = set()
+        for node in ast.walk(self._tree(path)):
+            if isinstance(node, ast.Import):
+                result.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                base = self._base(path, node)
+                result.add(base)
+                for alias in node.names:
+                    if alias.name == "*":
+                        continue
+                    child = f"{base}.{alias.name}"
+                    if child in self.modules:
+                        result.add(child)
+        return result
+```
+
+This deliberately records physical child modules while refusing to trace named symbol re-exports.
+
+- [ ] **Step 4: Verify direct and legacy semantic collector contracts**
+
+Run:
+
+```bash
+uv run pytest -q tests/architecture/test_import_collector_contract.py
+uv run mypy tests/architecture/imports.py
+uv run ruff check tests/architecture/imports.py tests/architecture/test_import_collector_contract.py
+uv run ruff format --check tests/architecture/imports.py tests/architecture/test_import_collector_contract.py
+```
+
+Expected: all pass; existing re-export/star/cycle tests remain unchanged and green.
+
+- [ ] **Step 5: Commit Task 1**
+
+```bash
+git add tests/architecture/imports.py tests/architecture/test_import_collector_contract.py
+git commit -m "test: distinguish direct and semantic imports"
+```
+
+---
+
+### Task 2: Define the Run Core facade and dependency boundary as RED architecture contracts
+
+**Files:**
+- Create: `tests/architecture/test_runs_capability_facade.py`
+- No production files modified in this task.
+
+**Interfaces:**
+- Consumes: `ImportCollector.collect_direct()` from Task 1.
+- Produces: exact Tier-2 facade surface, exact top-level evaluation API snapshot, and forbidden direct-owner dependency rule.
+
+- [ ] **Step 1: Add the exact facade surface and owner-identity contract**
+
+Create the following constants and test structure:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.architecture.imports import ImportCollector, within_module
+
+ROOT = Path(__file__).resolve().parents[2]
+PACKAGE = ROOT / "trade_rl"
+RUNS = PACKAGE / "evaluation" / "runs"
+
+RUNS_EXPORTS = {
+    "CandidateRunArtifactIdentity",
+    "CandidateRunConfig",
+    "CandidateRunResult",
+    "LeanCandidateConfig",
+    "LoadedCandidateRun",
+    "PublishedCandidateRun",
+    "ResolvedCandidateRunSpec",
+    "build_candidate_run_provenance",
+    "execute_candidate_run",
+    "inspect_candidate_run_artifact",
+    "load_candidate_run_artifact",
+    "parse_candidate_run_config",
+    "publish_candidate_run",
+    "resolve_candidate_run_spec",
+    "run_lean_candidate_suite",
+}
+
+FORBIDDEN_OWNER_MODULES = (
+    "trade_rl.evaluation.runs.artifact",
+    "trade_rl.evaluation.runs.candidate_suite",
+    "trade_rl.evaluation.runs.config",
+    "trade_rl.evaluation.runs.execute",
+    "trade_rl.evaluation.runs.provenance",
+)
+```
+
+Use runtime imports only for identity checks:
+
+```python
+def test_runs_facade_exports_exact_surface_and_owner_identity() -> None:
+    import trade_rl.evaluation.runs as facade
+    from trade_rl.evaluation.runs import artifact, candidate_suite, config, execute, provenance
+
+    assert set(facade.__all__) == RUNS_EXPORTS
+    assert facade.CandidateRunConfig is config.CandidateRunConfig
+    assert facade.ResolvedCandidateRunSpec is config.ResolvedCandidateRunSpec
+    assert facade.parse_candidate_run_config is config.parse_candidate_run_config
+    assert facade.resolve_candidate_run_spec is config.resolve_candidate_run_spec
+    assert facade.LeanCandidateConfig is candidate_suite.LeanCandidateConfig
+    assert facade.run_lean_candidate_suite is candidate_suite.run_lean_candidate_suite
+    assert facade.CandidateRunResult is execute.CandidateRunResult
+    assert facade.execute_candidate_run is execute.execute_candidate_run
+    assert facade.CandidateRunArtifactIdentity is artifact.CandidateRunArtifactIdentity
+    assert facade.LoadedCandidateRun is artifact.LoadedCandidateRun
+    assert facade.PublishedCandidateRun is artifact.PublishedCandidateRun
+    assert facade.inspect_candidate_run_artifact is artifact.inspect_candidate_run_artifact
+    assert facade.load_candidate_run_artifact is artifact.load_candidate_run_artifact
+    assert facade.publish_candidate_run is artifact.publish_candidate_run
+    assert facade.build_candidate_run_provenance is provenance.build_candidate_run_provenance
+    assert not hasattr(facade, "load_candidate_run_config")
+    assert not hasattr(facade, "PROVENANCE_SCHEMA")
+```
+
+- [ ] **Step 2: Add the production direct-import boundary test**
+
+Use `collect_direct()` and skip only the owner package itself:
+
+```python
+def test_production_outside_runs_imports_run_core_through_facade() -> None:
+    collector = ImportCollector(PACKAGE)
+    offenders: list[tuple[str, str]] = []
+    for path in sorted(PACKAGE.rglob("*.py")):
+        if path.is_relative_to(RUNS):
+            continue
+        for imported in sorted(collector.collect_direct(path)):
+            if any(within_module(imported, owner) for owner in FORBIDDEN_OWNER_MODULES):
+                offenders.append((path.relative_to(ROOT).as_posix(), imported))
+    assert offenders == []
+```
+
+This intentionally ignores tests and allows internal `runs/` modules to keep direct owner imports.
+
+- [ ] **Step 3: Snapshot the existing Tier-1 evaluation public API**
+
+Hard-code the current `trade_rl.evaluation.__all__` set so a facade refactor cannot silently broaden Tier 1:
+
+```python
+EVALUATION_EXPORTS = {
+    "BootstrapResult",
+    "CapacityCurve",
+    "CapacityPoint",
+    "ClosedTradeDiagnostics",
+    "ClosedTradeTracker",
+    "ExecutionDiagnostics",
+    "IndependentFoldSummary",
+    "LeanCandidateConfig",
+    "PERFECT_INFORMATION_BOUND_SCHEMA",
+    "PairedComparison",
+    "PerformanceMetrics",
+    "PerfectInformationBoundConfig",
+    "PerfectInformationBoundResult",
+    "ReplayDecision",
+    "ReturnKind",
+    "ReturnSeries",
+    "SeedEvaluation",
+    "SeedResult",
+    "SeedRobustnessSummary",
+    "SingleSymbolReplayResult",
+    "StrategyComparison",
+    "StrategyComparisonEntry",
+    "SymbolStrategyComparison",
+    "UniversalStrategyComparison",
+    "compare_paired_returns",
+    "compare_strategies",
+    "compare_strategies_by_symbol",
+    "compound_return",
+    "evaluate_capacity_grid",
+    "evaluate_performance",
+    "moving_block_mean_test",
+    "resolve_gate",
+    "run_lean_candidate_suite",
+    "run_single_symbol_replay",
+    "solve_perfect_information_bound",
+    "summarize_independent_folds",
+    "summarize_seed_robustness",
+}
+
+
+def test_evaluation_tier1_public_api_is_unchanged() -> None:
+    import trade_rl.evaluation as evaluation
+
+    assert set(evaluation.__all__) == EVALUATION_EXPORTS
+```
+
+- [ ] **Step 4: Run architecture RED**
+
+Run:
+
+```bash
+uv run pytest -q tests/architecture/test_runs_capability_facade.py
+```
+
+Expected failures:
+
+- `trade_rl.evaluation.runs` has no required Tier-2 `__all__`/exports yet.
+- external production files still directly import owner submodules.
+- Tier-1 snapshot should already pass.
+
+If failures occur outside these expected contracts, stop and debug before production changes.
+
+- [ ] **Step 5: Commit Task 2 RED**
+
+```bash
+git add tests/architecture/test_runs_capability_facade.py
+git commit -m "test: define runs capability facade boundary"
+```
+
+---
+
+### Task 3: Implement the pure facade and migrate cross-capability callers
+
+**Files:**
+- Modify: `trade_rl/evaluation/runs/__init__.py`
+- Modify: `trade_rl/evaluation/__init__.py`
+- Modify: `trade_rl/evaluation/experiments/analysis.py`
+- Modify: `trade_rl/evaluation/experiments/delta.py`
+- Modify: `trade_rl/evaluation/experiments/evidence.py`
+- Modify: `trade_rl/evaluation/experiments/workflow.py`
+- Modify: `trade_rl/evaluation/experiments/codec.py`
+- Modify: `trade_rl/evaluation/experiments/bootstrap/config.py`
+- Modify: `trade_rl/evaluation/experiments/bootstrap/workflow.py`
+
+**Interfaces:**
+- Consumes: existing owner symbols unchanged.
+- Produces: the exact `RUNS_EXPORTS` surface from Task 2; all external production callers use `from trade_rl.evaluation.runs import ...`.
+
+- [ ] **Step 1: Replace the empty facade with direct owner re-exports**
+
+Use only re-exports; no wrappers:
+
+```python
+"""Tier-2 public facade for immutable candidate-run contracts and execution."""
+
+from trade_rl.evaluation.runs.artifact import (
+    CandidateRunArtifactIdentity,
+    LoadedCandidateRun,
+    PublishedCandidateRun,
+    inspect_candidate_run_artifact,
+    load_candidate_run_artifact,
+    publish_candidate_run,
+)
+from trade_rl.evaluation.runs.candidate_suite import (
+    LeanCandidateConfig,
+    run_lean_candidate_suite,
+)
+from trade_rl.evaluation.runs.config import (
+    CandidateRunConfig,
+    ResolvedCandidateRunSpec,
+    parse_candidate_run_config,
+    resolve_candidate_run_spec,
+)
+from trade_rl.evaluation.runs.execute import CandidateRunResult, execute_candidate_run
+from trade_rl.evaluation.runs.provenance import build_candidate_run_provenance
+
+__all__ = [
+    "CandidateRunArtifactIdentity",
+    "CandidateRunConfig",
+    "CandidateRunResult",
+    "LeanCandidateConfig",
+    "LoadedCandidateRun",
+    "PublishedCandidateRun",
+    "ResolvedCandidateRunSpec",
+    "build_candidate_run_provenance",
+    "execute_candidate_run",
+    "inspect_candidate_run_artifact",
+    "load_candidate_run_artifact",
+    "parse_candidate_run_config",
+    "publish_candidate_run",
+    "resolve_candidate_run_spec",
+    "run_lean_candidate_suite",
+]
+```
+
+Do not import `candidate.py`; importing the facade must not pull in the CLI adapter.
+
+- [ ] **Step 2: Migrate each external production caller to the facade**
+
+Apply only import-path changes, preserving every imported symbol and all executable code below the imports.
+
+Replacement inventory:
+
+```text
+trade_rl/evaluation/__init__.py
+  runs.candidate_suite -> runs
+  symbols: LeanCandidateConfig, run_lean_candidate_suite
+
+trade_rl/evaluation/experiments/analysis.py
+  runs.artifact -> runs
+  symbols: LoadedCandidateRun
+
+trade_rl/evaluation/experiments/delta.py
+  runs.artifact -> runs
+  symbols: LoadedCandidateRun
+
+trade_rl/evaluation/experiments/codec.py
+  runs.config -> runs
+  symbols: CandidateRunConfig, ResolvedCandidateRunSpec
+
+trade_rl/evaluation/experiments/evidence.py
+  runs.artifact + runs.config + runs.execute + runs.provenance -> one runs import
+  symbols: LoadedCandidateRun, inspect_candidate_run_artifact,
+           load_candidate_run_artifact, publish_candidate_run,
+           CandidateRunConfig, ResolvedCandidateRunSpec,
+           resolve_candidate_run_spec, execute_candidate_run,
+           build_candidate_run_provenance
+
+trade_rl/evaluation/experiments/workflow.py
+  runs.config + runs.provenance -> one runs import
+  symbols: CandidateRunConfig, resolve_candidate_run_spec,
+           build_candidate_run_provenance
+
+trade_rl/evaluation/experiments/bootstrap/config.py
+  runs.config -> runs
+  symbols: CandidateRunConfig, parse_candidate_run_config
+
+trade_rl/evaluation/experiments/bootstrap/workflow.py
+  runs.config -> runs
+  symbols: ResolvedCandidateRunSpec, resolve_candidate_run_spec
+```
+
+Do not change direct owner imports inside `trade_rl/evaluation/runs/` itself.
+
+- [ ] **Step 3: Run targeted GREEN checks**
+
+Run:
+
+```bash
+uv run pytest -q \
+  tests/architecture/test_import_collector_contract.py \
+  tests/architecture/test_runs_capability_facade.py \
+  tests/evaluation \
+  tests/architecture/test_experiment_workflow_boundaries.py
+uv run ruff check trade_rl/evaluation tests/architecture/test_import_collector_contract.py tests/architecture/test_runs_capability_facade.py
+uv run ruff format --check trade_rl/evaluation tests/architecture/test_import_collector_contract.py tests/architecture/test_runs_capability_facade.py
+uv run mypy trade_rl/evaluation
+uv run mypy tests/architecture/imports.py
+```
+
+Expected: all green.
+
+- [ ] **Step 4: Re-run repository-wide production import inventory**
+
+Search and inspect every `trade_rl.evaluation.runs.` occurrence. Allowed production occurrences after migration are:
+
+- inside `trade_rl/evaluation/runs/` owner modules;
+- CLI module path text such as `python -m trade_rl.evaluation.runs.candidate` in docs/README;
+- no direct owner-submodule import outside `runs/`.
+
+The architecture test must independently enforce this; search output is a review signal, not the sole oracle.
+
+- [ ] **Step 5: Commit Task 3**
+
+```bash
+git add trade_rl/evaluation tests/architecture
+git commit -m "refactor: expose candidate run capability facade"
+```
+
+---
+
+### Task 4: Promote the durable boundary and remove completed Active docs
+
+**Files:**
+- Modify: `docs/architecture/package-boundaries.md`
+- Modify: `docs/README.md`
+- Delete: `docs/specs/2026-09-11-runs-capability-facade-design.md`
+- Delete: `docs/plans/2026-09-11-runs-capability-facade-implementation.md`
+- Verify: `tests/architecture/test_current_docs_layout.py`
+
+**Interfaces:**
+- Consumes: verified implementation from Tasks 1-3.
+- Produces: durable current architecture only; Git history retains completed spec/plan.
+
+- [ ] **Step 1: Add the durable Run Core boundary to `package-boundaries.md`**
+
+Document these current-state rules, not implementation history:
+
+```text
+- `trade_rl.evaluation.runs` is the Tier-2 public facade for candidate-run contracts,
+  execution, artifact inspection/publication, and provenance construction.
+- `runs/config.py`, `candidate_suite.py`, `execute.py`, `artifact.py`, and
+  `provenance.py` remain implementation owners.
+- production code outside `evaluation/runs/` imports Run Core through the facade;
+  package-internal code may import owner modules directly to avoid facade cycles.
+- `trade_rl.evaluation` remains the existing Tier-1 surface and is not expanded by
+  this capability rule.
+- persisted candidate-run schemas are independent compatibility contracts and are
+  not inferred from Python import paths.
+```
+
+Also note that architecture tooling distinguishes direct import spelling from semantic re-export ownership.
+
+- [ ] **Step 2: Remove completed spec/plan and restore README current-only state**
+
+Delete both Active files after durable docs are updated. Change `docs/README.md` back to a truthful no-active-work statement:
+
+```text
+現在Activeなspec/planはない。
+```
+
+Do not create `docs/history` or `docs/archive`.
+
+- [ ] **Step 3: Run docs retention/link tests**
+
+Run:
+
+```bash
+uv run pytest -q tests/architecture/test_current_docs_layout.py
+```
+
+Expected: current authorities present, no inactive/completed ephemeral docs, no broken links, old bootstrap docs still absent.
+
+- [ ] **Step 4: Commit Task 4**
+
+```bash
+git add docs tests/architecture/test_current_docs_layout.py
+git commit -m "docs: promote runs capability boundary"
+```
+
+---
+
+### Task 5: Falsification review and full hardened verification
+
+**Files:**
+- Review final diff only; no planned production files beyond Tasks 1-4.
+
+**Interfaces:**
+- Consumes: complete implementation.
+- Produces: objective evidence for merge/closure.
+
+- [ ] **Step 1: Run focused falsification probes**
+
+Use temporary local/worktree edits or equivalent non-final changes and prove the tests kill these mistakes, restoring the tree after each probe:
+
+1. Change one external facade import back to `from trade_rl.evaluation.runs.config import CandidateRunConfig`; `test_production_outside_runs_imports_run_core_through_facade` must fail.
+2. Change `collect_direct()` to call `_export()` for named symbols; the facade-symbol direct-collection test must fail.
+3. Replace one facade re-export with a wrapper function/class; owner-identity test must fail.
+4. Add an extra name such as `CandidateRunConfig` to `trade_rl.evaluation.__all__`; Tier-1 snapshot must fail.
+5. Verify a test-only direct internal import is not flagged by the production dependency scan.
+
+Record which probes were actually executed and their observed failures; do not claim unexecuted probes.
+
+- [ ] **Step 2: Run full repository checks**
+
+Run exactly:
+
+```bash
+uv run ruff check trade_rl tests
+uv run ruff format --check trade_rl tests
+uv run mypy trade_rl
+uv run mypy tests/architecture/imports.py tests/architecture/distribution.py
+uv run pytest -q tests
+uv build
+uv run python -m tests.architecture.distribution dist/*.tar.gz dist/*.whl
+```
+
+Then rebuild a wheel from the produced sdist and run the distribution closure check against that rebuilt wheel, matching `.github/workflows/ci.yml`.
+
+- [ ] **Step 3: Run clean-installed package smoke outside the checkout**
+
+Create a fresh Python 3.12 virtual environment, install the built wheel, change working directory outside the repository, and verify:
+
+```python
+import trade_rl
+import trade_rl.evaluation
+import trade_rl.evaluation.runs
+from trade_rl.evaluation.runs import CandidateRunConfig, load_candidate_run_artifact
+```
+
+Verify package version/installation origin and run:
+
+```bash
+python -I -m trade_rl.evaluation.runs.candidate --help
+python -I -m trade_rl.evaluation.experiments.bootstrap.cli --help
+```
+
+- [ ] **Step 4: Final diff/self-review**
+
+Check:
+
+```bash
+git diff --check main...HEAD
+git status --short
+git diff --name-status main...HEAD
+```
+
+Review requirement compliance, owner boundaries, cycles, public API, error behavior, artifact/provenance compatibility, dead helpers, temporary workflows, generated files, and unrelated changes.
+
+Expected final source/doc intent:
+
+- `tests/architecture/imports.py` + import contract tests;
+- new facade architecture test;
+- `runs/__init__.py` re-exports;
+- cross-capability import-path migration only;
+- durable `package-boundaries.md` update;
+- completed Active spec/plan absent from final tree.
+
+- [ ] **Step 5: Push final head and require exact-head CI**
+
+Open/update the implementation PR as Draft until local/targeted gates are green. Then require the GitHub Actions CI for the exact final PR head to succeed through:
+
+- Ruff
+- Format
+- production Mypy
+- architecture-tooling Mypy
+- full pytest
+- Build
+- distribution source closure and sdist rebuild
+- clean installed core smoke
+- package identity
+
+Do not use a successful run from an older commit as evidence for the final head.
+
+- [ ] **Step 6: Independent-equivalent review and merge**
+
+If a separate reviewer/subagent is available, give it the original spec, Acceptance Criteria, final diff, tests, and exact CI evidence and ask it to search for violations rather than confirm the implementation. If no independent agent is available, reconstruct the checks from the spec and review the final diff without relying on implementation conclusions.
+
+Only after this gate is green:
+
+```bash
+# Merge the PR using an expected-head SHA guard.
+```
+
+Then verify the resulting `main` merge commit has its own successful push CI before declaring the change complete.

--- a/docs/specs/2026-09-11-runs-capability-facade-design.md
+++ b/docs/specs/2026-09-11-runs-capability-facade-design.md
@@ -292,7 +292,7 @@ facadeが内部moduleをre-exportすることで既存internal dependency graph�
 
 - package内部はfacadeを使わずowner moduleを直接importする。
 - facadeだけがowner moduleを外向きに束ねる。
-- import順は `candidate_suite → config → execute → provenance → artifact` とし、既存internal dependency directionに従う。
+- facadeからowner moduleを直接re-exportし、owner側からfacadeへの依存は作らない。
 - clean import testで確認する。
 
 ### Over-export

--- a/docs/specs/2026-09-11-runs-capability-facade-design.md
+++ b/docs/specs/2026-09-11-runs-capability-facade-design.md
@@ -46,15 +46,14 @@ Issue #452 の目的は「すべてを一つのファイルにする」ことで
 - `evaluation/runs/` のファイル統合・rename・package再編はしない。
 - `CandidateRunConfig`、`ResolvedCandidateRunSpec`、artifact schema、provenance schemaの意味を変更しない。
 - `candidate.py` CLI adapterをcapability public APIへ昇格させない。
-- `PROVENANCE_SCHEMA` やprivate helperなど、内部module間だけで必要なsymbolをfacadeへ公開しない。
+- `load_candidate_run_config` をTier-2へ公開しない。現時点では `candidate.py` 内部だけが使用している。
+- `PROVENANCE_SCHEMA`、`runtime_environment_manifest`、private helperなど、内部module間だけで必要なsymbolをfacadeへ公開しない。
 - `trade_rl.evaluation.__all__` を拡大しない。
 - testsから内部moduleをimportすることを全面禁止しない。implementation-level testは内部ownerを直接検査してよい。
 - runtimeでprivate importを不可能にする仕組みは追加しない。これはsource architecture contractで管理する。
 - deprecated forwarding moduleや互換shimを新設しない。
 
 ## API tier
-
-今回の変更では以下のtierを採用する。
 
 ```text
 Tier 1: trade_rl.evaluation
@@ -72,13 +71,12 @@ Tier 4: persisted candidate-run artifact/schema contracts
 
 ## Tier-2 facade surface
 
-`trade_rl.evaluation.runs.__init__` は以下を公開する。
+`trade_rl.evaluation.runs.__init__` は以下だけを公開する。
 
 ### Config / resolve
 
 - `CandidateRunConfig`
 - `ResolvedCandidateRunSpec`
-- `load_candidate_run_config`
 - `parse_candidate_run_config`
 - `resolve_candidate_run_spec`
 
@@ -105,17 +103,11 @@ Tier 4: persisted candidate-run artifact/schema contracts
 
 - `build_candidate_run_provenance`
 
-`runtime_environment_manifest`、`PROVENANCE_SCHEMA`、CLI `main`、`run_candidate_artifact` は今回のTier-2 surfaceには含めない。
-
-理由:
-
-- runtime manifest/schema constantは現時点でcapability外のsemantic consumerを持たない。
-- CLI adapterはfilesystem entrypointであり、Run Core contractそのものではない。
-- facadeは「便利そうなsymbol一覧」ではなく、現在のcross-capability boundaryを表す必要最小限のsurfaceとする。
+このsurfaceは、現在のcross-capability利用と公開functionの戻り型に必要なcontractへ限定する。convenienceだけを理由にexportを増やさない。
 
 ## Dependency rule
 
-production sourceについて、`trade_rl/evaluation/runs/` の外から以下への直接importを禁止する。
+production sourceについて、`trade_rl/evaluation/runs/` の外から以下への**直接綴られたimport**を禁止する。
 
 ```text
 trade_rl.evaluation.runs.artifact
@@ -128,14 +120,51 @@ trade_rl.evaluation.runs.provenance
 許可する入口は:
 
 ```python
-from trade_rl.evaluation.runs import ...
+from trade_rl.evaluation.runs import CandidateRunConfig
 ```
 
-`candidate.py` はCLI adapterであり、通常のproduction dependencyとして利用すべきではない。ただし今回のhard gateでは、実際の利用状況とfalse positiveを避けるため、まず上記Run Core owner module群を対象とする。
+次のようなmodule importは、facade経由に見えても内部moduleを直接選択しているため禁止対象とする。
+
+```python
+from trade_rl.evaluation.runs import config
+```
+
+`candidate.py` はCLI adapterであり通常のcross-capability dependencyとして利用すべきではない。ただし今回のhard gateでは、実際にsemantic ownerとして使われている上記5 moduleを対象とし、CLI module自体の存在は禁止しない。
 
 `trade_rl/evaluation/runs/` 内部ではsubmodule direct importを許可する。package内部責務をfacade経由で循環させない。
 
-architecture testはproduction sourceを対象とし、tests自身のimplementation-level importsは対象外とする。
+architecture ruleはproduction sourceを対象とし、tests自身のimplementation-level importsは対象外とする。
+
+## Architecture tooling design
+
+既存 `tests/architecture/imports.py` の `ImportCollector.collect()` は、static re-exportを追跡してsemantic ownerまで展開する。この性質は既存dependency boundary検査には有用だが、今回の「callerがどのpathを直接綴ったか」というhard gateにはそのまま使えない。
+
+例えば:
+
+```python
+from trade_rl.evaluation.runs import CandidateRunConfig
+```
+
+を `collect()` すると、facadeからre-exportされた `trade_rl.evaluation.runs.config` まで依存として観測され得る。これをdirect-import禁止に使うと正しいfacade利用を誤検出する。
+
+したがって別parserを新設せず、既存 `ImportCollector` に **direct spelling専用API** を追加する。
+
+候補名:
+
+```python
+ImportCollector.collect_direct(path: Path) -> set[str]
+```
+
+契約:
+
+- relative importは既存 `_base()` でabsolute moduleへ解決する。
+- `import a.b.c` は `a.b.c` を返す。
+- `from a.b import Symbol` は `a.b` を返す。
+- `from a.b import child_module` で `a.b.child_module` が物理moduleとして存在する場合は、そのchild moduleも返す。
+- re-exportされたclass/functionのownerまでは追跡しない。
+- `collect()` の既存semantic/transitive behaviorは変更しない。
+
+これにより今回のdirect-spelling gateと既存semantic dependency gateを混同しない。
 
 ## Import migration
 
@@ -152,15 +181,15 @@ trade_rl/evaluation/experiments/bootstrap/config.py
 trade_rl/evaluation/experiments/bootstrap/workflow.py
 ```
 
-実際の変更前にrepository-wide import inventoryを再取得し、上記以外のproduction callerがあれば同じ契約で分類する。
+実装前にrepository-wide import inventoryを再取得し、上記以外のproduction callerがあれば同じcontractで分類する。
 
 migrationはimport pathだけを変え、呼出し順、引数、戻り値、exception handlingを変更しない。
+
+`evaluation/runs/` 内部moduleはfacadeを経由せず既存owner moduleを直接importする。
 
 ## Object identity contract
 
 facadeは既存ownerから直接re-exportする。
-
-例:
 
 ```python
 from trade_rl.evaluation.runs import CandidateRunConfig
@@ -169,9 +198,7 @@ from trade_rl.evaluation.runs.config import CandidateRunConfig as InternalCandid
 assert CandidateRunConfig is InternalCandidateRunConfig
 ```
 
-新しいwrapper class、subclass、adapter function、proxy objectは作らない。
-
-これによりtype identity、dataclass field定義、serialization behavior、exception semanticsを維持する。
+wrapper class、subclass、adapter function、proxy objectは作らない。
 
 ## Persisted artifact / provenance contract
 
@@ -186,13 +213,11 @@ assert CandidateRunConfig is InternalCandidateRunConfig
 - exact-file digest/size evidence
 - implementation manifestの定義
 
-注意: `build_candidate_run_provenance()` はpackage内Python sourceのpathとraw bytesをimplementation identityへ含める。そのため `runs/__init__.py` の変更およびimport source変更は **新しいimplementation digestを生成することが正しい**。
+`build_candidate_run_provenance()` はpackage内Python sourceのrelative pathとraw bytesをimplementation identityへ含める。したがって `runs/__init__.py` の変更やimport source変更により **新しいimplementation digestになることは正しい**。
 
-既存Studyやartifactの過去implementation identityを新sourceと同一視してはならない。これはbehavior compatibilityとimplementation identityを区別する既存契約である。
+既存Studyやartifactの過去implementation identityを新sourceと同一視してはならない。behavior compatibilityとimplementation identity preservationは別contractである。
 
 ## Architecture test design
-
-既存のAST import toolingを再利用し、別の簡易parserを作らない。
 
 hard gateは少なくとも次を検証する。
 
@@ -200,10 +225,14 @@ hard gateは少なくとも次を検証する。
 2. `from trade_rl.evaluation.runs.config import ...` がfailする。
 3. `import trade_rl.evaluation.runs.artifact` がfailする。
 4. `from trade_rl.evaluation.runs import CandidateRunConfig` はpassする。
-5. `evaluation/runs/` 内部のdirect submodule importはpassする。
-6. tests directoryはこのproduction dependency ruleの対象外である。
-7. facade exportが既存internal ownerとobject identityを共有する。
-8. `trade_rl.evaluation.__all__` の公開symbol集合は変更しない。
+5. `from trade_rl.evaluation.runs import config` はchild module direct selectionとしてfailする。
+6. relative import解決でも同じdirect-spelling contractになる。
+7. `evaluation/runs/` 内部のdirect submodule importはpassする。
+8. tests directoryはこのproduction dependency ruleの対象外である。
+9. facade exportが既存internal ownerとobject identityを共有する。
+10. exact `runs.__all__` が設計surfaceと一致する。
+11. `trade_rl.evaluation.__all__` の公開symbol集合は変更しない。
+12. 既存 `ImportCollector.collect()` のre-export追跡behaviorを壊さない。
 
 architecture gateは「内部moduleが存在してはいけない」とは判定しない。内部moduleは正規ownerとして必要である。
 
@@ -222,32 +251,35 @@ architecture gateは「内部moduleが存在してはいけない」とは判定
 
 ## Acceptance Criteria
 
-1. `trade_rl.evaluation.runs` からTier-2 surfaceをimportできる。
+1. `trade_rl.evaluation.runs` から設計済みTier-2 surfaceをimportできる。
 2. facade symbolは既存submodule symbolと同一objectである。
 3. capability外production codeにRun Core owner moduleへのdirect importが残っていない。
-4. architecture testが新しいdirect import regressionを検出する。
-5. `trade_rl.evaluation.__all__` は変更しない。
-6. candidate-run artifact schema、digest、provenance schema、CLI behaviorは変更しない。
-7. existing run/experiment/bootstrap testsがGreenである。
-8. full repository pytestがGreenである。
-9. Ruff / Format / Mypy / architecture-tooling MypyがGreenである。
-10. build、tracked-source closure、sdist rebuild、clean installed smoke、package identityがGreenである。
-11. exact final HEADのCI成功を確認する。
-12. final diffにtemporary workflow、helper、generated artifact、unrelated refactorが残らない。
-13. `docs/architecture/package-boundaries.md` に耐久的なTier-2 facade ruleを反映する。
-14. 実装完了後、このActive specをcurrent treeから削除する。
+4. `collect_direct()` がrelative importとactual child-module importを正しく判定し、re-export ownerは追跡しない。
+5. architecture testが新しいdirect import regressionを検出する。
+6. 既存 `ImportCollector.collect()` のsemantic/transitive behaviorは維持される。
+7. `trade_rl.evaluation.__all__` は変更しない。
+8. candidate-run artifact schema、digest、provenance schema、CLI behaviorは変更しない。
+9. existing run/experiment/bootstrap testsがGreenである。
+10. full repository pytestがGreenである。
+11. Ruff / Format / Mypy / architecture-tooling MypyがGreenである。
+12. build、tracked-source closure、sdist rebuild、clean installed smoke、package identityがGreenである。
+13. exact final HEADのCI成功を確認する。
+14. final diffにtemporary workflow、helper、generated artifact、unrelated refactorが残らない。
+15. `docs/architecture/package-boundaries.md` に耐久的なTier-2 facade ruleを反映する。
+16. 実装完了後、このActive specをcurrent treeから削除する。
 
 ## Invariants
 
 - Run Coreのsemantic ownersは既存内部moduleのまま維持する。
 - `runs/__init__.py` にbusiness logicを置かない。
-- facade importはside effectを追加しない。
+- facade importはnetwork/filesystem/mutation side effectを追加しない。
 - candidate execution結果は変えない。
 - persisted artifact formatを変えない。
 - historical artifact reader behaviorを変えない。
 - provenanceを弱めない。
 - top-level evaluation APIを増やさない。
 - CLI adapter contractを変えない。
+- 既存architecture import collectorのsemantic dependency検出能力を弱めない。
 
 ## Failure Modes
 
@@ -267,12 +299,21 @@ facadeが内部moduleをre-exportすることで既存internal dependency graph�
 
 対策:
 
-- actual cross-capability usageを基準にsurfaceを固定する。
+- actual cross-capability usageとpublic return typeを基準にsurfaceを固定する。
 - convenienceだけを理由にexportを追加しない。
 
-### False architecture violation
+### False architecture violation by re-export expansion
 
-implementation testsやpackage内部importまで禁止すると、内部責務テストや正常な依存が壊れる。
+既存 `collect()` はfacadeのre-export先まで追跡するため、direct import gateへ流用すると正しいfacade利用を違反扱いし得る。
+
+対策:
+
+- `collect_direct()` と `collect()` のoracleを分離する。
+- direct-spelling regression testを追加する。
+
+### False architecture violation of internal/tests imports
+
+implementation testsやpackage内部importまで禁止すると正常な責務テストが壊れる。
 
 対策:
 
@@ -284,7 +325,7 @@ import整理と同時にrefactorを行うとbehavior差分が混入する。
 
 対策:
 
-- migrationはimport statementとfacade/architecture tests/docsに限定する。
+- migrationはimport statement、facade、architecture tooling/tests、必要docsに限定する。
 - unrelated cleanupは別変更にする。
 
 ### Provenance confusion
@@ -302,8 +343,11 @@ source path/bytes変更によるimplementation digest変化をregressionと誤�
 
 観測対象:
 
+- exact Tier-2 `__all__`
 - facade/internal symbol object identity
-- architecture gateのallowed/forbidden import判定
+- `collect_direct()` のdirect import set
+- 既存 `collect()` のsemantic/transitive import set
+- architecture gateのallowed/forbidden判定
 - production import inventory
 - `trade_rl.evaluation.__all__` snapshot
 - existing config parse/resolve outputs
@@ -318,8 +362,10 @@ source path/bytes変更によるimplementation digest変化をregressionと誤�
 
 ## Required Test Layers
 
-- Static architecture tests
+- Unit tests for `ImportCollector.collect_direct()`
+- Static architecture tests for Run Core facade boundary
 - Unit tests for facade identity/export surface
+- Existing architecture import-tooling tests
 - Existing config/execute/artifact/provenance tests
 - Existing experiments/bootstrap integration tests
 - Existing CLI tests
@@ -337,14 +383,18 @@ source path/bytes変更によるimplementation digest変化をregressionと誤�
 
 ## Falsification review
 
-実装後、少なくとも以下を意図的に試す。
+実装後、少なくとも以下を意図的に確認する。
 
 - `experiments` から `runs.config` を再導入するとarchitecture testが落ちるか。
-- facadeのexportがwrapperに置き換わった場合identity testが落ちるか。
-- top-level `evaluation.__all__` を誤って増やすとtestが検出するか。
-- internal `runs` module同士の正常importを誤検出していないか。
-- testsのimplementation-level direct importを誤検出していないか。
-- artifact digest/schemaが変わっていないか。
+- `from trade_rl.evaluation.runs import config` を違反として検出できるか。
+- facadeの正規class/function importをre-export先追跡で誤検出しないか。
+- relative importでhard gateを迂回できないか。
+- facade exportをwrapperへ置き換える誤実装をidentity testが検出するか。
+- top-level `evaluation.__all__` の誤変更を検出するか。
+- internal `runs` module同士の正常importを誤検出しないか。
+- testsのimplementation-level direct importを誤検出しないか。
+- 既存semantic dependency testが `collect_direct()` 追加によって弱くなっていないか。
+- artifact schema/semantic digest behaviorが変わっていないか。
 - clean wheel上でもfacade importが成立するか。
 
 ## Quality Gate
@@ -353,6 +403,7 @@ source path/bytes変更によるimplementation digest変化をregressionと誤�
 
 - Acceptance Criteriaを満たす。
 - architecture hard gateが意図したdirect dependency regressionを検出できる。
+- 既存semantic import collector behaviorが維持される。
 - existing functional/integration testsがGreen。
 - full testsがGreen。
 - static/type/style checksがGreen。

--- a/docs/specs/2026-09-11-runs-capability-facade-design.md
+++ b/docs/specs/2026-09-11-runs-capability-facade-design.md
@@ -46,14 +46,15 @@ Issue #452 の目的は「すべてを一つのファイルにする」ことで
 - `evaluation/runs/` のファイル統合・rename・package再編はしない。
 - `CandidateRunConfig`、`ResolvedCandidateRunSpec`、artifact schema、provenance schemaの意味を変更しない。
 - `candidate.py` CLI adapterをcapability public APIへ昇格させない。
-- `load_candidate_run_config` をTier-2へ公開しない。現時点では `candidate.py` 内部だけが使用している。
-- `PROVENANCE_SCHEMA`、`runtime_environment_manifest`、private helperなど、内部module間だけで必要なsymbolをfacadeへ公開しない。
+- `PROVENANCE_SCHEMA` やprivate helperなど、内部module間だけで必要なsymbolをfacadeへ公開しない。
 - `trade_rl.evaluation.__all__` を拡大しない。
 - testsから内部moduleをimportすることを全面禁止しない。implementation-level testは内部ownerを直接検査してよい。
 - runtimeでprivate importを不可能にする仕組みは追加しない。これはsource architecture contractで管理する。
 - deprecated forwarding moduleや互換shimを新設しない。
 
 ## API tier
+
+今回の変更では以下のtierを採用する。
 
 ```text
 Tier 1: trade_rl.evaluation
@@ -71,7 +72,7 @@ Tier 4: persisted candidate-run artifact/schema contracts
 
 ## Tier-2 facade surface
 
-`trade_rl.evaluation.runs.__init__` は以下だけを公開する。
+`trade_rl.evaluation.runs.__init__` は以下を公開する。
 
 ### Config / resolve
 
@@ -79,6 +80,8 @@ Tier 4: persisted candidate-run artifact/schema contracts
 - `ResolvedCandidateRunSpec`
 - `parse_candidate_run_config`
 - `resolve_candidate_run_spec`
+
+`load_candidate_run_config` はCLI adapter内部でのみ利用され、現在cross-capability consumerを持たないためTier-2へは公開しない。
 
 ### Candidate suite
 
@@ -103,11 +106,17 @@ Tier 4: persisted candidate-run artifact/schema contracts
 
 - `build_candidate_run_provenance`
 
-このsurfaceは、現在のcross-capability利用と公開functionの戻り型に必要なcontractへ限定する。convenienceだけを理由にexportを増やさない。
+`runtime_environment_manifest`、`PROVENANCE_SCHEMA`、CLI `main`、`run_candidate_artifact` は今回のTier-2 surfaceには含めない。
+
+理由:
+
+- runtime manifest/schema constantは現時点でcapability外のsemantic consumerを持たない。
+- CLI adapterはfilesystem entrypointであり、Run Core contractそのものではない。
+- facadeは「便利そうなsymbol一覧」ではなく、現在のcross-capability boundaryを表す必要最小限のsurfaceとする。
 
 ## Dependency rule
 
-production sourceについて、`trade_rl/evaluation/runs/` の外から以下への**直接綴られたimport**を禁止する。
+production sourceについて、`trade_rl/evaluation/runs/` の外から以下への直接importを禁止する。
 
 ```text
 trade_rl.evaluation.runs.artifact
@@ -120,51 +129,40 @@ trade_rl.evaluation.runs.provenance
 許可する入口は:
 
 ```python
-from trade_rl.evaluation.runs import CandidateRunConfig
+from trade_rl.evaluation.runs import ...
 ```
 
-次のようなmodule importは、facade経由に見えても内部moduleを直接選択しているため禁止対象とする。
-
-```python
-from trade_rl.evaluation.runs import config
-```
-
-`candidate.py` はCLI adapterであり通常のcross-capability dependencyとして利用すべきではない。ただし今回のhard gateでは、実際にsemantic ownerとして使われている上記5 moduleを対象とし、CLI module自体の存在は禁止しない。
+`candidate.py` はCLI adapterであり、通常のproduction dependencyとして利用すべきではない。ただし今回のhard gateでは、実際の利用状況とfalse positiveを避けるため、まず上記Run Core owner module群を対象とする。
 
 `trade_rl/evaluation/runs/` 内部ではsubmodule direct importを許可する。package内部責務をfacade経由で循環させない。
 
-architecture ruleはproduction sourceを対象とし、tests自身のimplementation-level importsは対象外とする。
+architecture testはproduction sourceを対象とし、tests自身のimplementation-level importsは対象外とする。
 
-## Architecture tooling design
+## Import tooling contract
 
-既存 `tests/architecture/imports.py` の `ImportCollector.collect()` は、static re-exportを追跡してsemantic ownerまで展開する。この性質は既存dependency boundary検査には有用だが、今回の「callerがどのpathを直接綴ったか」というhard gateにはそのまま使えない。
+既存 `ImportCollector.collect()` は、static re-exportを追跡してsemantic ownerまで展開する。この挙動はtop-level dependency境界の検査に必要であり、変更しない。
 
-例えば:
+一方、今回必要なのは「sourceがどのmodule pathを直接import文に綴ったか」である。`collect()` をそのまま利用すると、正しいfacade importである
 
 ```python
 from trade_rl.evaluation.runs import CandidateRunConfig
 ```
 
-を `collect()` すると、facadeからre-exportされた `trade_rl.evaluation.runs.config` まで依存として観測され得る。これをdirect-import禁止に使うと正しいfacade利用を誤検出する。
+までre-export先の `trade_rl.evaluation.runs.config` に依存したと解釈され、false positiveになる。
 
-したがって別parserを新設せず、既存 `ImportCollector` に **direct spelling専用API** を追加する。
+そこで `ImportCollector` に `collect_direct(path: Path) -> set[str]` を追加する。
 
-候補名:
+`collect_direct()` は:
 
-```python
-ImportCollector.collect_direct(path: Path) -> set[str]
-```
+- absolute/relative importのbase moduleを解決する。
+- `import trade_rl.evaluation.runs.artifact` はそのfull moduleを返す。
+- `from trade_rl.evaluation.runs.config import CandidateRunConfig` は `trade_rl.evaluation.runs.config` を返す。
+- `from trade_rl.evaluation.runs import config` のようにimported nameが物理child moduleなら `trade_rl.evaluation.runs.config` も返す。
+- `from trade_rl.evaluation.runs import CandidateRunConfig` のようなsymbol re-exportは `trade_rl.evaluation.runs` だけを返し、owner moduleまで追跡しない。
+- local/function-scope importもdependencyとして収集する。
+- existing `collect()` のsemantic/re-export behaviorを変更しない。
 
-契約:
-
-- relative importは既存 `_base()` でabsolute moduleへ解決する。
-- `import a.b.c` は `a.b.c` を返す。
-- `from a.b import Symbol` は `a.b` を返す。
-- `from a.b import child_module` で `a.b.child_module` が物理moduleとして存在する場合は、そのchild moduleも返す。
-- re-exportされたclass/functionのownerまでは追跡しない。
-- `collect()` の既存semantic/transitive behaviorは変更しない。
-
-これにより今回のdirect-spelling gateと既存semantic dependency gateを混同しない。
+新しい単発parserは作らず、relative resolution/module catalogは既存collectorのprivate machineryを再利用する。
 
 ## Import migration
 
@@ -181,15 +179,15 @@ trade_rl/evaluation/experiments/bootstrap/config.py
 trade_rl/evaluation/experiments/bootstrap/workflow.py
 ```
 
-実装前にrepository-wide import inventoryを再取得し、上記以外のproduction callerがあれば同じcontractで分類する。
+実際の変更前にrepository-wide import inventoryを再取得し、上記以外のproduction callerがあれば同じ契約で分類する。
 
 migrationはimport pathだけを変え、呼出し順、引数、戻り値、exception handlingを変更しない。
-
-`evaluation/runs/` 内部moduleはfacadeを経由せず既存owner moduleを直接importする。
 
 ## Object identity contract
 
 facadeは既存ownerから直接re-exportする。
+
+例:
 
 ```python
 from trade_rl.evaluation.runs import CandidateRunConfig
@@ -198,7 +196,9 @@ from trade_rl.evaluation.runs.config import CandidateRunConfig as InternalCandid
 assert CandidateRunConfig is InternalCandidateRunConfig
 ```
 
-wrapper class、subclass、adapter function、proxy objectは作らない。
+新しいwrapper class、subclass、adapter function、proxy objectは作らない。
+
+これによりtype identity、dataclass field定義、serialization behavior、exception semanticsを維持する。
 
 ## Persisted artifact / provenance contract
 
@@ -213,28 +213,30 @@ wrapper class、subclass、adapter function、proxy objectは作らない。
 - exact-file digest/size evidence
 - implementation manifestの定義
 
-`build_candidate_run_provenance()` はpackage内Python sourceのrelative pathとraw bytesをimplementation identityへ含める。したがって `runs/__init__.py` の変更やimport source変更により **新しいimplementation digestになることは正しい**。
+注意: `build_candidate_run_provenance()` はpackage内Python sourceのpathとraw bytesをimplementation identityへ含める。そのため `runs/__init__.py` の変更およびimport source変更は **新しいimplementation digestを生成することが正しい**。
 
-既存Studyやartifactの過去implementation identityを新sourceと同一視してはならない。behavior compatibilityとimplementation identity preservationは別contractである。
+既存Studyやartifactの過去implementation identityを新sourceと同一視してはならない。これはbehavior compatibilityとimplementation identityを区別する既存契約である。
 
 ## Architecture test design
 
+既存のAST import toolingを拡張し、別の簡易parserを作らない。
+
 hard gateは少なくとも次を検証する。
 
-1. capability外production moduleが禁止submoduleをabsolute importするとfailする。
-2. `from trade_rl.evaluation.runs.config import ...` がfailする。
-3. `import trade_rl.evaluation.runs.artifact` がfailする。
-4. `from trade_rl.evaluation.runs import CandidateRunConfig` はpassする。
-5. `from trade_rl.evaluation.runs import config` はchild module direct selectionとしてfailする。
-6. relative import解決でも同じdirect-spelling contractになる。
+1. `collect_direct()` がabsolute/relative direct module spellingを正しく解決する。
+2. `collect_direct()` はfacade symbol re-exportを内部ownerまで追跡しない。
+3. capability外production moduleが禁止submoduleをabsolute importするとfailする。
+4. `from trade_rl.evaluation.runs.config import ...` がfailする。
+5. `import trade_rl.evaluation.runs.artifact` がfailする。
+6. `from trade_rl.evaluation.runs import CandidateRunConfig` はpassする。
 7. `evaluation/runs/` 内部のdirect submodule importはpassする。
 8. tests directoryはこのproduction dependency ruleの対象外である。
 9. facade exportが既存internal ownerとobject identityを共有する。
-10. exact `runs.__all__` が設計surfaceと一致する。
-11. `trade_rl.evaluation.__all__` の公開symbol集合は変更しない。
-12. 既存 `ImportCollector.collect()` のre-export追跡behaviorを壊さない。
+10. `trade_rl.evaluation.__all__` の公開symbol集合は変更しない。
 
 architecture gateは「内部moduleが存在してはいけない」とは判定しない。内部moduleは正規ownerとして必要である。
+
+既存 `collect()` のre-export-aware contract testsも引き続きGreenであることを必須とし、新API追加がsemantic dependency checkerを弱めていないことを確認する。
 
 ## Error / recovery behavior
 
@@ -251,35 +253,34 @@ architecture gateは「内部moduleが存在してはいけない」とは判定
 
 ## Acceptance Criteria
 
-1. `trade_rl.evaluation.runs` から設計済みTier-2 surfaceをimportできる。
+1. `trade_rl.evaluation.runs` からTier-2 surfaceをimportできる。
 2. facade symbolは既存submodule symbolと同一objectである。
 3. capability外production codeにRun Core owner moduleへのdirect importが残っていない。
-4. `collect_direct()` がrelative importとactual child-module importを正しく判定し、re-export ownerは追跡しない。
-5. architecture testが新しいdirect import regressionを検出する。
-6. 既存 `ImportCollector.collect()` のsemantic/transitive behaviorは維持される。
-7. `trade_rl.evaluation.__all__` は変更しない。
-8. candidate-run artifact schema、digest、provenance schema、CLI behaviorは変更しない。
-9. existing run/experiment/bootstrap testsがGreenである。
-10. full repository pytestがGreenである。
-11. Ruff / Format / Mypy / architecture-tooling MypyがGreenである。
-12. build、tracked-source closure、sdist rebuild、clean installed smoke、package identityがGreenである。
-13. exact final HEADのCI成功を確認する。
-14. final diffにtemporary workflow、helper、generated artifact、unrelated refactorが残らない。
-15. `docs/architecture/package-boundaries.md` に耐久的なTier-2 facade ruleを反映する。
-16. 実装完了後、このActive specをcurrent treeから削除する。
+4. architecture testが新しいdirect import regressionを検出する。
+5. `collect_direct()` 追加後も既存 `collect()` のsemantic/re-export contractは不変である。
+6. `trade_rl.evaluation.__all__` は変更しない。
+7. candidate-run artifact schema、digest、provenance schema、CLI behaviorは変更しない。
+8. existing run/experiment/bootstrap testsがGreenである。
+9. full repository pytestがGreenである。
+10. Ruff / Format / Mypy / architecture-tooling MypyがGreenである。
+11. build、tracked-source closure、sdist rebuild、clean installed smoke、package identityがGreenである。
+12. exact final HEADのCI成功を確認する。
+13. final diffにtemporary workflow、helper、generated artifact、unrelated refactorが残らない。
+14. `docs/architecture/package-boundaries.md` に耐久的なTier-2 facade ruleを反映する。
+15. 実装完了後、このActive specをcurrent treeから削除する。
 
 ## Invariants
 
 - Run Coreのsemantic ownersは既存内部moduleのまま維持する。
 - `runs/__init__.py` にbusiness logicを置かない。
-- facade importはnetwork/filesystem/mutation side effectを追加しない。
+- facade importはside effectを追加しない。
 - candidate execution結果は変えない。
 - persisted artifact formatを変えない。
 - historical artifact reader behaviorを変えない。
 - provenanceを弱めない。
 - top-level evaluation APIを増やさない。
 - CLI adapter contractを変えない。
-- 既存architecture import collectorのsemantic dependency検出能力を弱めない。
+- existing re-export-aware `ImportCollector.collect()` semanticsを変えない。
 
 ## Failure Modes
 
@@ -291,6 +292,7 @@ facadeが内部moduleをre-exportすることで既存internal dependency graph�
 
 - package内部はfacadeを使わずowner moduleを直接importする。
 - facadeだけがowner moduleを外向きに束ねる。
+- import順は `candidate_suite → config → execute → provenance → artifact` とし、既存internal dependency directionに従う。
 - clean import testで確認する。
 
 ### Over-export
@@ -299,25 +301,19 @@ facadeが内部moduleをre-exportすることで既存internal dependency graph�
 
 対策:
 
-- actual cross-capability usageとpublic return typeを基準にsurfaceを固定する。
+- actual cross-capability usageを基準にsurfaceを固定する。
 - convenienceだけを理由にexportを追加しない。
+- CLI-only `load_candidate_run_config` はexportしない。
 
-### False architecture violation by re-export expansion
+### False architecture violation
 
-既存 `collect()` はfacadeのre-export先まで追跡するため、direct import gateへ流用すると正しいfacade利用を違反扱いし得る。
-
-対策:
-
-- `collect_direct()` と `collect()` のoracleを分離する。
-- direct-spelling regression testを追加する。
-
-### False architecture violation of internal/tests imports
-
-implementation testsやpackage内部importまで禁止すると正常な責務テストが壊れる。
+semantic collectorをdirect spelling checkへ流用すると、facade re-export自体が禁止owner依存として見える。
 
 対策:
 
-- rule scopeをproduction sourceかつruns package外に限定する。
+- `collect_direct()` を別contractとして追加する。
+- synthetic package testでfacade symbolとphysical child moduleを区別する。
+- implementation testsやpackage内部importはrule scope外とする。
 
 ### Behavioral drift during import migration
 
@@ -325,7 +321,7 @@ import整理と同時にrefactorを行うとbehavior差分が混入する。
 
 対策:
 
-- migrationはimport statement、facade、architecture tooling/tests、必要docsに限定する。
+- migrationはimport statementとfacade/architecture tests/docsに限定する。
 - unrelated cleanupは別変更にする。
 
 ### Provenance confusion
@@ -343,11 +339,10 @@ source path/bytes変更によるimplementation digest変化をregressionと誤�
 
 観測対象:
 
-- exact Tier-2 `__all__`
 - facade/internal symbol object identity
-- `collect_direct()` のdirect import set
-- 既存 `collect()` のsemantic/transitive import set
-- architecture gateのallowed/forbidden判定
+- direct import spelling (`collect_direct`)
+- semantic/re-export dependency (`collect`)
+- architecture gateのallowed/forbidden import判定
 - production import inventory
 - `trade_rl.evaluation.__all__` snapshot
 - existing config parse/resolve outputs
@@ -362,10 +357,10 @@ source path/bytes変更によるimplementation digest変化をregressionと誤�
 
 ## Required Test Layers
 
-- Unit tests for `ImportCollector.collect_direct()`
-- Static architecture tests for Run Core facade boundary
+- Static architecture tests
+- ImportCollector direct-contract unit tests
+- Existing ImportCollector semantic-contract tests
 - Unit tests for facade identity/export surface
-- Existing architecture import-tooling tests
 - Existing config/execute/artifact/provenance tests
 - Existing experiments/bootstrap integration tests
 - Existing CLI tests
@@ -383,18 +378,16 @@ source path/bytes変更によるimplementation digest変化をregressionと誤�
 
 ## Falsification review
 
-実装後、少なくとも以下を意図的に確認する。
+実装後、少なくとも以下を意図的に試す。
 
 - `experiments` から `runs.config` を再導入するとarchitecture testが落ちるか。
-- `from trade_rl.evaluation.runs import config` を違反として検出できるか。
-- facadeの正規class/function importをre-export先追跡で誤検出しないか。
-- relative importでhard gateを迂回できないか。
-- facade exportをwrapperへ置き換える誤実装をidentity testが検出するか。
-- top-level `evaluation.__all__` の誤変更を検出するか。
-- internal `runs` module同士の正常importを誤検出しないか。
-- testsのimplementation-level direct importを誤検出しないか。
-- 既存semantic dependency testが `collect_direct()` 追加によって弱くなっていないか。
-- artifact schema/semantic digest behaviorが変わっていないか。
+- facade symbol importを `collect_direct()` が誤って `runs.config` まで展開しないか。
+- `from trade_rl.evaluation.runs import config` のphysical child importを見逃さないか。
+- facadeのexportがwrapperに置き換わった場合identity testが落ちるか。
+- top-level `evaluation.__all__` を誤って増やすとtestが検出するか。
+- internal `runs` module同士の正常importを誤検出していないか。
+- testsのimplementation-level direct importを誤検出していないか。
+- artifact digest/schemaが変わっていないか。
 - clean wheel上でもfacade importが成立するか。
 
 ## Quality Gate
@@ -403,28 +396,19 @@ source path/bytes変更によるimplementation digest変化をregressionと誤�
 
 - Acceptance Criteriaを満たす。
 - architecture hard gateが意図したdirect dependency regressionを検出できる。
-- 既存semantic import collector behaviorが維持される。
+- existing `ImportCollector.collect()` の契約が維持される。
 - existing functional/integration testsがGreen。
 - full testsがGreen。
-- static/type/style checksがGreen。
+- static/type/package checksがGreen。
 - build/distribution/clean-install checksがGreen。
-- final exact HEAD CIがGreen。
-- final diffをレビューし、unrelated changesがない。
-- falsification reviewを実施する。
-- PR comments/review threadsを確認する。
-- `package-boundaries.md` に耐久契約を反映する。
-- Active specを削除する。
+- final HEADのCIを確認する。
+- final diffをレビューし、一時ファイル・生成物・無関係変更がない。
+- falsification reviewを行う。
+- review comment/threadを確認する。
 - 未検証事項と残存リスクを最終報告する。
 
 ## Docs lifecycle
 
-実装中は本specを `docs/specs/` に保持する。
+実装中はこのspecを `Status: Active` で保持する。
 
-実装完了時:
-
-1. `docs/architecture/package-boundaries.md` にTier-2 capability facadeとdependency ruleの耐久部分を反映する。
-2. `docs/README.md` のActive spec/plan一覧を更新する。
-3. 本specを削除する。
-4. 完了履歴はGit historyとPRを正本とする。
-
-`docs/history`、`docs/archive`、永続的なcompleted-spec directoryは作らない。
+実装が完了し、durable ruleを `docs/architecture/package-boundaries.md` に反映した後は、このspecをcurrent treeから削除する。履歴はGit historyを正本とする。

--- a/docs/specs/2026-09-11-runs-capability-facade-design.md
+++ b/docs/specs/2026-09-11-runs-capability-facade-design.md
@@ -1,0 +1,379 @@
+# evaluation/runs capability facade design
+
+Status: Active
+Date: 2026-09-11
+Related: #452
+
+## 結論
+
+`trade_rl.evaluation.runs` を **Tier-2 capability public API** として明示し、`evaluation/runs/` 外のproduction codeは原則として `runs.config`、`runs.artifact`、`runs.execute`、`runs.provenance`、`runs.candidate_suite` の物理submoduleへ直接依存しない。
+
+内部module分割は維持する。今回の目的はファイル統合や大規模移動ではなく、既に分離済みのRun Coreについて「どこが意味上の入口か」を一意にすることである。
+
+`trade_rl.evaluation` のtop-level public APIは増やさない。`trade_rl.evaluation.runs` がcapability境界を所有し、必要な既存symbolだけを再公開する。
+
+## 背景
+
+現在の `evaluation/runs/` は責務自体は既に分離されている。
+
+```text
+runs/
+  __init__.py
+  artifact.py
+  candidate.py
+  candidate_suite.py
+  config.py
+  execute.py
+  provenance.py
+```
+
+一方、`runs/__init__.py` はownership docstringだけで、他capabilityがRun Coreを使う際は物理module pathを知る必要がある。実際に `evaluation/experiments/` は `runs.config`、`runs.artifact`、`runs.execute`、`runs.provenance` へ直接依存している。また `evaluation/__init__.py` も `runs.candidate_suite` から直接importしている。
+
+この状態では、内部ファイル分割がそのまま外部API構造として露出し、AgentがRun Coreの権威を探索する際に複数moduleを横断する必要がある。
+
+Issue #452 の目的は「すべてを一つのファイルにする」ことではなく、Domain → Capability → internal responsibility の順で一つの意味上の入口を発見できるようにすることである。
+
+## Objective
+
+1. `trade_rl.evaluation.runs` をRun Coreの明示的なcapability facadeにする。
+2. Run Core利用者が内部module配置を知らなくても必要なsemantic contractを発見できるようにする。
+3. production codeのcapability外direct-submodule importsをarchitecture testで検出する。
+4. 既存object identity、artifact schema、digest、execution behavior、CLI behavior、top-level `trade_rl.evaluation` APIを維持する。
+5. facadeを第二の実装authorityにせず、各内部moduleを引き続き実装ownerとする。
+
+## Non-goals
+
+- `evaluation/runs/` のファイル統合・rename・package再編はしない。
+- `CandidateRunConfig`、`ResolvedCandidateRunSpec`、artifact schema、provenance schemaの意味を変更しない。
+- `candidate.py` CLI adapterをcapability public APIへ昇格させない。
+- `PROVENANCE_SCHEMA` やprivate helperなど、内部module間だけで必要なsymbolをfacadeへ公開しない。
+- `trade_rl.evaluation.__all__` を拡大しない。
+- testsから内部moduleをimportすることを全面禁止しない。implementation-level testは内部ownerを直接検査してよい。
+- runtimeでprivate importを不可能にする仕組みは追加しない。これはsource architecture contractで管理する。
+- deprecated forwarding moduleや互換shimを新設しない。
+
+## API tier
+
+今回の変更では以下のtierを採用する。
+
+```text
+Tier 1: trade_rl.evaluation
+  既存の広域evaluation public API。今回export増加なし。
+
+Tier 2: trade_rl.evaluation.runs
+  Run Core capability public API。外部capabilityはここを入口にする。
+
+Tier 3: trade_rl.evaluation.runs.<module>
+  Run Core内部実装owner。runs package内およびimplementation-level testsから利用可能。
+
+Tier 4: persisted candidate-run artifact/schema contracts
+  Python import pathとは独立して互換性を維持する。
+```
+
+## Tier-2 facade surface
+
+`trade_rl.evaluation.runs.__init__` は以下を公開する。
+
+### Config / resolve
+
+- `CandidateRunConfig`
+- `ResolvedCandidateRunSpec`
+- `load_candidate_run_config`
+- `parse_candidate_run_config`
+- `resolve_candidate_run_spec`
+
+### Candidate suite
+
+- `LeanCandidateConfig`
+- `run_lean_candidate_suite`
+
+### Execute
+
+- `CandidateRunResult`
+- `execute_candidate_run`
+
+### Artifact
+
+- `CandidateRunArtifactIdentity`
+- `LoadedCandidateRun`
+- `PublishedCandidateRun`
+- `inspect_candidate_run_artifact`
+- `load_candidate_run_artifact`
+- `publish_candidate_run`
+
+### Provenance
+
+- `build_candidate_run_provenance`
+
+`runtime_environment_manifest`、`PROVENANCE_SCHEMA`、CLI `main`、`run_candidate_artifact` は今回のTier-2 surfaceには含めない。
+
+理由:
+
+- runtime manifest/schema constantは現時点でcapability外のsemantic consumerを持たない。
+- CLI adapterはfilesystem entrypointであり、Run Core contractそのものではない。
+- facadeは「便利そうなsymbol一覧」ではなく、現在のcross-capability boundaryを表す必要最小限のsurfaceとする。
+
+## Dependency rule
+
+production sourceについて、`trade_rl/evaluation/runs/` の外から以下への直接importを禁止する。
+
+```text
+trade_rl.evaluation.runs.artifact
+trade_rl.evaluation.runs.candidate_suite
+trade_rl.evaluation.runs.config
+trade_rl.evaluation.runs.execute
+trade_rl.evaluation.runs.provenance
+```
+
+許可する入口は:
+
+```python
+from trade_rl.evaluation.runs import ...
+```
+
+`candidate.py` はCLI adapterであり、通常のproduction dependencyとして利用すべきではない。ただし今回のhard gateでは、実際の利用状況とfalse positiveを避けるため、まず上記Run Core owner module群を対象とする。
+
+`trade_rl/evaluation/runs/` 内部ではsubmodule direct importを許可する。package内部責務をfacade経由で循環させない。
+
+architecture testはproduction sourceを対象とし、tests自身のimplementation-level importsは対象外とする。
+
+## Import migration
+
+主なmigration対象は次の通り。
+
+```text
+trade_rl/evaluation/__init__.py
+trade_rl/evaluation/experiments/analysis.py
+trade_rl/evaluation/experiments/delta.py
+trade_rl/evaluation/experiments/evidence.py
+trade_rl/evaluation/experiments/workflow.py
+trade_rl/evaluation/experiments/codec.py
+trade_rl/evaluation/experiments/bootstrap/config.py
+trade_rl/evaluation/experiments/bootstrap/workflow.py
+```
+
+実際の変更前にrepository-wide import inventoryを再取得し、上記以外のproduction callerがあれば同じ契約で分類する。
+
+migrationはimport pathだけを変え、呼出し順、引数、戻り値、exception handlingを変更しない。
+
+## Object identity contract
+
+facadeは既存ownerから直接re-exportする。
+
+例:
+
+```python
+from trade_rl.evaluation.runs import CandidateRunConfig
+from trade_rl.evaluation.runs.config import CandidateRunConfig as InternalCandidateRunConfig
+
+assert CandidateRunConfig is InternalCandidateRunConfig
+```
+
+新しいwrapper class、subclass、adapter function、proxy objectは作らない。
+
+これによりtype identity、dataclass field定義、serialization behavior、exception semanticsを維持する。
+
+## Persisted artifact / provenance contract
+
+今回の変更では以下を不変とする。
+
+- candidate result schema
+- candidate artifact identity schema
+- provenance schema
+- required artifact files
+- summary/returns/provenance encoding
+- semantic artifact digest
+- exact-file digest/size evidence
+- implementation manifestの定義
+
+注意: `build_candidate_run_provenance()` はpackage内Python sourceのpathとraw bytesをimplementation identityへ含める。そのため `runs/__init__.py` の変更およびimport source変更は **新しいimplementation digestを生成することが正しい**。
+
+既存Studyやartifactの過去implementation identityを新sourceと同一視してはならない。これはbehavior compatibilityとimplementation identityを区別する既存契約である。
+
+## Architecture test design
+
+既存のAST import toolingを再利用し、別の簡易parserを作らない。
+
+hard gateは少なくとも次を検証する。
+
+1. capability外production moduleが禁止submoduleをabsolute importするとfailする。
+2. `from trade_rl.evaluation.runs.config import ...` がfailする。
+3. `import trade_rl.evaluation.runs.artifact` がfailする。
+4. `from trade_rl.evaluation.runs import CandidateRunConfig` はpassする。
+5. `evaluation/runs/` 内部のdirect submodule importはpassする。
+6. tests directoryはこのproduction dependency ruleの対象外である。
+7. facade exportが既存internal ownerとobject identityを共有する。
+8. `trade_rl.evaluation.__all__` の公開symbol集合は変更しない。
+
+architecture gateは「内部moduleが存在してはいけない」とは判定しない。内部moduleは正規ownerとして必要である。
+
+## Error / recovery behavior
+
+この変更はerror taxonomyやrecovery policyを変更しない。
+
+- config validation error
+- dataset binding error
+- artifact integrity error
+- publication failure
+- provenance mismatch
+- candidate execution error
+
+はいずれも既存ownerで発生し、facadeはcatch/translate/wrapしない。
+
+## Acceptance Criteria
+
+1. `trade_rl.evaluation.runs` からTier-2 surfaceをimportできる。
+2. facade symbolは既存submodule symbolと同一objectである。
+3. capability外production codeにRun Core owner moduleへのdirect importが残っていない。
+4. architecture testが新しいdirect import regressionを検出する。
+5. `trade_rl.evaluation.__all__` は変更しない。
+6. candidate-run artifact schema、digest、provenance schema、CLI behaviorは変更しない。
+7. existing run/experiment/bootstrap testsがGreenである。
+8. full repository pytestがGreenである。
+9. Ruff / Format / Mypy / architecture-tooling MypyがGreenである。
+10. build、tracked-source closure、sdist rebuild、clean installed smoke、package identityがGreenである。
+11. exact final HEADのCI成功を確認する。
+12. final diffにtemporary workflow、helper、generated artifact、unrelated refactorが残らない。
+13. `docs/architecture/package-boundaries.md` に耐久的なTier-2 facade ruleを反映する。
+14. 実装完了後、このActive specをcurrent treeから削除する。
+
+## Invariants
+
+- Run Coreのsemantic ownersは既存内部moduleのまま維持する。
+- `runs/__init__.py` にbusiness logicを置かない。
+- facade importはside effectを追加しない。
+- candidate execution結果は変えない。
+- persisted artifact formatを変えない。
+- historical artifact reader behaviorを変えない。
+- provenanceを弱めない。
+- top-level evaluation APIを増やさない。
+- CLI adapter contractを変えない。
+
+## Failure Modes
+
+### Circular import
+
+facadeが内部moduleをre-exportすることで既存internal dependency graphにcycleを導入する可能性がある。
+
+対策:
+
+- package内部はfacadeを使わずowner moduleを直接importする。
+- facadeだけがowner moduleを外向きに束ねる。
+- clean import testで確認する。
+
+### Over-export
+
+内部実装detailまで公開するとTier-2 APIが新たなdumping groundになる。
+
+対策:
+
+- actual cross-capability usageを基準にsurfaceを固定する。
+- convenienceだけを理由にexportを追加しない。
+
+### False architecture violation
+
+implementation testsやpackage内部importまで禁止すると、内部責務テストや正常な依存が壊れる。
+
+対策:
+
+- rule scopeをproduction sourceかつruns package外に限定する。
+
+### Behavioral drift during import migration
+
+import整理と同時にrefactorを行うとbehavior差分が混入する。
+
+対策:
+
+- migrationはimport statementとfacade/architecture tests/docsに限定する。
+- unrelated cleanupは別変更にする。
+
+### Provenance confusion
+
+source path/bytes変更によるimplementation digest変化をregressionと誤認する可能性がある。
+
+対策:
+
+- semantic behavior preservationとimplementation identity preservationを分離する。
+- 新sourceは新implementation digestになることを明示する。
+
+## Test Oracle
+
+正しさは「importできた」だけでは判定しない。
+
+観測対象:
+
+- facade/internal symbol object identity
+- architecture gateのallowed/forbidden import判定
+- production import inventory
+- `trade_rl.evaluation.__all__` snapshot
+- existing config parse/resolve outputs
+- candidate execution outputs
+- artifact load/inspect/publish behavior
+- artifact semantic/file identity
+- provenance schema validation
+- CLI smoke
+- distribution source closure
+- clean-installed package import origin
+- exact-head CI result
+
+## Required Test Layers
+
+- Static architecture tests
+- Unit tests for facade identity/export surface
+- Existing config/execute/artifact/provenance tests
+- Existing experiments/bootstrap integration tests
+- Existing CLI tests
+- Ruff
+- Format check
+- Mypy production
+- Mypy architecture tooling
+- Full pytest
+- Build
+- sdist/direct-wheel/source-rebuilt-wheel closure
+- Clean installed smoke
+- Package identity
+- Final diff/self review
+- Falsification review
+
+## Falsification review
+
+実装後、少なくとも以下を意図的に試す。
+
+- `experiments` から `runs.config` を再導入するとarchitecture testが落ちるか。
+- facadeのexportがwrapperに置き換わった場合identity testが落ちるか。
+- top-level `evaluation.__all__` を誤って増やすとtestが検出するか。
+- internal `runs` module同士の正常importを誤検出していないか。
+- testsのimplementation-level direct importを誤検出していないか。
+- artifact digest/schemaが変わっていないか。
+- clean wheel上でもfacade importが成立するか。
+
+## Quality Gate
+
+次をすべて満たすまで完成扱いしない。
+
+- Acceptance Criteriaを満たす。
+- architecture hard gateが意図したdirect dependency regressionを検出できる。
+- existing functional/integration testsがGreen。
+- full testsがGreen。
+- static/type/style checksがGreen。
+- build/distribution/clean-install checksがGreen。
+- final exact HEAD CIがGreen。
+- final diffをレビューし、unrelated changesがない。
+- falsification reviewを実施する。
+- PR comments/review threadsを確認する。
+- `package-boundaries.md` に耐久契約を反映する。
+- Active specを削除する。
+- 未検証事項と残存リスクを最終報告する。
+
+## Docs lifecycle
+
+実装中は本specを `docs/specs/` に保持する。
+
+実装完了時:
+
+1. `docs/architecture/package-boundaries.md` にTier-2 capability facadeとdependency ruleの耐久部分を反映する。
+2. `docs/README.md` のActive spec/plan一覧を更新する。
+3. 本specを削除する。
+4. 完了履歴はGit historyとPRを正本とする。
+
+`docs/history`、`docs/archive`、永続的なcompleted-spec directoryは作らない。

--- a/tests/architecture/test_current_docs_layout.py
+++ b/tests/architecture/test_current_docs_layout.py
@@ -138,7 +138,6 @@ def test_completed_canonical_bootstrap_docs_are_promoted_and_removed() -> None:
         assert required in research
 
     index = (DOCS / "README.md").read_text(encoding="utf-8")
-    assert "現在Activeなspec/planはない" in index
     for path in COMPLETED_EPHEMERAL_DOCS:
         assert path.name not in index
 
@@ -172,6 +171,8 @@ def test_docs_index_routes_to_every_current_doc() -> None:
         "research/current-status.md",
     ):
         assert target in index
+    for relative in sorted(_doc_files() - REQUIRED_DOC_FILES):
+        assert relative in index
 
 
 def test_agent_contract_defines_update_and_retention_policy() -> None:


### PR DESCRIPTION
## Status

Design + implementation plan only. No production implementation is included in this PR.

Related to #452.

## What

- adds the Active normative design for an `evaluation/runs` Tier-2 capability facade;
- adds the Active implementation plan;
- indexes both Active docs in `docs/README.md`;
- repairs the docs-layout architecture contract so unrelated future Active specs/plans are allowed while completed bootstrap docs remain forbidden.

## Key design decisions

- keep `runs.config`, `runs.artifact`, `runs.execute`, `runs.provenance`, and `runs.candidate_suite` as implementation owners;
- expose only the minimum Run Core surface required across capabilities;
- do not expand `trade_rl.evaluation.__all__`;
- do not expose CLI-only `load_candidate_run_config`, CLI adapter symbols, or internal provenance symbols;
- preserve existing artifact/schema/provenance/CLI behavior;
- add `ImportCollector.collect_direct()` as a separate contract instead of changing existing re-export-aware `collect()` semantics.

## Self-review findings

1. Reusing `ImportCollector.collect()` for direct-import ownership would be wrong because it intentionally follows static re-exports. The design now introduces `collect_direct()` so valid facade imports are not misclassified as owner-submodule imports.
2. `load_candidate_run_config` was removed from the Tier-2 surface because it currently has no cross-capability consumer.
3. Initial CI exposed an over-specific docs test asserting there could never be any Active spec/plan after the old bootstrap work completed. The current docs policy explicitly allows Active ephemeral docs. The test now preserves the completed-bootstrap cleanup invariant and separately requires every current Active ephemeral doc to be indexed by `docs/README.md`.

## Quality contract

The design and plan define Objective, Non-goals, Acceptance Criteria, Invariants, Failure Modes, Test Oracle, Required Test Layers, TDD RED/GREEN sequence, falsification review, exact-head CI gate, and final docs cleanup.

## Docs lifecycle

Both Active files are temporary current-state documents. After verified implementation, durable rules move to `docs/architecture/package-boundaries.md`, `docs/README.md` returns to no-active-work state, and the completed spec/plan are deleted from the current tree; Git history retains them.