### PR TITLE
fix: replay runtime performance create-once on current main

### DIFF
--- a/tests/simulation/test_runtime_performance_publish_once.py
+++ b/tests/simulation/test_runtime_performance_publish_once.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import TypeVar
+
+import pytest
+
+from trade_rl.simulation.diagnostics.runtime_performance import (
+    RuntimePerformanceApprovalPolicy,
+    RuntimePerformanceEvidence,
+    RuntimePerformanceMeasurement,
+    RuntimePerformanceWorkload,
+)
+from trade_rl.simulation.diagnostics.runtime_performance_io import (
+    load_runtime_performance_evidence,
+    load_runtime_performance_policy,
+    write_runtime_performance_evidence,
+    write_runtime_performance_policy,
+)
+
+_T = TypeVar("_T")
+
+
+def _policy(max_elapsed_slowdown_ratio: float) -> RuntimePerformanceApprovalPolicy:
+    return RuntimePerformanceApprovalPolicy(
+        max_elapsed_slowdown_ratio=max_elapsed_slowdown_ratio,
+        max_peak_process_tree_rss_ratio=2.0,
+        minimum_workloads=1,
+        minimum_max_timesteps=8,
+        reviewed=True,
+        review_reference="concurrency-contract",
+    )
+
+
+def _evidence(source_digest: str) -> RuntimePerformanceEvidence:
+    legacy = RuntimePerformanceMeasurement(
+        timesteps=8,
+        elapsed_seconds=4.0,
+        steps_per_second=2.0,
+        peak_self_rss_bytes=100,
+        peak_children_rss_bytes=0,
+        peak_process_tree_rss_bytes=100,
+        peak_process_count=1,
+    )
+    candidate = RuntimePerformanceMeasurement(
+        timesteps=8,
+        elapsed_seconds=8.0,
+        steps_per_second=1.0,
+        peak_self_rss_bytes=90,
+        peak_children_rss_bytes=90,
+        peak_process_tree_rss_bytes=180,
+        peak_process_count=2,
+    )
+    return RuntimePerformanceEvidence(
+        runtime_version="1.230.0",
+        platform="linux-x86_64",
+        algorithm="ppo",
+        dataset_kind="deterministic_synthetic_btcusdt",
+        source_digest=source_digest,
+        workloads=(
+            RuntimePerformanceWorkload(
+                timesteps=8,
+                legacy_authoritative=legacy,
+                nautilus_dual_shadow_streaming=candidate,
+            ),
+        ),
+        performance_approved=False,
+        approval_policy_digest=None,
+        approval_note="Observational evidence only.",
+    )
+
+
+def _assert_concurrent_publish_once(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    path: Path,
+    left: _T,
+    right: _T,
+    writer: Callable[[Path, _T], Path],
+    loader: Callable[[Path], _T],
+) -> None:
+    original_replace = Path.replace
+    replace_barrier = threading.Barrier(2)
+
+    def synchronized_replace(source: Path, target: str | Path) -> Path:
+        if Path(target) == path:
+            replace_barrier.wait(timeout=5.0)
+        return original_replace(source, target)
+
+    monkeypatch.setattr(Path, "replace", synchronized_replace)
+
+    def attempt(value: _T) -> BaseException | None:
+        try:
+            writer(path, value)
+        except BaseException as error:
+            return error
+        return None
+
+    values = (left, right)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = tuple(executor.submit(attempt, value) for value in values)
+        outcomes = tuple(future.result(timeout=10.0) for future in futures)
+
+    success_indices = tuple(
+        index for index, outcome in enumerate(outcomes) if outcome is None
+    )
+    failures = tuple(outcome for outcome in outcomes if outcome is not None)
+    assert len(success_indices) == 1
+    assert len(failures) == 1
+    assert isinstance(failures[0], FileExistsError)
+    assert loader(path) == values[success_indices[0]]
+    assert not tuple(path.parent.glob(f".{path.name}.tmp*"))
+
+
+def test_runtime_performance_policy_concurrent_drift_never_overwrites(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _assert_concurrent_publish_once(
+        monkeypatch,
+        path=tmp_path / "policy.json",
+        left=_policy(3.0),
+        right=_policy(4.0),
+        writer=write_runtime_performance_policy,
+        loader=load_runtime_performance_policy,
+    )
+
+
+def test_runtime_performance_evidence_concurrent_drift_never_overwrites(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _assert_concurrent_publish_once(
+        monkeypatch,
+        path=tmp_path / "evidence.json",
+        left=_evidence("a" * 64),
+        right=_evidence("b" * 64),
+        writer=write_runtime_performance_evidence,
+        loader=load_runtime_performance_evidence,
+    )

--- a/trade_rl/simulation/diagnostics/runtime_performance_io.py
+++ b/trade_rl/simulation/diagnostics/runtime_performance_io.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+import uuid
 from pathlib import Path
 from typing import cast
 
@@ -25,26 +27,47 @@ def _policy_artifact_mapping(
     return {"policy_digest": policy.digest, **policy.to_mapping()}
 
 
+def _publish_immutable_bytes(
+    path: str | Path,
+    payload: bytes,
+    *,
+    artifact_name: str,
+) -> Path:
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        if target.read_bytes() != payload:
+            raise FileExistsError(
+                f"refusing to overwrite immutable {artifact_name}: {target}"
+            )
+        return target
+
+    temporary = target.with_name(f".{target.name}.tmp-{os.getpid()}-{uuid.uuid4().hex}")
+    temporary.write_bytes(payload)
+    try:
+        try:
+            os.link(temporary, target)
+        except FileExistsError as error:
+            if target.read_bytes() != payload:
+                raise FileExistsError(
+                    f"refusing to overwrite immutable {artifact_name}: {target}"
+                ) from error
+        return target
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
 def write_runtime_performance_evidence(
     path: str | Path,
     evidence: RuntimePerformanceEvidence,
 ) -> Path:
     """Persist one canonical performance evidence artifact without overwriting drift."""
 
-    target = Path(path)
-    target.parent.mkdir(parents=True, exist_ok=True)
-    encoded = canonical_json_bytes(_artifact_mapping(evidence))
-    if target.exists():
-        if target.read_bytes() != encoded:
-            raise FileExistsError(f"refusing to overwrite immutable evidence: {target}")
-        return target
-    temporary = target.with_name(f".{target.name}.tmp")
-    temporary.write_bytes(encoded)
-    try:
-        temporary.replace(target)
-    finally:
-        temporary.unlink(missing_ok=True)
-    return target
+    return _publish_immutable_bytes(
+        path,
+        canonical_json_bytes(_artifact_mapping(evidence)),
+        artifact_name="evidence",
+    )
 
 
 def write_runtime_performance_policy(
@@ -53,20 +76,11 @@ def write_runtime_performance_policy(
 ) -> Path:
     """Persist one reviewed performance policy without overwriting threshold drift."""
 
-    target = Path(path)
-    target.parent.mkdir(parents=True, exist_ok=True)
-    encoded = canonical_json_bytes(_policy_artifact_mapping(policy))
-    if target.exists():
-        if target.read_bytes() != encoded:
-            raise FileExistsError(f"refusing to overwrite immutable policy: {target}")
-        return target
-    temporary = target.with_name(f".{target.name}.tmp")
-    temporary.write_bytes(encoded)
-    try:
-        temporary.replace(target)
-    finally:
-        temporary.unlink(missing_ok=True)
-    return target
+    return _publish_immutable_bytes(
+        path,
+        canonical_json_bytes(_policy_artifact_mapping(policy)),
+        artifact_name="policy",
+    )
 
 
 def load_runtime_performance_evidence(


### PR DESCRIPTION
## Status

Current-main replay is implemented and exact-head hardened CI is complete. Ready for review; **not merged**.

Related to #452. Supersedes #466.

## Why this replacement PR exists

#466 reproduced and fixed the immutable-publication race and passed exact-head CI against main `5e300a30...`. While that work was in progress, main advanced through merged #463 and design PR #465 to `3a8af41da6cd3f4942a727ec186a70a13eb918b3`.

Per repository quality policy, old-base CI is not treated as current integration evidence. The current-main `runtime_performance_io.py` was byte-identical to #466's original pre-fix base, so this branch mechanically replays the exact two durable #466 files without rewriting #463/#465 work.

## What

Durable diff is exactly:

- `trade_rl/simulation/diagnostics/runtime_performance_io.py`;
- `tests/simulation/test_runtime_performance_publish_once.py`.

The previous writer used `exists check -> shared fixed temp -> Path.replace(target)`, so absence-check and publication were not one atomic create-once operation and racing writers shared one temp path.

The fix keeps the create-once owner local to the runtime-performance persistence capability:

1. existing identical bytes remain idempotent; existing different bytes raise `FileExistsError`;
2. bytes are completed in a unique same-directory temp (`pid + UUID`);
3. `os.link(temp, target)` creates the destination only when absent;
4. a race compares the winning target: same bytes are idempotent, different bytes raise immutable conflict;
5. temp is always removed.

`atomic_write_bytes()` is not reused because it owns replacement semantics; StudyStore and Binance cache also have different transaction responsibilities.

## Original TDD RED evidence from #466

Formal RED head: `fedd135c42a9bf2f68b9f6bddc82ac35987fc120`.
CI run `34599114518`, job `103261829547`:

- Ruff / Format / production Mypy / architecture-tooling Mypy: pass;
- full pytest: **990 passed / 2 failed**;
- failures were exactly the new policy/evidence concurrency tests;
- both reproduced `FileNotFoundError` at the shared-temp `replace` race instead of immutable-conflict `FileExistsError`.

## Current-main exact-head verification

Base: `3a8af41da6cd3f4942a727ec186a70a13eb918b3`.
Final PR head: `6ce8fcfbfcebbf62dacf2e389b292b52ee9972c5`.
CI run `34600287192`, job `103265636694`: **completed / success** on that exact head.

Observed results:

- Ruff: pass;
- Format: **303 files already formatted**;
- production Mypy: **131 source files, 0 issues**;
- architecture-tooling Mypy: **2 source files, 0 issues**;
- full pytest: **995 passed in 39.87s**;
- build: sdist + wheel success;
- tracked Python source closure: sdist OK;
- tracked Python source closure: direct wheel OK;
- wheel rebuilt from sdist: source closure OK;
- clean non-editable installed core public imports/package identity: OK;
- candidate CLI `--help`: OK;
- canonical bootstrap CLI `--help`: OK;
- package identity: OK.

The 995-test count is the current-main suite including merged #463 plus the two new publish-once tests.

## Non-goals / invariants

- no runtime-performance schema/digest/approval change;
- no public API change;
- no Binance cache or StudyStore refactor;
- no generic filesystem abstraction;
- no docs or research change;
- no claim of stronger crash/power-loss durability.

## Final diff / independent-equivalent review

Final diff re-read confirms exactly the two intended files and no helper workflow, generated artifact, docs change, or unrelated refactor. PR conversation comments and inline review threads were empty at the review checkpoint.

No independent external subagent/reviewer is available in this environment. Independent-equivalent review reconstructed the acceptance criteria from the original immutable-publication contract, re-read the two-file final diff, retained the original formal RED evidence, and required exact-head hardened CI against the current main line.

## Residual risk

Verified on current Linux CI: distinct in-process racing payloads produce one winner + one `FileExistsError`, the winner remains loadable, and temp residue is removed.

Not newly proven: Windows/macOS hard-link behavior, cross-process stress, hostile external deletion/symlink races, or crash/power-loss fsync durability. The design should not be generalized automatically to every artifact writer.