### PR TITLE
fix: accept cross-asset reference in market build JSON

### DIFF
--- a/tests/data/test_market_build_config_session.py
+++ b/tests/data/test_market_build_config_session.py
@@ -35,7 +35,9 @@ def test_market_build_request_accepts_session_calendar(tmp_path: Path) -> None:
     assert request.config.session_periods_per_year == 252
 
 
-def test_market_build_request_accepts_cross_asset_reference_symbol(tmp_path: Path) -> None:
+def test_market_build_request_accepts_cross_asset_reference_symbol(
+    tmp_path: Path,
+) -> None:
     path = tmp_path / "build.json"
     path.write_text(
         json.dumps(

--- a/tests/data/test_market_build_config_session.py
+++ b/tests/data/test_market_build_config_session.py
@@ -33,3 +33,30 @@ def test_market_build_request_accepts_session_calendar(tmp_path: Path) -> None:
 
     assert request.config.calendar_kind == "session_calendar"
     assert request.config.session_periods_per_year == 252
+
+
+def test_market_build_request_accepts_cross_asset_reference_symbol(tmp_path: Path) -> None:
+    path = tmp_path / "build.json"
+    path.write_text(
+        json.dumps(
+            {
+                "source_root": ".",
+                "base_timeframe": "1h",
+                "cross_asset_reference_symbol": "BTCUSDT",
+                "features": [{"name": "ret", "kind": "log_return"}],
+                "instruments": [
+                    {
+                        "symbol": "BTCUSDT",
+                        "listed_at": "2020-01-01T00:00:00Z",
+                        "volume_unit": "base_asset",
+                        "contract_multiplier": 1.0,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    request = load_market_build_request(path)
+
+    assert request.config.cross_asset_reference_symbol == "BTCUSDT"

--- a/tests/data/test_market_build_config_session.py
+++ b/tests/data/test_market_build_config_session.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from trade_rl.data.build.config import load_market_build_request
 
 
@@ -62,3 +64,29 @@ def test_market_build_request_accepts_cross_asset_reference_symbol(
     request = load_market_build_request(path)
 
     assert request.config.cross_asset_reference_symbol == "BTCUSDT"
+
+
+def test_market_build_request_still_rejects_unknown_root_field(tmp_path: Path) -> None:
+    path = tmp_path / "build.json"
+    path.write_text(
+        json.dumps(
+            {
+                "source_root": ".",
+                "base_timeframe": "1h",
+                "unexpected": True,
+                "features": [{"name": "ret", "kind": "log_return"}],
+                "instruments": [
+                    {
+                        "symbol": "BTCUSDT",
+                        "listed_at": "2020-01-01T00:00:00Z",
+                        "volume_unit": "base_asset",
+                        "contract_multiplier": 1.0,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="market build config contains unknown fields"):
+        load_market_build_request(path)

--- a/trade_rl/data/build/config.py
+++ b/trade_rl/data/build/config.py
@@ -200,6 +200,7 @@ def load_market_build_request(path: str | Path) -> MarketDatasetBuildRequest:
             "base_timeframe",
             "calendar_kind",
             "session_periods_per_year",
+            "cross_asset_reference_symbol",
             "features",
             "instruments",
         },


### PR DESCRIPTION
## Status

Implementation and exact-head verification are complete. Ready for review; **not merged**.

Related to #452 config-authority audit.

## Objective

Make the strict market-build JSON loader accept the existing `MarketBuildConfig.cross_asset_reference_symbol` field instead of rejecting it as unknown.

## Non-goals

No calendar-kind refactor, cross-asset feature algorithm change, schema/version change, Binance dataset change, public API change, or config permissiveness beyond this maintained field.

## Acceptance Criteria

- JSON containing `cross_asset_reference_symbol` loads successfully and preserves the exact symbol.
- Unknown unrelated root keys remain rejected by the strict parser.
- Existing market-build/data and full repository contracts remain green.

## Invariants

`MarketBuildConfig` remains the semantic authority for validating the reference symbol. The JSON adapter only routes an already-supported field into that contract.

## Failure Modes

- the maintained field remains unreachable from JSON;
- parser becomes permissive for unrelated root keys;
- reference symbol is silently normalized/dropped;
- unrelated market-data semantics change.

## Test Oracle

A JSON request with `cross_asset_reference_symbol="BTCUSDT"` must load and preserve `BTCUSDT`. A separate preservation test supplies an unrelated `unexpected` key and requires the existing unknown-field `ValueError`.

## TDD RED evidence

The first RED attempt was rejected as false RED because Ruff Format failed before pytest. Production remained unchanged and only the test formatting was corrected.

Formal RED head: `d4ad4fb71c23aae5fe5fb618cf5483be000545f9`.
CI run `34609574545`, job `103296383157`:

- Ruff: pass;
- Format: **306 files already formatted**;
- production Mypy: **131 source files, 0 issues**;
- architecture-tooling Mypy: **2 source files, 0 issues**;
- full pytest: **1009 passed / 1 failed**;
- the only failure was the new regression test;
- exact failure: `market build config contains unknown fields: ['cross_asset_reference_symbol']` from the root `_reject_unknown` allowlist.

This establishes the root cause directly: the loader already reads/routes the field later, but its strict root allowlist omitted it.

## GREEN implementation

Production diff is exactly one semantic change: add `"cross_asset_reference_symbol"` to the existing root allowlist. No parser/coercion/constructor logic changed.

A preservation test also proves an unrelated root field is still rejected.

## Changed authorities / public surfaces

None. This repairs an adapter inconsistency around an existing config authority and existing field.

## Exact-head final verification

Base/current main: `4838c32f7982792ddeaf05e3302a05437fcc30f9`.
Final PR head: `16d322d084ead1b83fce97678eb0bf70fb5e9c18`.
CI run `34609904737`, job `103297594898`: **completed / success** on that exact head.

Observed results:

- Ruff: pass;
- Format: **306 files already formatted**;
- production Mypy: **131 source files, 0 issues**;
- architecture-tooling Mypy: **2 source files, 0 issues**;
- full pytest: **1011 passed in 41.70s**;
- `uv build`: success;
- tracked Python source closure: sdist OK;
- tracked Python source closure: direct wheel OK;
- wheel rebuilt from sdist: source closure OK;
- clean non-editable installed core public imports/package identity: OK;
- Candidate Run CLI `--help`: OK;
- canonical bootstrap CLI `--help`: OK;
- package identity: OK.

A fresh read immediately before Ready transition still reports main at `4838c32f7982792ddeaf05e3302a05437fcc30f9`, so the final CI is not stale relative to a moved base.

## Final diff / falsification

Final diff contains exactly two files:

- `trade_rl/data/build/config.py`: one allowlist entry;
- `tests/data/test_market_build_config_session.py`: regression + strictness-preservation tests.

No docs, schema, generated artifact, workflow helper, calendar refactor, or unrelated cleanup is present. PR conversation and inline review threads were empty at the final checkpoint.

Falsification evidence:

- old code is killed by the valid-field RED;
- unrelated unknown root keys remain rejected after GREEN;
- production change cannot broaden nested feature/instrument allowlists because they are untouched.

## Unverified items

No new live-provider or cross-platform-specific verification was required for this pure config-loader fix. The separate `calendar_kind` semantic duplication observed during audit remains intentionally unmodified and requires its own compatibility design.

## Residual risk

Low and localized. Future `MarketBuildConfig` fields can still become unreachable if a strict JSON adapter allowlist is not updated; that broader source-of-truth problem remains a #452 design concern and should be addressed separately rather than by making the parser permissive.