### PR TITLE
feat: add Agent Coordination Plane v1

### DIFF
--- a/.github/workflows/issue500-stack-ci.yml
+++ b/.github/workflows/issue500-stack-ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install
         run: uv sync --extra dev
 
+      - name: Coordination tests
+        run: uv run pytest -q tests/agent_repo/test_coordination_*.py
+
       - name: Ruff
         run: uv run ruff check trade_rl tests tools
 
@@ -40,6 +43,3 @@ jobs:
 
       - name: Repository tooling types
         run: uv run mypy tools/agent_repo tests/architecture/distribution.py
-
-      - name: Coordination tests
-        run: uv run pytest -q tests/agent_repo/test_coordination_*.py

--- a/.github/workflows/issue500-stack-ci.yml
+++ b/.github/workflows/issue500-stack-ci.yml
@@ -1,0 +1,45 @@
+name: Issue 500 stacked coordination CI
+
+on:
+  push:
+    branches:
+      - feat/agent-coordination-plane-v1
+
+permissions:
+  contents: read
+
+concurrency:
+  group: issue500-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  coordination:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout exact head
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Install
+        run: uv sync --extra dev
+
+      - name: Ruff
+        run: uv run ruff check trade_rl tests tools
+
+      - name: Format
+        run: uv run ruff format --check trade_rl tests tools
+
+      - name: Repository tooling types
+        run: uv run mypy tools/agent_repo tests/architecture/distribution.py
+
+      - name: Coordination tests
+        run: uv run pytest -q tests/agent_repo/test_coordination_model.py

--- a/.github/workflows/issue500-stack-ci.yml
+++ b/.github/workflows/issue500-stack-ci.yml
@@ -35,8 +35,11 @@ jobs:
       - name: Ruff
         run: uv run ruff check trade_rl tests tools
 
-      - name: Format
-        run: uv run ruff format --check trade_rl tests tools
+      - name: Format diff
+        shell: bash
+        run: |
+          uv run ruff format --diff tools/agent_repo/coordination/model.py || true
+          uv run ruff format --check trade_rl tests tools
 
       - name: Repository tooling types
         run: uv run mypy tools/agent_repo tests/architecture/distribution.py

--- a/.github/workflows/issue500-stack-ci.yml
+++ b/.github/workflows/issue500-stack-ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Format diff
         shell: bash
         run: |
-          uv run ruff format --diff tests/agent_repo/test_coordination_scheduler.py || true
+          uv run ruff format --diff tests/agent_repo/test_coordination_leases.py || true
           uv run ruff format --check trade_rl tests tools
 
       - name: Repository tooling types

--- a/.github/workflows/issue500-stack-ci.yml
+++ b/.github/workflows/issue500-stack-ci.yml
@@ -38,8 +38,11 @@ jobs:
       - name: Ruff
         run: uv run ruff check trade_rl tests tools
 
-      - name: Format
-        run: uv run ruff format --check trade_rl tests tools
+      - name: Format diff
+        shell: bash
+        run: |
+          uv run ruff format --diff tests/agent_repo/test_coordination_scheduler.py || true
+          uv run ruff format --check trade_rl tests tools
 
       - name: Repository tooling types
         run: uv run mypy tools/agent_repo tests/architecture/distribution.py

--- a/.github/workflows/issue500-stack-ci.yml
+++ b/.github/workflows/issue500-stack-ci.yml
@@ -35,14 +35,11 @@ jobs:
       - name: Ruff
         run: uv run ruff check trade_rl tests tools
 
-      - name: Format diff
-        shell: bash
-        run: |
-          uv run ruff format --diff tools/agent_repo/coordination/model.py || true
-          uv run ruff format --check trade_rl tests tools
+      - name: Format
+        run: uv run ruff format --check trade_rl tests tools
 
       - name: Repository tooling types
         run: uv run mypy tools/agent_repo tests/architecture/distribution.py
 
       - name: Coordination tests
-        run: uv run pytest -q tests/agent_repo/test_coordination_model.py
+        run: uv run pytest -q tests/agent_repo/test_coordination_*.py

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,14 +12,16 @@
 - [`architecture/controlled-experiment-loop.md`](architecture/controlled-experiment-loop.md) — development Study、Canonical M2 bootstrap preparation、EvidenceSet、controlled factor、lineage、FAILED/INVALID、freezeの恒久契約
 - [`research/current-status.md`](research/current-status.md) — 現在の研究目的、比較候補、M1/M2/M3の状態、canonical bootstrap、development/final評価手順と未検証事項
 
-現在Activeなspecは次の1件である。
+現在Activeなspecは次の2件である。
 
 - [`specs/2026-09-11-agent-repository-control-plane-v1-design.md`](specs/2026-09-11-agent-repository-control-plane-v1-design.md) — Agent Eval、source-derived inspector、Semantic Diff、risk-based verification、merge safetyを定義するAgent-safe Repository設計
+- [`specs/2026-09-12-agent-coordination-plane-v1-design.md`](specs/2026-09-12-agent-coordination-plane-v1-design.md) — #500。複数AgentのTask DAG、execution mode、lease fencing、semantic conflict、independent review、exact-snapshot evidence、handoff、integrationを定義する設計
 
-現在Activeなplanは次の2件である。
+現在Activeなplanは次の3件である。
 
 - [`plans/2026-09-11-agent-repository-eval-implementation.md`](plans/2026-09-11-agent-repository-eval-implementation.md) — prompt-only corpus、generic rubric、matched baseline/comparison protocolと、未実施のfresh-Agent比較を管理するcurrent plan
 - [`plans/2026-09-11-agent-repository-merge-safety-implementation.md`](plans/2026-09-11-agent-repository-merge-safety-implementation.md) — 実装済みのPR integration invariantと、未適用のGitHub `main` protection/rulesetだけを管理するcurrent plan
+- [`plans/2026-09-12-agent-coordination-plane-v1-implementation.md`](plans/2026-09-12-agent-coordination-plane-v1-implementation.md) — #500。Task contract/state/evidence、dependency/conflict scheduler、lease/recovery、GitHub projection、operator CLI、adversarial verificationをTDDで実装するcurrent plan
 
 Preflight/context/impact、Semantic Diff、risk-based verificationなどのControl Plane Core実装は完了しているため、旧core implementation planはcurrent treeから削除済みである。実装経緯はGit historyおよびsuperseded PR #464を参照する。
 

--- a/docs/plans/2026-09-12-agent-coordination-plane-v1-implementation.md
+++ b/docs/plans/2026-09-12-agent-coordination-plane-v1-implementation.md
@@ -1,0 +1,269 @@
+# Agent Coordination Plane v1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the network-light, repository-local coordination primitives defined by #500 so multiple agents can be scheduled, isolated, reviewed, recovered, and integrated without duplicate ownership or stale evidence.
+
+**Architecture:** Extend the existing `tools.agent_repo` owner from stacked base PR #475. Keep the core model pure and deterministic; keep GitHub projection/serialization at the boundary; keep `trade_rl/**` completely independent. The implementation PR is stacked on `feat/agent-repository-control-plane-v1` until #475 becomes canonical, at which point it must be synchronized with current `main` and all integration evidence regenerated.
+
+**Tech Stack:** Python 3.12, stdlib dataclasses/enums/hashlib/json/datetime/pathlib, pytest, existing `tools.agent_repo` CLI and repository-tooling CI.
+
+**Spec:** `docs/specs/2026-09-12-agent-coordination-plane-v1-design.md`
+
+## Global Constraints
+
+- Do not add coordination dependencies to `trade_rl/**` or the production wheel.
+- Do not introduce a checked-in mutable global task ledger or a database/Redis lock service.
+- Keep one active Coordinator as the v1 operational invariant; do not claim multi-Coordinator consensus.
+- `read_only` tasks do not require writable branch/worktree state; `write` tasks do.
+- Task contracts bind evidence through `task_id + task_revision + task_contract_digest + base/source SHA + exact HEAD when applicable`.
+- Lease reassignment increments epoch and uses a new lease branch/worktree; old-epoch output cannot become current ownership without explicit salvage/review.
+- File-disjoint semantic/identity/side-effect collisions must be representable.
+- Main movement invalidates integration evidence; HEAD movement invalidates exact-HEAD review/verification evidence.
+- Existing final CI gates remain unchanged in strength.
+- This stacked implementation is not integration-complete until #475 is canonical and the final tested #500 HEAD contains then-current `main`.
+
+---
+
+### Task 1: Task contract, state, and evidence identity
+
+**Files:**
+- Create: `tools/agent_repo/coordination/__init__.py`
+- Create: `tools/agent_repo/coordination/model.py`
+- Create: `tools/agent_repo/coordination/state.py`
+- Create: `tests/agent_repo/test_coordination_model.py`
+
+**Interfaces:**
+- Produces `ExecutionMode`, `TaskPhase`, `TaskCondition`, `RiskLevel`, `DependencyKind`, `EvidenceKind`, `EvidenceResult` enums.
+- Produces immutable `TaskDependency`, `WriteScope`, `TaskPacket`, `TaskStatus`, and `EvidenceRecord` dataclasses.
+- `TaskPacket.canonical_payload() -> dict[str, object]` excludes runtime status/presentation-only fields.
+- `TaskPacket.contract_digest() -> str` returns SHA-256 of canonical UTF-8 JSON with sorted keys and compact separators.
+- `validate_transition(current: TaskPhase, target: TaskPhase) -> None` rejects illegal phase transitions.
+- `evidence_is_current(evidence, packet, *, head_sha, current_main_sha=None) -> bool` enforces exact binding; integration/post-merge evidence additionally requires current-main binding.
+
+- [ ] **Step 1: Write failing contract/evidence tests**
+
+Cover exact digest determinism under equivalent tuple/list construction, digest change on semantic fields, no digest change from absent runtime state, invalid SHA/revision/task id rejection, `read_only` vs `write` scope validation, legal/illegal phase transitions, exact-head evidence invalidation, and integration evidence invalidation when current main changes.
+
+- [ ] **Step 2: Run RED**
+
+Run: `uv run pytest -q tests/agent_repo/test_coordination_model.py`
+
+Expected: import/attribute failures because coordination model does not exist.
+
+- [ ] **Step 3: Implement minimal immutable model/state layer**
+
+Use frozen dataclasses and string enums. Validate full lowercase 40-hex Git SHAs where a commit identity is required. Canonicalize sequence fields to tuples in `__post_init__`; reject duplicate dependency task IDs or duplicate resource/capability entries rather than silently collapsing them.
+
+- [ ] **Step 4: Run GREEN + adjacent types**
+
+Run:
+`uv run pytest -q tests/agent_repo/test_coordination_model.py`
+`uv run mypy tools/agent_repo/coordination`
+`uv run ruff check tools/agent_repo/coordination tests/agent_repo/test_coordination_model.py`
+
+- [ ] **Step 5: Commit**
+
+`git commit -m "feat: add agent coordination task model"`
+
+---
+
+### Task 2: Dependency DAG, semantic conflicts, and deterministic scheduling
+
+**Files:**
+- Create: `tools/agent_repo/coordination/dependencies.py`
+- Create: `tools/agent_repo/coordination/conflicts.py`
+- Create: `tools/agent_repo/coordination/scheduler.py`
+- Create: `tests/agent_repo/test_coordination_scheduler.py`
+
+**Interfaces:**
+- `DependencyGraph(packets: Sequence[TaskPacket])` validates referenced task IDs and rejects cycles.
+- `DependencyGraph.dependencies_satisfied(task_id, statuses, evidence) -> bool` distinguishes hard/evidence/integration dependencies.
+- `ConflictLevel = NONE | SOFT | HARD`.
+- `classify_conflict(left: TaskPacket, right: TaskPacket) -> ConflictLevel` returns NONE when both tasks are read-only immutable-snapshot work; otherwise file-prefix/identity/schema/side-effect collisions are HARD and authority/workflow/artifact collisions are SOFT unless a stronger shared key exists.
+- `ready_tasks(packets, statuses, leases, evidence) -> tuple[str, ...]` returns only healthy, dependency-satisfied, unleased, non-hard-conflicting tasks in deterministic priority/order.
+
+- [ ] **Step 1: Write failing DAG/conflict/scheduler tests**
+
+Include missing dependency, hard cycle, `requires_phase`, evidence dependency, integration dependency, `file:docs/**` vs `file:docs/x.md`, same identity/schema/side-effect HARD, same authority/workflow/artifact SOFT, read-only sharing NONE, and two write tasks with a hard collision never both ready/executing.
+
+- [ ] **Step 2: Run RED**
+
+Run: `uv run pytest -q tests/agent_repo/test_coordination_scheduler.py`
+
+- [ ] **Step 3: Implement deterministic DAG/conflict/scheduler logic**
+
+Avoid Git/network access. Normalize resource keys once, fail closed on unknown namespaces, and use stable task-id tie-breaking after descendant/critical-path ranking.
+
+- [ ] **Step 4: Run GREEN + Task 1 regression**
+
+Run: `uv run pytest -q tests/agent_repo/test_coordination_model.py tests/agent_repo/test_coordination_scheduler.py`
+
+- [ ] **Step 5: Commit**
+
+`git commit -m "feat: schedule nonconflicting agent tasks"`
+
+---
+
+### Task 3: Lease epochs, branch fencing, heartbeat, and reconciliation
+
+**Files:**
+- Create: `tools/agent_repo/coordination/leases.py`
+- Create: `tests/agent_repo/test_coordination_leases.py`
+
+**Interfaces:**
+- Frozen `LeaseRecord` binds task/revision/digest/base/owner/epoch/branch/head/heartbeat/expiry.
+- Frozen `LeaseReconciliation` binds the expired epoch to observed remote side effects and a decision: `resume | salvage | supersede | reassign`.
+- `lease_branch_name(task_id, epoch, owner) -> str` yields deterministic `agent/<task>/eNNNN-<owner>` fencing branch names with safe slug validation.
+- `grant_lease(packet, owner, *, epoch, now, ttl, previous=None, reconciliation=None) -> LeaseRecord` rejects read-only tasks, active duplicate leases, non-monotonic epochs, mismatched reconciliation, and reuse of a previous epoch branch on reassignment.
+- `lease_is_current(lease, packet, *, now) -> bool` includes revision/digest/base/expiry checks.
+- `heartbeat(lease, *, head_sha, observed_at) -> LeaseRecord` is monotonic in time and preserves ownership/epoch.
+
+- [ ] **Step 1: Write failing lease/fencing tests**
+
+Cover duplicate claim, active lease rejection, expiry alone not sufficient for reassignment, matching reconciliation required, epoch monotonicity, branch uniqueness, stale epoch output rejection, task revision/digest change invalidation, head heartbeat update, and read-only task no-write-lease rule.
+
+- [ ] **Step 2: Run RED**
+
+Run: `uv run pytest -q tests/agent_repo/test_coordination_leases.py`
+
+- [ ] **Step 3: Implement minimal lease protocol**
+
+Use timezone-aware UTC datetimes only. `ttl` must be positive. Reconciliation data records branch existence/head plus stable identifiers for PR/CI/artifacts; it does not perform remote mutation.
+
+- [ ] **Step 4: Run GREEN + scheduler regression**
+
+Run: `uv run pytest -q tests/agent_repo/test_coordination_model.py tests/agent_repo/test_coordination_scheduler.py tests/agent_repo/test_coordination_leases.py`
+
+- [ ] **Step 5: Commit**
+
+`git commit -m "feat: fence agent task ownership with lease epochs"`
+
+---
+
+### Task 4: Durable GitHub projection, handoff, recovery, and dashboard
+
+**Files:**
+- Create: `tools/agent_repo/coordination/github_state.py`
+- Create: `tools/agent_repo/coordination/dashboard.py`
+- Create: `tests/agent_repo/test_coordination_projection.py`
+
+**Interfaces:**
+- `TaskStatusRecord` is a strict machine-readable projection of packet identity + phase/condition + owner/lease/head/checkpoint/blocking fields.
+- `render_status_comment(record) -> str` emits exactly one marker `<!-- agent-coordination:<task-id> -->` and one fenced canonical JSON object.
+- `parse_status_comment(text) -> TaskStatusRecord` fails closed on missing/duplicate marker, invalid JSON, unknown fields/enums, malformed SHA/digest, or inconsistent lease fields.
+- Frozen `HandoffPacket` binds task/revision/digest/lease epoch/last-good HEAD + verified/pending/known-failures/do-not-repeat/evidence identifiers.
+- `validate_handoff(handoff, packet, lease) -> None` rejects stale revision/digest/epoch/head.
+- `render_dashboard(parent_title, main_sha, snapshots) -> str` is deterministic and displays progress, phase/condition, owner, PR, dependency/blocking/stale reason without becoming state authority.
+
+- [ ] **Step 1: Write failing projection/recovery tests**
+
+Include round-trip status comment, malformed/partial status fail-closed, duplicate marker rejection, Coordinator restart reconstruction from serialized records, stale handoff rejection, and deterministic dashboard ordering.
+
+- [ ] **Step 2: Run RED**
+
+Run: `uv run pytest -q tests/agent_repo/test_coordination_projection.py`
+
+- [ ] **Step 3: Implement strict serialization boundary**
+
+Use stdlib JSON only; reject unknown keys rather than silently ignoring them. Never serialize secrets/tokens. Labels remain derived and are not parsed as authority.
+
+- [ ] **Step 4: Run GREEN + full coordination tests**
+
+Run: `uv run pytest -q tests/agent_repo/test_coordination_*.py`
+
+- [ ] **Step 5: Commit**
+
+`git commit -m "feat: project agent coordination state to GitHub records"`
+
+---
+
+### Task 5: CLI/operator surface and architecture boundaries
+
+**Files:**
+- Modify: `tools/agent_repo/__main__.py`
+- Modify: `tests/agent_repo/test_cli.py`
+- Create: `tests/architecture/test_agent_coordination_boundary.py`
+- Modify: `docs/AGENTS.md`
+- Modify: `docs/architecture/package-boundaries.md`
+
+**Interfaces:**
+- Extend the existing CLI with a nested `task` command, not a new binary.
+- v1 network-free commands:
+  - `task digest <packet-json>`
+  - `task ready <snapshot-json>`
+  - `task status-render <status-json>`
+  - `task status-parse <status-text-file>`
+  - `task dashboard <snapshot-json>`
+- CLI write operations such as live GitHub claim/comment mutation are deliberately deferred; the library exposes deterministic state rules and external Coordinators/connectors perform authorized writes.
+- Architecture test asserts `trade_rl/**` does not import `tools.agent_repo` and coordination tooling is not in the production wheel.
+
+- [ ] **Step 1: Write failing CLI/boundary tests**
+
+Add one end-to-end JSON fixture that constructs two independent tasks plus one hard-conflicting task and verifies digest/ready/dashboard output. Assert malformed packet/status inputs return exit code 2 and no stdout. Assert CLI invocation does not mutate the temporary Git repo.
+
+- [ ] **Step 2: Run RED**
+
+Run: `uv run pytest -q tests/agent_repo/test_cli.py tests/architecture/test_agent_coordination_boundary.py`
+
+- [ ] **Step 3: Implement CLI dispatch and durable docs**
+
+Follow the existing `_parser` / `_dispatch` / `_write_json` pattern. Keep network calls out of the CLI. Document source-derived Control Plane vs Coordination Plane responsibilities and the stacked dependency on #475.
+
+- [ ] **Step 4: Run GREEN + repository-tooling checks**
+
+Run:
+`uv run pytest -q tests/agent_repo tests/architecture/test_agent_coordination_boundary.py`
+`uv run mypy tools/agent_repo tests/architecture/distribution.py`
+`uv run ruff check tools tests/agent_repo tests/architecture/test_agent_coordination_boundary.py`
+`uv run ruff format --check tools tests/agent_repo tests/architecture/test_agent_coordination_boundary.py`
+
+- [ ] **Step 5: Commit**
+
+`git commit -m "feat: expose agent coordination operator commands"`
+
+---
+
+### Task 6: Adversarial verification and stacked integration readiness
+
+**Files:**
+- Create or extend: `tests/agent_repo/test_coordination_falsification.py`
+- Modify only if needed: `docs/specs/2026-09-12-agent-coordination-plane-v1-design.md`
+- Modify only if needed: `docs/plans/2026-09-12-agent-coordination-plane-v1-implementation.md`
+
+**Interfaces:**
+- No new production interface unless a falsification finding proves one necessary.
+- Final stacked HEAD must be reviewable independently of private conversation state.
+
+- [ ] **Step 1: Add adversarial tests before any required fix**
+
+Exercise: two workers racing one task, stale old-epoch result after reassignment, task body/digest drift without revision bump, approved old HEAD followed by new commit, Green old-main with advanced main, file-disjoint shared identity conflict, all-child-complete with parent acceptance false, malformed status reconstruction, and read-only task attempting write lease.
+
+- [ ] **Step 2: Verify falsification suite catches seeded wrong states**
+
+Run: `uv run pytest -q tests/agent_repo/test_coordination_falsification.py`
+
+If a demonstrated defect requires production changes, preserve TDD: keep the failing case, apply the smallest fix, rerun targeted tests.
+
+- [ ] **Step 3: Run full stacked quality gate on exact final HEAD**
+
+Run equivalent to permanent CI:
+`uv run ruff check trade_rl tests tools`
+`uv run ruff format --check trade_rl tests tools`
+`uv run mypy trade_rl`
+`uv run mypy tools/agent_repo tests/architecture/distribution.py`
+`uv run pytest -q tests`
+`uv build`
+plus existing distribution closure, clean-installed smoke, and package identity steps from `.github/workflows/ci.yml`.
+
+- [ ] **Step 4: Final diff/self-review**
+
+Confirm no `trade_rl/**` behavior/schema changes, no coordination generated state checked in, no temporary workflows/debug artifacts, no duplicate #475 authority, and only active spec/plan remain as current work.
+
+- [ ] **Step 5: Stacked PR disposition**
+
+Record that implementation evidence is valid for the exact stacked HEAD only. Do not claim final integration while #475 is Draft. Once #475 is canonical, retarget/synchronize #500 to current main, invalidate stale integration evidence, rerun exact-head review/full CI, then perform post-merge main verification before closing #500.
+
+- [ ] **Step 6: Commit**
+
+`git commit -m "test: falsify agent coordination failure modes"`

--- a/docs/specs/2026-09-12-agent-coordination-plane-v1-design.md
+++ b/docs/specs/2026-09-12-agent-coordination-plane-v1-design.md
@@ -1,0 +1,1008 @@
+# Agent Coordination Plane v1
+
+Status: Active
+
+Related: #500, #475
+
+## 1. Objective
+
+Trade RL で複数のAI Agentが同時に作業するとき、単なるparallel executionではなく、**task decomposition / ownership / dependency / collision / review / verification / integration / recoveryを一貫したprotocolで管理する**。
+
+v1は次を機械的に保つためのcoordination layerである。
+
+- 同一Taskを複数Workerが重複実装しない。
+- 独立Taskだけを安全に並列化する。
+- fileが異なっても同じsemantic authority / identity / side effectを変更するTaskを競合として扱う。
+- Task contract、PR HEAD、current mainの変化で古いevidenceを再利用しない。
+- Agent/session消失後もGitHub上のdurable evidenceから復元できる。
+- read-only investigation/reviewは不要なbranchを作らず軽量に並列化する。
+- write Taskはlease epochごとにwritable worktree/branchを隔離する。
+- Worker自身の「完了」ではなくindependent review / verification / integration evidenceで完了を決める。
+- child Task完了数だけでparent Issueをcloseせず、parent Acceptance Criteriaを最後に再評価する。
+
+この仕組みを **Agent Coordination Plane** と呼ぶ。
+
+## 2. Three-plane architecture
+
+PR #475 の Agent Repository Control Plane は、Repositoryをsource-derivedに理解・検証する層である。
+
+```text
+┌────────────────────────────────────────────┐
+│            Coordination Plane              │
+│ Task DAG / lease / scheduling / conflict   │
+│ capability / heartbeat / handoff / status  │
+└─────────────────────┬──────────────────────┘
+                      │ consumes facts
+┌─────────────────────▼──────────────────────┐
+│         Repository Control Plane           │
+│ preflight / context / impact / diff        │
+│ verify / source-derived inspection         │
+└─────────────────────┬──────────────────────┘
+                      │ produces evidence
+┌─────────────────────▼──────────────────────┐
+│            Integration Plane               │
+│ review / verification / main sync          │
+│ merge authorization / post-merge oracle    │
+└────────────────────────────────────────────┘
+```
+
+Repository Control Planeは「Repository上の事実」を読む。
+Coordination Planeは「誰が、何を、どの権限で、いつ実行できるか」を決める。
+Integration Planeは「現在のmainへ統合してよいか」を判断する。
+
+Coordination Planeはdomain / research / artifact authorityにはならない。
+
+## 3. Dependency on #475
+
+#500は#475のsource inspection primitiveを再実装しない。
+
+実装時に#475がmainへ統合済みならcanonical `tools.agent_repo` APIを利用する。未統合なら次のどちらかにする。
+
+1. #475をcurrent mainへ同期・検証・統合してから#500を実装する。
+2. #475 HEADを明示的stack baseにし、#475統合後にcurrent mainへ同期して全integration evidenceを取り直す。
+
+mainに存在しない#475実装をcopy/pasteして別ownerを作ることは禁止する。
+
+## 4. Non-goals
+
+v1では次を行わない。
+
+- Agent同士のfree-form peer-to-peer negotiationをcoordination authorityにしない。
+- Redis / DB / distributed lock serviceを導入しない。
+- runtime `trade_rl/**` にorchestration APIを混ぜない。
+- checked-in global mutable task ledgerを作らない。
+- generated coordination reportをcurrent treeへ蓄積しない。
+- unlimited autonomous recursive task decompositionを許可しない。
+- automatic merge authorizationを導入しない。
+- Worker自己レビューだけでindependent reviewを代替しない。
+- Tests Greenだけでcompleteにしない。
+- approximate equalityをidentity/evidence contractの代替にしない。
+- 複数Coordinatorのhigh-availability / split-brain consensusをv1で解決しない。
+
+v1のoperational invariantは**同時にactive Coordinatorは1つだけ**である。Coordinator takeoverは旧Coordinator sessionが停止済みであることを確認してから行う。
+
+## 5. Authority and persistence model
+
+### 5.1 Single-writer coordination
+
+Taskのauthoritative coordination stateを書き換えるのはCoordinatorだけ。
+
+Worker / Reviewer / Verifier / Integratorは成果物とevidenceを生成するが、lease、phase、condition、dependency resolutionを直接確定しない。
+
+### 5.2 Durable evidence
+
+Coordinator再起動後に必要な状態は次のGit/GitHub evidenceから復元可能でなければならない。
+
+```text
+Issue Task contract
+Coordinator-owned Task status record
+branch / commit SHA
+PR
+review
+CI run
+artifact
+main commit
+```
+
+Conflict graph、ready-set、priority等はdurable evidenceから再計算するderived stateとする。
+
+### 5.3 Labels and dashboards are projections
+
+GitHub labelsやdashboard表示はoperator UX用projectionであり、state authorityではない。Issue Task contract、Coordinator status record、Git/PR/CI evidenceから再構成する。
+
+### 5.4 Fail closed
+
+Task contract、lease、dependency、contract digest、HEAD binding等が欠ける・壊れる場合、推測でdispatch/mergeしない。
+
+## 6. Task granularity
+
+Task Issueへ分離する単位は次をすべて満たすものとする。
+
+1. 別Agentへhandoff可能。
+2. 独立Acceptance Criteria / Test Oracleを持てる。
+3. fresh Reviewerが単独でapprove/rejectできる。
+
+helper renameや同一TDD loop中のRED/GREEN stepはTaskへ分割しない。
+
+## 7. Task Packet v1
+
+Logical schema:
+
+```yaml
+schema: agent_task_v1
+
+task_id: T500-03
+task_revision: 1
+parent_issue: 500
+
+title: Implement lease and ownership state machine
+objective:
+  Prevent duplicate task ownership and make abandoned work recoverable.
+
+execution_mode: write
+
+non_goals:
+  - no distributed lock server
+  - no automatic merge
+
+dependencies:
+  hard:
+    - task_id: T500-01
+      requires_phase: complete
+  evidence: []
+  integration: []
+
+write_scope:
+  allow:
+    - tools/agent_repo/**
+    - tests/agent_repo/**
+  deny:
+    - trade_rl/**
+
+resource_keys:
+  - authority:agent-coordination-task-state
+  - workflow:agent-task-claim
+  - side-effect:github-task-status
+
+capabilities:
+  - repository_read
+  - lease_branch_write
+  - draft_pr_write
+
+acceptance_criteria:
+  - duplicate claim is rejected
+  - expired lease is not reassigned before reconciliation
+  - stale epoch cannot become current ownership
+
+test_oracle:
+  - deterministic state-machine transitions
+  - stale-epoch race simulation
+
+base_sha: <exact commit>
+risk: medium
+
+deliverable:
+  type: pull_request
+```
+
+これはlogical schemaであり、checked-in YAML task ledgerを要求しない。Issue body等から同一contractを再構築してよい。
+
+## 8. Execution mode
+
+Taskは`read_only`または`write`を明示する。
+
+### read_only
+
+調査、review、evidence verification等。
+
+- immutable checkout/snapshotを共有してよい。
+- writable worktree/branchを原則要求しない。
+- source mutationを行わない。
+- GitHub review/comment等、Task Packetで明示したside effectだけ許可する。
+
+### write
+
+source/docs/config/Git refs等を変更するTask。
+
+- active lease必須。
+- lease epoch固有のwritable worktree/branch必須。
+- write scope / Resource Key / capability contract必須。
+
+これにより「parallel investigationは軽く、implementationは強く隔離」を両立する。
+
+## 9. Task contract identity
+
+`task_revision`だけではmanual editのrevision-bump漏れを検知できない。そのため**canonical Task Contract digest**を導入する。
+
+Canonical payloadはruntime statusやpresentation-only fieldを除外し、UTF-8 JSON / sorted keys / stable separatorsで一意にserializeしてSHA-256を取る。
+
+```text
+task_contract_digest = sha256(canonical_task_packet)
+```
+
+Lease、review、verification、integration evidenceは最低限次へbindする。
+
+```text
+task_id
+task_revision
+task_contract_digest
+base_sha
+head_sha when applicable
+```
+
+Issue本文が変更されrevisionが同じでもdigestが変われば`stale`としてfail closedする。semantic変更ならrevisionを増やし、presentation-only変更ならcanonical payloadを変えない。
+
+## 10. Task revision
+
+`task_revision`はsemantic contract変更時に単調増加するintegerとする。
+
+Revisionを上げる例:
+
+- objective / non-goal変更;
+- execution mode変更;
+- dependency変更;
+- write scope / capability変更;
+- Resource Key変更;
+- Acceptance Criteria / Test Oracle変更。
+
+Workerがrevision 2で作業中にrevision 3へ変われば、旧lease/review/verificationはstaleとなる。
+
+## 11. Phase + Condition state model
+
+Task状態は単一enumではなく2軸で表す。
+
+### Phase
+
+```text
+planned
+ready
+executing
+review
+verification
+integration
+complete
+```
+
+### Condition
+
+```text
+healthy
+blocked
+stale
+failed
+conflicted
+```
+
+例:
+
+```text
+review / stale
+executing / blocked
+verification / failed
+integration / stale
+```
+
+通常遷移:
+
+```text
+planned
+  ↓ dependencies satisfied
+ready
+  ↓ dispatch / lease grant when write
+executing
+  ↓ reviewable result submitted
+review
+  ↓ independent review PASS
+verification
+  ↓ acceptance + quality evidence PASS
+integration
+  ↓ merge + post-merge oracle when applicable
+complete
+```
+
+代表的な逆遷移:
+
+```text
+review       → executing     CHANGES_REQUIRED
+verification → executing     implementation defect
+integration  → verification  re-evidence only
+integration  → executing     semantic merge conflict
+```
+
+Read-only Taskでmergeが存在しない場合、verificationからcompleteへ進める。ただしTask Packetが要求するdurable evidenceを満たすこと。
+
+`complete`はterminal。後発問題は原則new Task/Issueとして扱う。
+
+## 12. Lease and fencing protocol
+
+Leaseは`write` Taskのduplicate work防止とabandoned work回収のためのownership fenceである。
+
+### Lease record
+
+```yaml
+owner: agent-A
+epoch: 3
+task_revision: 2
+task_contract_digest: <sha256>
+base_sha: abc123
+lease_branch: agent/T500-03/e0003-agent-a
+head_sha: def456
+last_heartbeat_at: <timestamp>
+expires_at: <timestamp>
+```
+
+Lease recordを更新するのはCoordinatorだけ。
+
+### Epoch fencing
+
+新しいownership grantごとに`epoch`を増加する。旧epoch resultをcurrent ownershipとしてacceptしない。
+
+### Branch per epoch
+
+**Reassignment後に同じwritable branchを再利用しない。**
+
+```text
+agent/T500-03/e0003-agent-a
+agent/T500-03/e0004-agent-b
+```
+
+旧Workerがold branchへlate pushしてもnew Owner branchを直接汚さない。旧成果物を再利用する場合はnew epoch branchへexplicit importし、改めてreviewする。
+
+Same-owner resumeでownership/epochが変わらない場合のみ同一lease branchを継続できる。
+
+### Expiry is not reassignment
+
+Lease expiry後は必ずreconciliationする。
+
+```text
+old epoch branch HEAD
+open PR
+CI runs
+reviews/comments
+artifacts
+unmerged commits
+```
+
+をinventoryし、`resume / salvage / supersede / reassign`を決めてからnew epochをgrantする。
+
+## 13. Heartbeat
+
+Heartbeatは単なるlivenessではなく、leaseが同じrevision/digest/base/branchに対して意味を持つか確認するeventである。
+
+Coordinatorは次をprogress evidenceとして利用できる。
+
+- explicit Worker progress event;
+- lease branch HEAD advance;
+- Draft PR create/update;
+- CI start/finish;
+- reviewable checkpoint publication。
+
+固定intervalはrepository contractにしないが、expiry/reconciliation semanticsはdeterministic test対象とする。
+
+## 14. Capability model
+
+Roleごとにleast privilegeをTask Packet上で明示する。
+
+Conceptual capabilities:
+
+```text
+repository_read
+lease_branch_write
+draft_pr_write
+issue_comment_write
+review_write
+ci_read
+artifact_read
+integration_write
+merge_write
+```
+
+Default:
+
+- Worker(write): repository_read + lease_branch_write + draft_pr_write。
+- Worker(read_only): repository_read。必要な外部side effectだけ追加。
+- Reviewer: repository_read + review_write。production branch writeなし。
+- Verifier: repository_read + ci_read + artifact_read。原則source writeなし。
+- Integrator: repository_read + integration_write。merge_writeは明示authorization時のみ。
+
+Runtime/toolingが物理的permission isolationを提供できない場合でも、protocol contractとして違反を検出・報告する。v1は利用可能でない権限制御を実装済みと主張しない。
+
+## 15. Work isolation
+
+Write Task default invariant:
+
+```text
+1 active Task lease
+= 1 owner
+= 1 lease epoch
+= 1 isolated writable worktree
+= 1 lease branch
+= normally 1 PR
+```
+
+Worker同士はwritable worktreeを共有しない。
+
+Read-only Taskは同一immutable commit snapshotを共有可能。ただしgenerated mutable cacheが結果を変える場合は分離する。
+
+## 16. Dependency graph
+
+依存関係は3種類。
+
+### Hard dependency
+
+上流Taskが指定`requires_phase`を満たすまで下流実行不可。
+
+### Evidence dependency
+
+実装はparallel可能だが指定上流evidenceなしではverification/complete不可。
+
+### Integration dependency
+
+実装/reviewは独立だがintegration順序を持つ。
+
+DAG cycleはfail closedする。依存先Task revisionが変わり、edgeの前提が崩れた場合もdependent Taskを再評価する。
+
+## 17. Resource Keys
+
+File overlapだけでsemantic collisionを判定しない。
+
+v1 namespace:
+
+```text
+file:<repository-path-or-prefix>
+authority:<semantic-owner>
+identity:<content-addressed-identity>
+schema:<schema-or-contract>
+workflow:<workflow-or-integration-path>
+artifact:<artifact-family>
+side-effect:<external-or-repository-resource>
+```
+
+例:
+
+```text
+authority:market-feature-computation
+identity:market-dataset
+schema:candidate-run-v2
+workflow:canonical-m2-bootstrap
+artifact:evidence-set
+side-effect:github-issue-500-status
+```
+
+可能な限り#475のcontext/impactからderiveし、sourceから判定できないsemantic/side-effect concernだけTask contractで明示する。
+
+## 18. Conflict graph
+
+Task pairは`hard / soft / none`へ分類する。
+
+### Hard
+
+同時executing禁止。
+
+- same writable file region;
+- same schema/identity authorityを別方針で変更;
+- same mutable external side-effect resourceを同時更新。
+
+### Soft
+
+parallel implementation可。ただし片方のintegration後、他方のrelevant review/verificationをstaleにする。
+
+- same package/public facadeの別surface;
+- shared verification workflow変更;
+- common architecture contract変更。
+
+### None
+
+独立parallel可。
+
+Ready set:
+
+```text
+ready = dependency-satisfied
+      ∩ non-hard-conflicting
+      ∩ unleased when write
+      ∩ current contract digest
+```
+
+## 19. Scheduler
+
+Coordinator refresh cycle:
+
+```text
+1. refresh current main / task contracts / status / PRs / evidence
+2. recompute Task Contract digests
+3. invalidate stale contract/head/main/conflict evidence
+4. reconcile expired write leases
+5. resolve dependency states
+6. derive/update Resource Keys
+7. build conflict graph
+8. compute ready-set
+9. rank ready Tasks deterministically
+10. dispatch role work / grant write leases
+11. publish status/dashboard projection
+```
+
+v1 priority:
+
+1. blocking upstream Task;
+2. critical path;
+3. largest descendant-unblock count;
+4. lower-risk independent Task;
+5. stable task-id tie-break。
+
+複雑なAI priority scoreはv1に入れない。
+
+## 20. Roles
+
+### Coordinator
+
+Task decomposition、revision/digest、DAG、conflict graph、phase/condition、lease、stale invalidation、scheduling、status projectionを所有する。原則production implementationを行わない。
+
+### Worker
+
+Task Packet、TDD、focused implementation/investigation、checkpoint、self-review、reviewable resultを担当する。Write Taskではepoch worktree/branchを使う。WorkerはTaskをcompleteにできない。
+
+### Reviewer
+
+Workerとは独立したcontextで、Task Packet / current source / exact diff/result / tests/evidenceからadversarial reviewする。Worker reasoningをauthorityとして引き継がない。
+
+Verdict:
+
+```text
+PASS
+CHANGES_REQUIRED
+BLOCKING_FINDING
+```
+
+### Verifier
+
+Acceptance Criteria、Invariants、Failure Modes、Test Oracle、quality gate、falsification、unverified itemsをexact snapshotに対して確認する。
+
+### Integrator
+
+current main、tested-head containment、competing work、exact-head review/CI、expected-head merge、post-merge oracleを担当する。
+
+Small deploymentではCoordinator/Integrator併任可。material write TaskではWorker/Reviewerを分離する。
+
+## 21. Worker submission gate
+
+Write Taskの`executing → review`前に最低限:
+
+- current task revision/digest確認;
+- write scope/capability確認;
+- reproducing RED観測;
+- minimal GREEN観測;
+- refactor後GREEN;
+- final diff self-review;
+- debug/tmp/generated residueなし;
+- epoch branchへcommit/push;
+- immutable review targetあり;
+- known limitations / unverified items明記。
+
+Read-only TaskではRED/GREENやbranch要件のうち非該当項目を除外し、Task固有Test Oracle/evidenceを満たす。
+
+自然言語「できた」はtransition oracleではない。
+
+## 22. Checkpoint and handoff
+
+Meaningful boundaryでrecoverable checkpointをdurable化する。
+
+```text
+RED reproduced
+root cause evidence captured
+minimal GREEN
+refactor complete
+long external CI before wait
+reviewable HEAD/result
+```
+
+Worker交代時のhandoff minimum:
+
+```yaml
+task_id: T500-03
+task_revision: 2
+task_contract_digest: <sha256>
+lease_epoch: 4
+last_good_head: abc123
+verified:
+  - RED reproduction confirmed
+pending:
+  - full CI
+known_failures: []
+do_not_repeat:
+  - completed root-cause diagnostic
+evidence:
+  - pr: 512
+  - ci_run: 123456
+```
+
+Private conversation historyなしで再開できることをoracleとする。
+
+## 23. Evidence binding and invalidation
+
+Evidence logical minimum:
+
+```yaml
+evidence_kind: review | test | ci | artifact | integration | post_merge
+task_id: T500-03
+task_revision: 2
+task_contract_digest: <sha256>
+base_sha: aaa111
+head_sha: bbb222
+identifier: <stable id>
+result: pass | fail
+```
+
+Read-only evidenceでHEADが不要な場合も、評価したimmutable source snapshot SHAを`head_sha`相当としてbindする。
+
+Invalidation rules:
+
+- task revision/digest change → lease/review/verification/integration stale;
+- source/PR HEAD change → review/verification/integration stale;
+- current main change → integration stale;
+- hard/soft conflict integration → affected Task evidence stale according to edge;
+- malformed/missing binding → invalid, not unknown-pass。
+
+v1は安全側に倒し、HEADが変わればreview/verificationを取り直す。
+
+## 24. Current-main and Integration
+
+Integration invariant:
+
+```text
+tested PR head contains then-current main
++
+exact head has required review and CI evidence
+```
+
+main advance後は:
+
+```text
+phase=integration
+condition=stale
+reason=current_main_advanced
+```
+
+とする。
+
+Integrationはfirst-class phaseであり、merge successだけではcompleteではない。
+
+Required oracle:
+
+```text
+current main resolved
+no unresolved hard conflict
+current Task Contract digest
+PR head contains current main
+review exact HEAD PASS
+verification exact HEAD PASS
+required CI exact HEAD Green
+final diff/status clean
+merge authorization present
+merge uses expected HEAD
+post-merge main HEAD observed
+post-merge required oracle Green
+```
+
+## 25. Parent completion
+
+Parent Issue completion:
+
+1. required child Tasks complete;
+2. parent Acceptance Criteria再評価;
+3. cross-task invariants再評価;
+4. integration ordering/final tree確認;
+5. residual risks / unverified items明記。
+
+```text
+all children complete
+≠ automatically parent complete
+```
+
+## 26. GitHub projection
+
+推奨durable mapping:
+
+| Information | Location |
+|---|---|
+| Task contract | Issue body |
+| phase/condition | Coordinator status record; labels are projection |
+| owner | assignee + status record |
+| revision/digest/lease/base/head | Coordinator status record |
+| implementation | epoch-specific branch / PR |
+| review | PR review |
+| verification | CI / immutable artifact |
+| completion | Issue closed/completed after required oracle |
+
+Coordinator-owned status commentはTaskごとに原則1つをupdate-in-placeする。
+
+```text
+<!-- agent-coordination:T500-03 -->
+Schema: agent_coordination_status_v1
+Task-Revision: 2
+Task-Contract-Digest: sha256:...
+Phase: executing
+Condition: healthy
+Owner: agent-A
+Lease-Epoch: 4
+Base: aaa111
+Lease-Branch: agent/T500-03/e0004-agent-a
+Head: bbb222
+Checkpoint: RED confirmed
+Blocking: none
+```
+
+Worker/Reviewerはこのrecordを直接編集しない。
+
+Human-facing dashboardはこのevidenceから生成するderived viewとする。
+
+## 27. Recovery and fencing scenarios
+
+### Worker lost before push
+
+Durable evidenceなし。未push stateをprogressとして扱わずlast durable checkpointから再実行する。
+
+### Worker lost after push
+
+Remote branch/PR/CIをreconcileし、same epoch resumeまたはnew epoch salvageを選ぶ。
+
+### Stale Worker returns after reassignment
+
+旧Workerは旧epoch branchへしか成果物を出さない。旧epoch resultをcurrent stateとしてacceptしない。必要ならnew epoch branchへexplicit importして再reviewする。
+
+### Coordinator restart
+
+Issue/status/branch/PR/CI evidenceからstateを再構築する。Coordinator memoryだけに必要情報があれば設計違反。
+
+### Coordinator split-brain
+
+v1では自動解決しない。複数Coordinatorを同時activeにしないことをoperational invariantとし、takeover前に旧session停止を要求する。
+
+## 28. Security / trust boundary
+
+- Worker summaryよりGit SHA/diff/test outputを優先する。
+- Reviewer proseよりreview target SHAを確認する。
+- CI textよりrun/head bindingを確認する。
+- labelだけでmerge可否を決めない。
+- malformed status/contractはfail closedする。
+- write scope/capability違反はTask contract violation。
+- secrets/token値をTask Packet/statusへ保存しない。
+- Reviewer/Verifierへ不要なwrite capabilityを与えない。
+
+## 29. Failure modes and mitigations
+
+| Failure | Mitigation |
+|---|---|
+| Duplicate claim | single Coordinator + one active lease + epoch |
+| Stale Worker after reassign | branch-per-epoch fencing + old epoch rejection |
+| Issue edited without revision bump | canonical Task Contract digest |
+| Worker uses stale Task spec | revision/digest transition checks |
+| Read-only task creates unnecessary mutable state | execution mode contract |
+| File-disjoint semantic collision | Resource Keys + conflict graph |
+| External side-effect race | `side-effect:` Resource Key |
+| Review stale after commit | exact snapshot evidence binding |
+| Green PR stale after main advance | integration invalidation + current-main containment |
+| Global ledger merge conflict | no checked-in mutable ledger |
+| Agent death loses work | meaningful durable checkpoints |
+| Child completion masks parent failure | parent final acceptance re-evaluation |
+| Coordinator restart loses state | GitHub evidence reconstruction |
+| Coordinator split-brain | explicit single-active-Coordinator invariant |
+| Role overreach | least-capability contract + violation detection |
+
+## 30. Test strategy
+
+### Unit
+
+- Task Packet canonicalization/digest;
+- execution mode/capability validation;
+- phase/condition transitions;
+- task revision invalidation;
+- typed dependency DAG and cycle rejection;
+- Resource Key normalization;
+- hard/soft/none conflict classification;
+- lease epoch/fencing;
+- evidence invalidation;
+- deterministic ready-set/scheduling。
+
+### Property / model-based
+
+- at most one active write lease per Task;
+- epoch monotonicity;
+- epoch branch uniqueness;
+- hard-conflicting write Tasks never both executing;
+- stale evidence never satisfies completion;
+- complete implies required verification/integration evidence;
+- digest change with unchanged revision never remains healthy;
+- read-only Task never requires or mutates lease branch state。
+
+### Integration
+
+Temporary Git repo/worktreeで:
+
+- isolated write worktrees;
+- shared immutable read-only snapshots;
+- epoch branches;
+- old-worker late push isolation;
+- HEAD movement;
+- main movement;
+- merge-base/current-main containment;
+- checkpoint recovery/handoff。
+
+### GitHub contract
+
+- Task/status parse;
+- status reconstruction;
+- exact PR head;
+- review/CI head binding;
+- stale-main detection;
+- malformed status fail-closed;
+- side-effect Resource Key collision。
+
+### Falsification
+
+意図的に:
+
+- duplicate lease;
+- stale epoch result;
+- Issue contract mutation without revision bump;
+- read-only Task attempting source write;
+- cyclic dependency;
+- semantic conflict without file overlap;
+- same external side effect without file overlap;
+- approved-old-HEAD + new commit;
+- Green-old-main + advanced main;
+- all children complete + parent AC failure
+
+を作り、systemが拒否することを確認する。
+
+## 31. Implementation boundary
+
+#475がcanonicalになった場合、同じrepository-tooling ownerへ追加する。
+
+Conceptual responsibility split:
+
+```text
+tools/agent_repo/
+  coordination/
+    model.py
+    contract.py
+    state.py
+    dependencies.py
+    conflicts.py
+    leases.py
+    scheduler.py
+    github_state.py
+    dashboard.py
+```
+
+- `model.py`: immutable domain-neutral coordination types
+- `contract.py`: Task Packet canonicalization/digest/capabilities
+- `state.py`: phase/condition and invalidation
+- `dependencies.py`: typed DAG
+- `conflicts.py`: Resource Keys/conflict graph
+- `leases.py`: epoch/fencing/reconciliation state
+- `scheduler.py`: deterministic ready-set/allocation
+- `github_state.py`: GitHub durable projection boundary
+- `dashboard.py`: human derived view
+
+Exact filenamesは実装時の#475 structureに合わせて調整可能だが責務分離は維持し、巨大single fileへ集約しない。
+
+`trade_rl/**`からこのtoolingへ依存しない。
+
+## 32. CLI direction
+
+#475のentrypointを継続できる場合、別binaryではなくnamespaceを追加する。
+
+```text
+python -m tools.agent_repo task show <id>
+python -m tools.agent_repo task graph <parent>
+python -m tools.agent_repo task ready <parent>
+python -m tools.agent_repo task reconcile <id>
+python -m tools.agent_repo task dashboard [<parent>]
+```
+
+Write commandsを直接CLIへ公開するかCoordinator API専用にするかは、implementation時点のGitHub permission surfaceを確認して決める。Read-only model/state contractsはwrite capabilityに依存させない。
+
+## 33. Dogfood
+
+Coordination Plane自身のcontract testsがGreenになる前に本番coordination authorityとして使わない。
+
+最初のdogfoodは開始時点のcurrent stateを確認し、semantic scopeが独立した2+ Taskを選ぶ。候補例は#494と#476だが、完了/仕様変更済みなら別Taskを選ぶ。
+
+評価:
+
+- duplicate work zero;
+- scope/capability violation zero;
+- stale evidence reuse zero;
+- successful recovery/handoff;
+- no hidden semantic/side-effect collision;
+- integration後のsoft-conflicting remaining Taskが正しくstale化。
+
+## 34. Acceptance Criteria
+
+1. Independent read-only/write Taskを2つ以上、安全にconcurrent dispatchできる。
+2. Read-only Taskに不要なwritable branch/worktreeを要求しない。
+3. 同一write Taskへactive leaseを二重grantできない。
+4. Lease expiry後、side-effect reconciliationなしにreassignできない。
+5. New lease epochはunique writable branchを持ち、old Worker late pushがnew owner branchを直接汚さない。
+6. Task revisionまたはcanonical contract digest変更で旧lease/review/verificationがstaleになる。
+7. File overlapなしのsemantic/side-effect Resource Key collisionをhard/soft conflictとして表現できる。
+8. Hard-conflicting write Tasksを同時executingにしない。
+9. PR/source snapshot変更後、旧review/CI evidenceをvalid扱いしない。
+10. Main advancement後、integration evidenceをstaleにしcurrent-main-inclusive exact HEADを再検証する。
+11. Agent/session loss後、durable checkpointからprivate chatなしでhandoffできる。
+12. WorkerはTaskをcompleteにできずreview/verification/integration protocolを通る。
+13. All child completeだけでparent closeせずparent ACを再評価する。
+14. Coordinator restart後、durable evidenceからstateを再構築できる。
+15. Repository Control PlaneとCoordination Planeのauthorityを分離する。
+16. Role capability violationを検出・報告できる。
+17. `trade_rl/**` runtime/public API/artifact semanticsをcoordination都合で変更しない。
+18. Existing final quality gatesを弱めない。
+19. Multi-Coordinator consensusを実装したと誤って主張せず、v1 single-active-Coordinator invariantを明記する。
+
+## 35. Quality Gate
+
+Implementation completeには最低限:
+
+- Task contract digest tests Green;
+- execution-mode/capability tests Green;
+- state/revision/lease/fencing/property tests Green;
+- dependency/conflict/scheduler tests Green;
+- temp-Git/worktree integration Green;
+- old-worker late-push falsification Green;
+- GitHub projection/reconstruction tests Green;
+- stale-HEAD/stale-main falsification Green;
+- parent completion falsification Green;
+- Ruff / Format / Mypy;
+- repository-tooling type checks;
+- full pytest;
+- build/distribution closure;
+- clean-installed production package checks;
+- final diff review;
+- generated coordination/debug residueなし;
+- exact final HEAD CI Green;
+- current-main containment before merge;
+- post-merge main oracle;
+- dogfood result and residual risks documented。
+
+Tests Greenだけではcompletionとしない。
+
+## 36. Implementation sequencing
+
+### Phase 0 — dependency normalization
+
+#475のcurrent statusを再確認し、Control Plane primitiveをcanonicalにする順序を決める。
+
+### Phase 1 — pure model
+
+Task Packet canonical digest、execution mode/capability、phase/condition、revision/evidence invalidation、DAG、Resource Keysをnetwork-freeで実装する。
+
+### Phase 2 — lease/fencing/scheduler
+
+Epoch branch fencing、reconciliation、ready-set、hard/soft conflict schedulingを実装する。
+
+### Phase 3 — Git/GitHub projection
+
+Issue/status/branch/PR/head/CIからstateをreconstructするboundaryを実装する。
+
+### Phase 4 — role protocol
+
+Worker submission、Reviewer、Verifier、Integrator、handoff/recoveryを接続する。
+
+### Phase 5 — dashboard
+
+active/blocked/stale/owner/dependencyを一目で確認できるderived viewを作る。
+
+### Phase 6 — adversarial verification
+
+race、stale worker、contract mutation、capability violation、side-effect collision、main movement、parent acceptanceを壊す。
+
+### Phase 7 — dogfood
+
+独立Taskを2+ Workerで並列運用して実環境検証する。
+
+## 37. Completion lifecycle
+
+このspecはimplementation中だけ`docs/specs/`へ保持する。
+
+実装完了後はdurable responsibility/invariantを`docs/AGENTS.md`と必要なarchitecture docsへ移し、completed planとActive specをcurrent treeから削除する。Historical designはGit history / PR / Issueを参照する。

--- a/tests/agent_repo/test_coordination_leases.py
+++ b/tests/agent_repo/test_coordination_leases.py
@@ -182,7 +182,9 @@ def test_lease_freshness_binds_revision_digest_base_and_expiry() -> None:
     lease = grant_lease(packet, "agent-a", epoch=1, now=NOW, ttl=TTL)
 
     assert lease_is_current(lease, packet, now=NOW + timedelta(minutes=1))
-    assert not lease_is_current(lease, _packet(revision=2), now=NOW + timedelta(minutes=1))
+    assert not lease_is_current(
+        lease, _packet(revision=2), now=NOW + timedelta(minutes=1)
+    )
     assert not lease_is_current(
         lease,
         _packet(objective="changed"),

--- a/tests/agent_repo/test_coordination_leases.py
+++ b/tests/agent_repo/test_coordination_leases.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from tools.agent_repo.coordination.leases import (
+    LeaseReconciliation,
+    ReconciliationDecision,
+    grant_lease,
+    heartbeat,
+    lease_branch_name,
+    lease_is_current,
+)
+from tools.agent_repo.coordination.model import (
+    Capability,
+    ExecutionMode,
+    TaskPacket,
+    WriteScope,
+)
+
+BASE_SHA = "a" * 40
+HEAD_SHA = "b" * 40
+NEXT_HEAD_SHA = "c" * 40
+NOW = datetime(2026, 9, 12, 12, 0, tzinfo=UTC)
+TTL = timedelta(minutes=15)
+
+
+def _packet(*, revision: int = 1, objective: str = "write") -> TaskPacket:
+    return TaskPacket(
+        task_id="T500-03",
+        task_revision=revision,
+        parent_issue=500,
+        title="Lease protocol",
+        objective=objective,
+        execution_mode=ExecutionMode.WRITE,
+        write_scope=WriteScope(allow=("tools/agent_repo/**",)),
+        capabilities=(Capability.REPOSITORY_READ, Capability.LEASE_BRANCH_WRITE),
+        base_sha=BASE_SHA,
+    )
+
+
+def _read_only_packet() -> TaskPacket:
+    return TaskPacket(
+        task_id="T500-R",
+        task_revision=1,
+        parent_issue=500,
+        title="Read only",
+        objective="Inspect evidence",
+        execution_mode=ExecutionMode.READ_ONLY,
+        base_sha=BASE_SHA,
+    )
+
+
+def test_branch_name_is_epoch_fenced_and_slug_safe() -> None:
+    assert lease_branch_name("T500-03", 3, "Agent A") == "agent/T500-03/e0003-agent-a"
+    assert lease_branch_name("T500-03", 4, "Agent A") != lease_branch_name(
+        "T500-03", 3, "Agent A"
+    )
+    with pytest.raises(ValueError, match="owner"):
+        lease_branch_name("T500-03", 3, "../unsafe")
+
+
+def test_grant_rejects_read_only_tasks_and_duplicate_active_lease() -> None:
+    with pytest.raises(ValueError, match="read_only"):
+        grant_lease(_read_only_packet(), "agent-a", epoch=1, now=NOW, ttl=TTL)
+
+    packet = _packet()
+    lease = grant_lease(packet, "agent-a", epoch=1, now=NOW, ttl=TTL)
+    with pytest.raises(ValueError, match="active lease"):
+        grant_lease(
+            packet,
+            "agent-b",
+            epoch=2,
+            now=NOW + timedelta(minutes=1),
+            ttl=TTL,
+            previous=lease,
+        )
+
+
+def test_expiry_alone_cannot_reassign_without_matching_reconciliation() -> None:
+    packet = _packet()
+    old = grant_lease(packet, "agent-a", epoch=1, now=NOW, ttl=TTL)
+    expired_at = NOW + TTL + timedelta(seconds=1)
+
+    with pytest.raises(ValueError, match="reconciliation"):
+        grant_lease(
+            packet,
+            "agent-b",
+            epoch=2,
+            now=expired_at,
+            ttl=TTL,
+            previous=old,
+        )
+
+    wrong = LeaseReconciliation(
+        task_id=packet.task_id,
+        expired_epoch=99,
+        observed_branch=old.lease_branch,
+        observed_head_sha=None,
+        decision=ReconciliationDecision.REASSIGN,
+    )
+    with pytest.raises(ValueError, match="reconciliation"):
+        grant_lease(
+            packet,
+            "agent-b",
+            epoch=2,
+            now=expired_at,
+            ttl=TTL,
+            previous=old,
+            reconciliation=wrong,
+        )
+
+
+def test_reassignment_increments_epoch_and_changes_branch() -> None:
+    packet = _packet()
+    old = grant_lease(packet, "agent-a", epoch=3, now=NOW, ttl=TTL)
+    expired_at = NOW + TTL + timedelta(seconds=1)
+    reconciliation = LeaseReconciliation(
+        task_id=packet.task_id,
+        expired_epoch=old.epoch,
+        observed_branch=old.lease_branch,
+        observed_head_sha=HEAD_SHA,
+        pr_ids=("502",),
+        ci_ids=("34600000000",),
+        artifact_ids=("1000",),
+        decision=ReconciliationDecision.REASSIGN,
+    )
+    new = grant_lease(
+        packet,
+        "agent-b",
+        epoch=4,
+        now=expired_at,
+        ttl=TTL,
+        previous=old,
+        reconciliation=reconciliation,
+    )
+
+    assert new.epoch == 4
+    assert new.owner == "agent-b"
+    assert new.lease_branch != old.lease_branch
+    assert new.lease_branch == "agent/T500-03/e0004-agent-b"
+
+    with pytest.raises(ValueError, match="next epoch"):
+        grant_lease(
+            packet,
+            "agent-c",
+            epoch=6,
+            now=expired_at,
+            ttl=TTL,
+            previous=old,
+            reconciliation=reconciliation,
+        )
+
+
+def test_same_owner_resume_keeps_epoch_and_branch_only_after_reconciliation() -> None:
+    packet = _packet()
+    old = grant_lease(packet, "agent-a", epoch=2, now=NOW, ttl=TTL)
+    expired_at = NOW + TTL + timedelta(seconds=1)
+    reconciliation = LeaseReconciliation(
+        task_id=packet.task_id,
+        expired_epoch=old.epoch,
+        observed_branch=old.lease_branch,
+        observed_head_sha=HEAD_SHA,
+        decision=ReconciliationDecision.RESUME,
+    )
+    resumed = grant_lease(
+        packet,
+        "agent-a",
+        epoch=2,
+        now=expired_at,
+        ttl=TTL,
+        previous=old,
+        reconciliation=reconciliation,
+    )
+    assert resumed.epoch == old.epoch
+    assert resumed.lease_branch == old.lease_branch
+
+
+def test_lease_freshness_binds_revision_digest_base_and_expiry() -> None:
+    packet = _packet()
+    lease = grant_lease(packet, "agent-a", epoch=1, now=NOW, ttl=TTL)
+
+    assert lease_is_current(lease, packet, now=NOW + timedelta(minutes=1))
+    assert not lease_is_current(lease, _packet(revision=2), now=NOW + timedelta(minutes=1))
+    assert not lease_is_current(
+        lease,
+        _packet(objective="changed"),
+        now=NOW + timedelta(minutes=1),
+    )
+    assert not lease_is_current(lease, packet, now=NOW + TTL)
+
+
+def test_heartbeat_is_monotonic_and_updates_exact_head() -> None:
+    packet = _packet()
+    lease = grant_lease(packet, "agent-a", epoch=1, now=NOW, ttl=TTL)
+    updated = heartbeat(
+        lease,
+        head_sha=NEXT_HEAD_SHA,
+        observed_at=NOW + timedelta(minutes=2),
+    )
+    assert updated.head_sha == NEXT_HEAD_SHA
+    assert updated.last_heartbeat_at == NOW + timedelta(minutes=2)
+    assert updated.owner == lease.owner
+    assert updated.epoch == lease.epoch
+
+    with pytest.raises(ValueError, match="monotonic"):
+        heartbeat(
+            updated,
+            head_sha=HEAD_SHA,
+            observed_at=NOW + timedelta(minutes=1),
+        )
+
+
+def test_lease_requires_timezone_aware_time_and_positive_ttl() -> None:
+    packet = _packet()
+    with pytest.raises(ValueError, match="timezone-aware"):
+        grant_lease(
+            packet,
+            "agent-a",
+            epoch=1,
+            now=datetime(2026, 9, 12, 12, 0),
+            ttl=TTL,
+        )
+    with pytest.raises(ValueError, match="positive"):
+        grant_lease(packet, "agent-a", epoch=1, now=NOW, ttl=timedelta())

--- a/tests/agent_repo/test_coordination_model.py
+++ b/tests/agent_repo/test_coordination_model.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import pytest
+
+from tools.agent_repo.coordination.model import (
+    Capability,
+    DependencyKind,
+    EvidenceKind,
+    EvidenceRecord,
+    EvidenceResult,
+    ExecutionMode,
+    RiskLevel,
+    TaskCondition,
+    TaskDependency,
+    TaskPacket,
+    TaskPhase,
+    TaskStatus,
+    WriteScope,
+)
+from tools.agent_repo.coordination.state import evidence_is_current, validate_transition
+
+BASE_SHA = "a" * 40
+HEAD_SHA = "b" * 40
+OTHER_HEAD_SHA = "c" * 40
+MAIN_SHA = "d" * 40
+OTHER_MAIN_SHA = "e" * 40
+
+
+def _packet(
+    *,
+    revision: int = 1,
+    objective: str = "Implement coordination state",
+    title: str = "Coordination state",
+    execution_mode: ExecutionMode = ExecutionMode.WRITE,
+) -> TaskPacket:
+    return TaskPacket(
+        task_id="T500-01",
+        task_revision=revision,
+        parent_issue=500,
+        title=title,
+        objective=objective,
+        execution_mode=execution_mode,
+        non_goals=("no distributed lock service",),
+        dependencies=(
+            TaskDependency(
+                task_id="T500-00",
+                kind=DependencyKind.HARD,
+                requires_phase=TaskPhase.COMPLETE,
+            ),
+        ),
+        write_scope=(
+            WriteScope(
+                allow=("tools/agent_repo/**", "tests/agent_repo/**"),
+                deny=("trade_rl/**",),
+            )
+            if execution_mode is ExecutionMode.WRITE
+            else WriteScope()
+        ),
+        resource_keys=(
+            "authority:agent-coordination-task-state",
+            "workflow:agent-task-claim",
+        ),
+        capabilities=(
+            Capability.REPOSITORY_READ,
+            *(
+                (Capability.LEASE_BRANCH_WRITE, Capability.DRAFT_PR_WRITE)
+                if execution_mode is ExecutionMode.WRITE
+                else ()
+            ),
+        ),
+        acceptance_criteria=("duplicate claim is rejected",),
+        test_oracle=("deterministic transition",),
+        base_sha=BASE_SHA,
+        risk=RiskLevel.MEDIUM,
+        deliverable="pull_request",
+    )
+
+
+def _evidence(
+    packet: TaskPacket,
+    *,
+    kind: EvidenceKind = EvidenceKind.REVIEW,
+    head_sha: str = HEAD_SHA,
+    main_sha: str | None = None,
+) -> EvidenceRecord:
+    return EvidenceRecord(
+        evidence_kind=kind,
+        task_id=packet.task_id,
+        task_revision=packet.task_revision,
+        task_contract_digest=packet.contract_digest(),
+        base_sha=packet.base_sha,
+        head_sha=head_sha,
+        identifier="evidence-1",
+        result=EvidenceResult.PASS,
+        main_sha=main_sha,
+    )
+
+
+def test_task_contract_digest_is_deterministic_and_semantic() -> None:
+    left = _packet()
+    right = _packet()
+
+    assert left.canonical_payload() == right.canonical_payload()
+    assert left.contract_digest() == right.contract_digest()
+    assert len(left.contract_digest()) == 64
+
+    changed = _packet(objective="Changed semantic objective")
+    assert changed.contract_digest() != left.contract_digest()
+
+    presentation_only = _packet(title="Different display title")
+    assert presentation_only.contract_digest() == left.contract_digest()
+
+
+def test_task_packet_rejects_invalid_identity_and_scope() -> None:
+    with pytest.raises(ValueError, match="task_id"):
+        TaskPacket(
+            task_id="",
+            task_revision=1,
+            parent_issue=500,
+            title="x",
+            objective="x",
+            execution_mode=ExecutionMode.READ_ONLY,
+            base_sha=BASE_SHA,
+        )
+
+    with pytest.raises(ValueError, match="task_revision"):
+        _packet(revision=0)
+
+    with pytest.raises(ValueError, match="base_sha"):
+        TaskPacket(
+            task_id="T500-01",
+            task_revision=1,
+            parent_issue=500,
+            title="x",
+            objective="x",
+            execution_mode=ExecutionMode.READ_ONLY,
+            base_sha="not-a-sha",
+        )
+
+    with pytest.raises(ValueError, match="read_only"):
+        TaskPacket(
+            task_id="T500-01",
+            task_revision=1,
+            parent_issue=500,
+            title="x",
+            objective="x",
+            execution_mode=ExecutionMode.READ_ONLY,
+            write_scope=WriteScope(allow=("tools/**",)),
+            base_sha=BASE_SHA,
+        )
+
+    with pytest.raises(ValueError, match="write.*allow"):
+        TaskPacket(
+            task_id="T500-01",
+            task_revision=1,
+            parent_issue=500,
+            title="x",
+            objective="x",
+            execution_mode=ExecutionMode.WRITE,
+            base_sha=BASE_SHA,
+        )
+
+
+def test_task_packet_rejects_duplicate_contract_entries() -> None:
+    with pytest.raises(ValueError, match="duplicate dependency"):
+        TaskPacket(
+            task_id="T500-01",
+            task_revision=1,
+            parent_issue=500,
+            title="x",
+            objective="x",
+            execution_mode=ExecutionMode.WRITE,
+            dependencies=(
+                TaskDependency("T500-00", DependencyKind.HARD),
+                TaskDependency("T500-00", DependencyKind.EVIDENCE),
+            ),
+            write_scope=WriteScope(allow=("tools/**",)),
+            base_sha=BASE_SHA,
+        )
+
+    with pytest.raises(ValueError, match="duplicate resource key"):
+        TaskPacket(
+            task_id="T500-01",
+            task_revision=1,
+            parent_issue=500,
+            title="x",
+            objective="x",
+            execution_mode=ExecutionMode.WRITE,
+            write_scope=WriteScope(allow=("tools/**",)),
+            resource_keys=("identity:x", "identity:x"),
+            base_sha=BASE_SHA,
+        )
+
+
+def test_phase_transition_contract_is_explicit() -> None:
+    for current, target in (
+        (TaskPhase.PLANNED, TaskPhase.READY),
+        (TaskPhase.READY, TaskPhase.EXECUTING),
+        (TaskPhase.EXECUTING, TaskPhase.REVIEW),
+        (TaskPhase.REVIEW, TaskPhase.VERIFICATION),
+        (TaskPhase.VERIFICATION, TaskPhase.INTEGRATION),
+        (TaskPhase.INTEGRATION, TaskPhase.COMPLETE),
+        (TaskPhase.REVIEW, TaskPhase.EXECUTING),
+        (TaskPhase.VERIFICATION, TaskPhase.EXECUTING),
+        (TaskPhase.INTEGRATION, TaskPhase.VERIFICATION),
+        (TaskPhase.INTEGRATION, TaskPhase.EXECUTING),
+    ):
+        validate_transition(current, target)
+
+    with pytest.raises(ValueError, match="transition"):
+        validate_transition(TaskPhase.READY, TaskPhase.COMPLETE)
+    with pytest.raises(ValueError, match="terminal"):
+        validate_transition(TaskPhase.COMPLETE, TaskPhase.EXECUTING)
+
+
+def test_task_status_keeps_phase_and_condition_independent() -> None:
+    status = TaskStatus(
+        phase=TaskPhase.REVIEW,
+        condition=TaskCondition.STALE,
+        reason="head_changed",
+    )
+    assert status.phase is TaskPhase.REVIEW
+    assert status.condition is TaskCondition.STALE
+    assert status.reason == "head_changed"
+
+
+def test_review_evidence_is_bound_to_exact_task_contract_and_head() -> None:
+    packet = _packet()
+    evidence = _evidence(packet)
+
+    assert evidence_is_current(evidence, packet, head_sha=HEAD_SHA)
+    assert not evidence_is_current(evidence, packet, head_sha=OTHER_HEAD_SHA)
+    assert not evidence_is_current(evidence, _packet(revision=2), head_sha=HEAD_SHA)
+    assert not evidence_is_current(
+        evidence,
+        _packet(objective="new objective"),
+        head_sha=HEAD_SHA,
+    )
+
+
+def test_integration_evidence_is_also_bound_to_current_main() -> None:
+    packet = _packet()
+    evidence = _evidence(
+        packet,
+        kind=EvidenceKind.INTEGRATION,
+        main_sha=MAIN_SHA,
+    )
+
+    assert evidence_is_current(
+        evidence,
+        packet,
+        head_sha=HEAD_SHA,
+        current_main_sha=MAIN_SHA,
+    )
+    assert not evidence_is_current(
+        evidence,
+        packet,
+        head_sha=HEAD_SHA,
+        current_main_sha=OTHER_MAIN_SHA,
+    )
+    assert not evidence_is_current(evidence, packet, head_sha=HEAD_SHA)
+
+
+def test_evidence_rejects_malformed_sha_and_integration_without_main() -> None:
+    packet = _packet()
+    with pytest.raises(ValueError, match="head_sha"):
+        EvidenceRecord(
+            evidence_kind=EvidenceKind.REVIEW,
+            task_id=packet.task_id,
+            task_revision=packet.task_revision,
+            task_contract_digest=packet.contract_digest(),
+            base_sha=packet.base_sha,
+            head_sha="bad",
+            identifier="evidence-1",
+            result=EvidenceResult.PASS,
+        )
+
+    with pytest.raises(ValueError, match="main_sha"):
+        _evidence(packet, kind=EvidenceKind.INTEGRATION)

--- a/tests/agent_repo/test_coordination_projection.py
+++ b/tests/agent_repo/test_coordination_projection.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from tools.agent_repo.coordination.dashboard import (
+    DashboardSnapshot,
+    render_dashboard,
+)
+from tools.agent_repo.coordination.github_state import (
+    HandoffPacket,
+    TaskStatusRecord,
+    parse_status_comment,
+    render_status_comment,
+    validate_handoff,
+)
+from tools.agent_repo.coordination.leases import grant_lease, heartbeat
+from tools.agent_repo.coordination.model import (
+    Capability,
+    ExecutionMode,
+    TaskCondition,
+    TaskPacket,
+    TaskPhase,
+    WriteScope,
+)
+
+BASE_SHA = "a" * 40
+HEAD_SHA = "b" * 40
+MAIN_SHA = "c" * 40
+NOW = datetime(2026, 9, 12, 12, 0, tzinfo=UTC)
+
+
+def _packet() -> TaskPacket:
+    return TaskPacket(
+        task_id="T500-04",
+        task_revision=2,
+        parent_issue=500,
+        title="GitHub projection",
+        objective="Persist reconstructible coordination state",
+        execution_mode=ExecutionMode.WRITE,
+        write_scope=WriteScope(allow=("tools/agent_repo/**",)),
+        capabilities=(Capability.REPOSITORY_READ, Capability.LEASE_BRANCH_WRITE),
+        base_sha=BASE_SHA,
+    )
+
+
+def _lease():
+    packet = _packet()
+    lease = grant_lease(
+        packet,
+        "agent-a",
+        epoch=3,
+        now=NOW,
+        ttl=timedelta(minutes=15),
+    )
+    return heartbeat(
+        lease,
+        head_sha=HEAD_SHA,
+        observed_at=NOW + timedelta(minutes=1),
+    )
+
+
+def _record() -> TaskStatusRecord:
+    packet = _packet()
+    lease = _lease()
+    return TaskStatusRecord(
+        task_id=packet.task_id,
+        task_revision=packet.task_revision,
+        task_contract_digest=packet.contract_digest(),
+        phase=TaskPhase.EXECUTING,
+        condition=TaskCondition.HEALTHY,
+        base_sha=packet.base_sha,
+        owner=lease.owner,
+        lease_epoch=lease.epoch,
+        lease_branch=lease.lease_branch,
+        head_sha=lease.head_sha,
+        pr_id="502",
+        checkpoint="minimal GREEN",
+    )
+
+
+def test_status_comment_round_trip_is_canonical_and_single_marker() -> None:
+    record = _record()
+    rendered = render_status_comment(record)
+
+    assert rendered.count("<!-- agent-coordination:T500-04 -->") == 1
+    assert parse_status_comment(rendered) == record
+    assert render_status_comment(parse_status_comment(rendered)) == rendered
+
+
+def test_status_comment_parser_fails_closed_on_malformed_or_ambiguous_input() -> None:
+    rendered = render_status_comment(_record())
+    with pytest.raises(ValueError, match="marker"):
+        parse_status_comment(rendered + "\n" + rendered)
+    with pytest.raises(ValueError, match="JSON"):
+        parse_status_comment("<!-- agent-coordination:T500-04 -->\n```json\n{bad}\n```")
+
+    unknown = rendered.replace(
+        '"task_revision": 2,',
+        '"unknown": true,\n  "task_revision": 2,',
+    )
+    with pytest.raises(ValueError, match="unknown field"):
+        parse_status_comment(unknown)
+
+
+def test_status_record_rejects_partial_lease_projection() -> None:
+    packet = _packet()
+    with pytest.raises(ValueError, match="lease fields"):
+        TaskStatusRecord(
+            task_id=packet.task_id,
+            task_revision=packet.task_revision,
+            task_contract_digest=packet.contract_digest(),
+            phase=TaskPhase.EXECUTING,
+            condition=TaskCondition.HEALTHY,
+            base_sha=packet.base_sha,
+            owner="agent-a",
+        )
+
+
+def test_handoff_binds_exact_task_contract_lease_epoch_and_head() -> None:
+    packet = _packet()
+    lease = _lease()
+    handoff = HandoffPacket(
+        task_id=packet.task_id,
+        task_revision=packet.task_revision,
+        task_contract_digest=packet.contract_digest(),
+        lease_epoch=lease.epoch,
+        last_good_head=HEAD_SHA,
+        verified=("targeted tests green",),
+        pending=("full CI",),
+        known_failures=(),
+        do_not_repeat=("root-cause investigation",),
+        evidence_ids=("ci:34600000000", "pr:502"),
+    )
+    validate_handoff(handoff, packet, lease)
+
+    stale_revision = HandoffPacket(
+        task_id=handoff.task_id,
+        task_revision=handoff.task_revision + 1,
+        task_contract_digest=handoff.task_contract_digest,
+        lease_epoch=handoff.lease_epoch,
+        last_good_head=handoff.last_good_head,
+    )
+    with pytest.raises(ValueError, match="task contract"):
+        validate_handoff(stale_revision, packet, lease)
+
+    stale_epoch = HandoffPacket(
+        task_id=handoff.task_id,
+        task_revision=handoff.task_revision,
+        task_contract_digest=handoff.task_contract_digest,
+        lease_epoch=handoff.lease_epoch + 1,
+        last_good_head=handoff.last_good_head,
+    )
+    with pytest.raises(ValueError, match="lease epoch"):
+        validate_handoff(stale_epoch, packet, lease)
+
+    stale_head = HandoffPacket(
+        task_id=handoff.task_id,
+        task_revision=handoff.task_revision,
+        task_contract_digest=handoff.task_contract_digest,
+        lease_epoch=handoff.lease_epoch,
+        last_good_head="d" * 40,
+    )
+    with pytest.raises(ValueError, match="head"):
+        validate_handoff(stale_head, packet, lease)
+
+
+def test_dashboard_is_deterministic_and_surfaces_operator_state() -> None:
+    snapshots = (
+        DashboardSnapshot(
+            task_id="T500-02",
+            title="Scheduler",
+            phase=TaskPhase.COMPLETE,
+            condition=TaskCondition.HEALTHY,
+        ),
+        DashboardSnapshot(
+            task_id="T500-01",
+            title="Model",
+            phase=TaskPhase.REVIEW,
+            condition=TaskCondition.STALE,
+            owner="agent-a",
+            pr_id="502",
+            dependency_summary="waits T500-00",
+            stale_reason="head_changed",
+        ),
+    )
+    rendered = render_dashboard("#500 Agent Coordination Plane", MAIN_SHA, snapshots)
+
+    assert rendered.index("T500-01") < rendered.index("T500-02")
+    assert "review / stale" in rendered
+    assert "agent-a" in rendered
+    assert "PR #502" in rendered
+    assert "waits T500-00" in rendered
+    assert "head_changed" in rendered
+    assert MAIN_SHA in rendered
+    assert "1 / 2 complete" in rendered

--- a/tests/agent_repo/test_coordination_scheduler.py
+++ b/tests/agent_repo/test_coordination_scheduler.py
@@ -108,9 +108,15 @@ def test_dependency_kinds_have_distinct_completion_rules() -> None:
         "TI": _healthy(TaskPhase.READY),
     }
     assert graph.dependencies_satisfied("TH", statuses, evidence_task_ids=frozenset())
-    assert not graph.dependencies_satisfied("TE", statuses, evidence_task_ids=frozenset())
-    assert graph.dependencies_satisfied("TE", statuses, evidence_task_ids=frozenset({"T0"}))
-    assert not graph.dependencies_satisfied("TI", statuses, evidence_task_ids=frozenset({"T0"}))
+    assert not graph.dependencies_satisfied(
+        "TE", statuses, evidence_task_ids=frozenset()
+    )
+    assert graph.dependencies_satisfied(
+        "TE", statuses, evidence_task_ids=frozenset({"T0"})
+    )
+    assert not graph.dependencies_satisfied(
+        "TI", statuses, evidence_task_ids=frozenset({"T0"})
+    )
 
     statuses["T0"] = _healthy(TaskPhase.COMPLETE)
     assert graph.dependencies_satisfied("TI", statuses, evidence_task_ids=frozenset())

--- a/tests/agent_repo/test_coordination_scheduler.py
+++ b/tests/agent_repo/test_coordination_scheduler.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import pytest
+
+from tools.agent_repo.coordination.conflicts import ConflictLevel, classify_conflict
+from tools.agent_repo.coordination.dependencies import DependencyGraph
+from tools.agent_repo.coordination.model import (
+    Capability,
+    DependencyKind,
+    ExecutionMode,
+    RiskLevel,
+    TaskCondition,
+    TaskDependency,
+    TaskPacket,
+    TaskPhase,
+    TaskStatus,
+    WriteScope,
+)
+from tools.agent_repo.coordination.scheduler import ready_tasks
+
+BASE_SHA = "a" * 40
+
+
+def _packet(
+    task_id: str,
+    *,
+    mode: ExecutionMode = ExecutionMode.WRITE,
+    dependencies: tuple[TaskDependency, ...] = (),
+    resource_keys: tuple[str, ...] = (),
+    risk: RiskLevel = RiskLevel.MEDIUM,
+) -> TaskPacket:
+    return TaskPacket(
+        task_id=task_id,
+        task_revision=1,
+        parent_issue=500,
+        title=task_id,
+        objective=f"Implement {task_id}",
+        execution_mode=mode,
+        dependencies=dependencies,
+        write_scope=(
+            WriteScope(allow=(f"tools/{task_id}/**",))
+            if mode is ExecutionMode.WRITE
+            else WriteScope()
+        ),
+        resource_keys=resource_keys,
+        capabilities=(
+            (Capability.REPOSITORY_READ, Capability.LEASE_BRANCH_WRITE)
+            if mode is ExecutionMode.WRITE
+            else (Capability.REPOSITORY_READ,)
+        ),
+        acceptance_criteria=("works",),
+        test_oracle=("deterministic",),
+        base_sha=BASE_SHA,
+        risk=risk,
+    )
+
+
+def _healthy(phase: TaskPhase) -> TaskStatus:
+    return TaskStatus(phase=phase, condition=TaskCondition.HEALTHY)
+
+
+def test_dependency_graph_rejects_missing_targets_and_cycles() -> None:
+    missing = _packet(
+        "T2",
+        dependencies=(TaskDependency("T1", DependencyKind.HARD),),
+    )
+    with pytest.raises(ValueError, match="unknown dependency"):
+        DependencyGraph((missing,))
+
+    first = _packet(
+        "T1",
+        dependencies=(TaskDependency("T2", DependencyKind.HARD),),
+    )
+    second = _packet(
+        "T2",
+        dependencies=(TaskDependency("T1", DependencyKind.HARD),),
+    )
+    with pytest.raises(ValueError, match="cycle"):
+        DependencyGraph((first, second))
+
+
+def test_dependency_kinds_have_distinct_completion_rules() -> None:
+    root = _packet("T0")
+    hard = _packet(
+        "TH",
+        dependencies=(
+            TaskDependency(
+                "T0",
+                DependencyKind.HARD,
+                requires_phase=TaskPhase.VERIFICATION,
+            ),
+        ),
+    )
+    evidence = _packet(
+        "TE",
+        dependencies=(TaskDependency("T0", DependencyKind.EVIDENCE),),
+    )
+    integration = _packet(
+        "TI",
+        dependencies=(TaskDependency("T0", DependencyKind.INTEGRATION),),
+    )
+    graph = DependencyGraph((root, hard, evidence, integration))
+
+    statuses = {
+        "T0": _healthy(TaskPhase.VERIFICATION),
+        "TH": _healthy(TaskPhase.READY),
+        "TE": _healthy(TaskPhase.READY),
+        "TI": _healthy(TaskPhase.READY),
+    }
+    assert graph.dependencies_satisfied("TH", statuses, evidence_task_ids=frozenset())
+    assert not graph.dependencies_satisfied("TE", statuses, evidence_task_ids=frozenset())
+    assert graph.dependencies_satisfied("TE", statuses, evidence_task_ids=frozenset({"T0"}))
+    assert not graph.dependencies_satisfied("TI", statuses, evidence_task_ids=frozenset({"T0"}))
+
+    statuses["T0"] = _healthy(TaskPhase.COMPLETE)
+    assert graph.dependencies_satisfied("TI", statuses, evidence_task_ids=frozenset())
+
+
+def test_read_only_snapshot_work_does_not_conflict_on_shared_read_resources() -> None:
+    left = _packet(
+        "R1",
+        mode=ExecutionMode.READ_ONLY,
+        resource_keys=("identity:market-dataset", "authority:feature-computation"),
+    )
+    right = _packet(
+        "R2",
+        mode=ExecutionMode.READ_ONLY,
+        resource_keys=("identity:market-dataset", "authority:feature-computation"),
+    )
+    assert classify_conflict(left, right) is ConflictLevel.NONE
+
+
+def test_conflict_model_distinguishes_hard_soft_and_none() -> None:
+    assert (
+        classify_conflict(
+            _packet("A", resource_keys=("file:docs/**",)),
+            _packet("B", resource_keys=("file:docs/AGENTS.md",)),
+        )
+        is ConflictLevel.HARD
+    )
+    for key in (
+        "identity:market-dataset",
+        "schema:candidate-run-v2",
+        "side-effect:github-task-status",
+    ):
+        assert (
+            classify_conflict(
+                _packet("A", resource_keys=(key,)),
+                _packet("B", resource_keys=(key,)),
+            )
+            is ConflictLevel.HARD
+        )
+    for key in (
+        "authority:experiment-analysis",
+        "workflow:canonical-m2-bootstrap",
+        "artifact:evidence-set",
+    ):
+        assert (
+            classify_conflict(
+                _packet("A", resource_keys=(key,)),
+                _packet("B", resource_keys=(key,)),
+            )
+            is ConflictLevel.SOFT
+        )
+    assert (
+        classify_conflict(
+            _packet("A", resource_keys=("authority:a",)),
+            _packet("B", resource_keys=("authority:b",)),
+        )
+        is ConflictLevel.NONE
+    )
+
+
+def test_conflict_model_fails_closed_for_unknown_resource_namespace() -> None:
+    with pytest.raises(ValueError, match="resource namespace"):
+        classify_conflict(
+            _packet("A", resource_keys=("mystery:x",)),
+            _packet("B"),
+        )
+
+
+def test_scheduler_returns_dependency_satisfied_nonconflicting_ready_set() -> None:
+    root = _packet("T0")
+    first = _packet(
+        "T1",
+        dependencies=(TaskDependency("T0", DependencyKind.HARD),),
+        resource_keys=("identity:shared",),
+        risk=RiskLevel.LOW,
+    )
+    second = _packet(
+        "T2",
+        dependencies=(TaskDependency("T0", DependencyKind.HARD),),
+        resource_keys=("identity:shared",),
+        risk=RiskLevel.HIGH,
+    )
+    independent = _packet(
+        "T3",
+        dependencies=(TaskDependency("T0", DependencyKind.HARD),),
+        resource_keys=("authority:other",),
+    )
+    packets = (root, first, second, independent)
+    statuses = {
+        "T0": _healthy(TaskPhase.COMPLETE),
+        "T1": _healthy(TaskPhase.READY),
+        "T2": _healthy(TaskPhase.READY),
+        "T3": _healthy(TaskPhase.READY),
+    }
+
+    result = ready_tasks(
+        packets,
+        statuses,
+        leased_task_ids=frozenset(),
+        evidence_task_ids=frozenset(),
+    )
+
+    assert "T1" in result
+    assert "T2" not in result
+    assert "T3" in result
+
+
+def test_scheduler_excludes_leased_blocked_and_active_hard_conflicts() -> None:
+    active = _packet("ACTIVE", resource_keys=("identity:shared",))
+    conflict = _packet("CONFLICT", resource_keys=("identity:shared",))
+    leased = _packet("LEASED", resource_keys=("authority:leased",))
+    blocked = _packet("BLOCKED", resource_keys=("authority:blocked",))
+    ready = _packet("READY", resource_keys=("authority:ready",))
+    packets = (active, conflict, leased, blocked, ready)
+    statuses = {
+        "ACTIVE": _healthy(TaskPhase.EXECUTING),
+        "CONFLICT": _healthy(TaskPhase.READY),
+        "LEASED": _healthy(TaskPhase.READY),
+        "BLOCKED": TaskStatus(TaskPhase.READY, TaskCondition.BLOCKED, "external"),
+        "READY": _healthy(TaskPhase.READY),
+    }
+
+    assert ready_tasks(
+        packets,
+        statuses,
+        leased_task_ids=frozenset({"ACTIVE", "LEASED"}),
+        evidence_task_ids=frozenset(),
+    ) == ("READY",)

--- a/tools/agent_repo/coordination/__init__.py
+++ b/tools/agent_repo/coordination/__init__.py
@@ -1,0 +1,39 @@
+"""Agent Coordination Plane primitives.
+
+This package is repository tooling. Production ``trade_rl`` modules must not depend on it.
+"""
+
+from tools.agent_repo.coordination.model import (
+    Capability,
+    DependencyKind,
+    EvidenceKind,
+    EvidenceRecord,
+    EvidenceResult,
+    ExecutionMode,
+    RiskLevel,
+    TaskCondition,
+    TaskDependency,
+    TaskPacket,
+    TaskPhase,
+    TaskStatus,
+    WriteScope,
+)
+from tools.agent_repo.coordination.state import evidence_is_current, validate_transition
+
+__all__ = [
+    "Capability",
+    "DependencyKind",
+    "EvidenceKind",
+    "EvidenceRecord",
+    "EvidenceResult",
+    "ExecutionMode",
+    "RiskLevel",
+    "TaskCondition",
+    "TaskDependency",
+    "TaskPacket",
+    "TaskPhase",
+    "TaskStatus",
+    "WriteScope",
+    "evidence_is_current",
+    "validate_transition",
+]

--- a/tools/agent_repo/coordination/conflicts.py
+++ b/tools/agent_repo/coordination/conflicts.py
@@ -1,0 +1,91 @@
+"""Semantic and side-effect conflict classification for coordinated tasks."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from tools.agent_repo.coordination.model import ExecutionMode, TaskPacket
+
+_ALLOWED_NAMESPACES = {
+    "file",
+    "authority",
+    "identity",
+    "schema",
+    "workflow",
+    "artifact",
+    "side-effect",
+}
+_HARD_NAMESPACES = {"identity", "schema", "side-effect"}
+_SOFT_NAMESPACES = {"authority", "workflow", "artifact"}
+
+
+class ConflictLevel(str, Enum):
+    NONE = "none"
+    SOFT = "soft"
+    HARD = "hard"
+
+
+def _split_key(key: str) -> tuple[str, str]:
+    namespace, separator, value = key.partition(":")
+    if not separator or namespace not in _ALLOWED_NAMESPACES or not value:
+        raise ValueError(f"unknown resource namespace: {key}")
+    return namespace, value
+
+
+def _file_prefix(value: str) -> str:
+    normalized = value.replace("\\", "/").strip("/")
+    if not normalized or ".." in normalized.split("/"):
+        raise ValueError(f"invalid file resource key: {value}")
+    for suffix in ("/**", "/*"):
+        if normalized.endswith(suffix):
+            normalized = normalized[: -len(suffix)].rstrip("/")
+    return normalized
+
+
+def _file_overlap(left: str, right: str) -> bool:
+    left_prefix = _file_prefix(left)
+    right_prefix = _file_prefix(right)
+    return (
+        left_prefix == right_prefix
+        or left_prefix.startswith(f"{right_prefix}/")
+        or right_prefix.startswith(f"{left_prefix}/")
+    )
+
+
+def classify_conflict(left: TaskPacket, right: TaskPacket) -> ConflictLevel:
+    """Classify whether two tasks can safely execute concurrently."""
+
+    left_keys = [_split_key(key) for key in left.resource_keys]
+    right_keys = [_split_key(key) for key in right.resource_keys]
+
+    shared_side_effect = any(
+        left_namespace == right_namespace == "side-effect" and left_value == right_value
+        for left_namespace, left_value in left_keys
+        for right_namespace, right_value in right_keys
+    )
+    if (
+        left.execution_mode is ExecutionMode.READ_ONLY
+        and right.execution_mode is ExecutionMode.READ_ONLY
+        and not shared_side_effect
+    ):
+        return ConflictLevel.NONE
+
+    level = ConflictLevel.NONE
+    for left_namespace, left_value in left_keys:
+        for right_namespace, right_value in right_keys:
+            if left_namespace != right_namespace:
+                continue
+            if left_namespace == "file":
+                if _file_overlap(left_value, right_value):
+                    return ConflictLevel.HARD
+                continue
+            if left_value != right_value:
+                continue
+            if left_namespace in _HARD_NAMESPACES:
+                return ConflictLevel.HARD
+            if left_namespace in _SOFT_NAMESPACES:
+                level = ConflictLevel.SOFT
+    return level
+
+
+__all__ = ["ConflictLevel", "classify_conflict"]

--- a/tools/agent_repo/coordination/dependencies.py
+++ b/tools/agent_repo/coordination/dependencies.py
@@ -1,0 +1,102 @@
+"""Dependency graph rules for Agent Coordination Plane tasks."""
+
+from __future__ import annotations
+
+from collections.abc import Collection, Mapping, Sequence
+
+from tools.agent_repo.coordination.model import (
+    DependencyKind,
+    TaskCondition,
+    TaskPacket,
+    TaskPhase,
+    TaskStatus,
+)
+
+_PHASE_ORDER = {
+    TaskPhase.PLANNED: 0,
+    TaskPhase.READY: 1,
+    TaskPhase.EXECUTING: 2,
+    TaskPhase.REVIEW: 3,
+    TaskPhase.VERIFICATION: 4,
+    TaskPhase.INTEGRATION: 5,
+    TaskPhase.COMPLETE: 6,
+}
+
+
+class DependencyGraph:
+    """Validated acyclic task dependency graph."""
+
+    def __init__(self, packets: Sequence[TaskPacket]) -> None:
+        self._packets = {packet.task_id: packet for packet in packets}
+        if len(self._packets) != len(packets):
+            raise ValueError("duplicate task_id in dependency graph")
+        for packet in packets:
+            for dependency in packet.dependencies:
+                if dependency.task_id not in self._packets:
+                    raise ValueError(
+                        f"unknown dependency {dependency.task_id} for {packet.task_id}"
+                    )
+        self._assert_acyclic()
+
+    @property
+    def task_ids(self) -> tuple[str, ...]:
+        return tuple(sorted(self._packets))
+
+    def _assert_acyclic(self) -> None:
+        visiting: set[str] = set()
+        visited: set[str] = set()
+
+        def visit(task_id: str) -> None:
+            if task_id in visiting:
+                raise ValueError("dependency graph contains a cycle")
+            if task_id in visited:
+                return
+            visiting.add(task_id)
+            for dependency in self._packets[task_id].dependencies:
+                visit(dependency.task_id)
+            visiting.remove(task_id)
+            visited.add(task_id)
+
+        for task_id in sorted(self._packets):
+            visit(task_id)
+
+    def dependencies_satisfied(
+        self,
+        task_id: str,
+        statuses: Mapping[str, TaskStatus],
+        *,
+        evidence_task_ids: Collection[str],
+    ) -> bool:
+        packet = self._packets[task_id]
+        evidence_ids = set(evidence_task_ids)
+        for dependency in packet.dependencies:
+            status = statuses.get(dependency.task_id)
+            if dependency.kind is DependencyKind.EVIDENCE:
+                if dependency.task_id not in evidence_ids:
+                    return False
+                continue
+            if status is None or status.condition is not TaskCondition.HEALTHY:
+                return False
+            if dependency.kind is DependencyKind.INTEGRATION:
+                if status.phase is not TaskPhase.COMPLETE:
+                    return False
+                continue
+            if _PHASE_ORDER[status.phase] < _PHASE_ORDER[dependency.requires_phase]:
+                return False
+        return True
+
+    def descendant_count(self, task_id: str) -> int:
+        descendants: set[str] = set()
+        frontier = [task_id]
+        while frontier:
+            parent = frontier.pop()
+            for candidate in self._packets.values():
+                if candidate.task_id in descendants:
+                    continue
+                if any(dep.task_id == parent for dep in candidate.dependencies):
+                    descendants.add(candidate.task_id)
+                    frontier.append(candidate.task_id)
+        return len(descendants)
+
+
+__all__ = ["DependencyGraph"]

--- a/tools/agent_repo/coordination/leases.py
+++ b/tools/agent_repo/coordination/leases.py
@@ -1,0 +1,283 @@
+"""Lease fencing and recovery rules for coordinated write tasks."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, replace
+from datetime import datetime, timedelta
+from enum import Enum
+
+from tools.agent_repo.coordination.model import ExecutionMode, TaskPacket
+
+_FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+_FULL_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+_TASK_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_OWNER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._ -]*$")
+
+
+class ReconciliationDecision(str, Enum):
+    RESUME = "resume"
+    SALVAGE = "salvage"
+    SUPERSEDE = "supersede"
+    REASSIGN = "reassign"
+
+
+def _require_aware(value: datetime, *, field_name: str) -> None:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field_name} must be timezone-aware")
+
+
+def _require_sha(value: str, *, field_name: str) -> None:
+    if not _FULL_SHA_RE.fullmatch(value):
+        raise ValueError(f"{field_name} must be a lowercase 40-hex Git SHA")
+
+
+def _require_digest(value: str, *, field_name: str) -> None:
+    if not _FULL_DIGEST_RE.fullmatch(value):
+        raise ValueError(f"{field_name} must be a lowercase 64-hex SHA-256 digest")
+
+
+def _owner_slug(owner: str) -> str:
+    if not _OWNER_RE.fullmatch(owner) or ".." in owner:
+        raise ValueError("owner must contain only safe branch-name characters")
+    slug = re.sub(r"[ ._]+", "-", owner.strip().lower())
+    slug = re.sub(r"-+", "-", slug).strip("-")
+    if not slug:
+        raise ValueError("owner must produce a non-empty branch slug")
+    return slug
+
+
+def lease_branch_name(task_id: str, epoch: int, owner: str) -> str:
+    """Return the branch fence for one concrete lease epoch."""
+
+    if not _TASK_ID_RE.fullmatch(task_id):
+        raise ValueError("task_id is invalid for a lease branch")
+    if isinstance(epoch, bool) or epoch < 1:
+        raise ValueError("epoch must be a positive integer")
+    return f"agent/{task_id}/e{epoch:04d}-{_owner_slug(owner)}"
+
+
+@dataclass(frozen=True)
+class LeaseRecord:
+    task_id: str
+    task_revision: int
+    task_contract_digest: str
+    base_sha: str
+    owner: str
+    epoch: int
+    lease_branch: str
+    head_sha: str | None
+    last_heartbeat_at: datetime
+    expires_at: datetime
+    ttl_seconds: float
+
+    def __post_init__(self) -> None:
+        if not _TASK_ID_RE.fullmatch(self.task_id):
+            raise ValueError("task_id is invalid")
+        if isinstance(self.task_revision, bool) or self.task_revision < 1:
+            raise ValueError("task_revision must be a positive integer")
+        _require_digest(self.task_contract_digest, field_name="task_contract_digest")
+        _require_sha(self.base_sha, field_name="base_sha")
+        if self.head_sha is not None:
+            _require_sha(self.head_sha, field_name="head_sha")
+        if isinstance(self.epoch, bool) or self.epoch < 1:
+            raise ValueError("epoch must be a positive integer")
+        expected_branch = lease_branch_name(self.task_id, self.epoch, self.owner)
+        if self.lease_branch != expected_branch:
+            raise ValueError("lease_branch does not match task/epoch/owner fence")
+        _require_aware(self.last_heartbeat_at, field_name="last_heartbeat_at")
+        _require_aware(self.expires_at, field_name="expires_at")
+        if self.ttl_seconds <= 0.0:
+            raise ValueError("ttl_seconds must be positive")
+        if self.expires_at <= self.last_heartbeat_at:
+            raise ValueError("expires_at must be after last_heartbeat_at")
+
+
+@dataclass(frozen=True)
+class LeaseReconciliation:
+    task_id: str
+    expired_epoch: int
+    observed_branch: str
+    observed_head_sha: str | None
+    decision: ReconciliationDecision
+    pr_ids: tuple[str, ...] = ()
+    ci_ids: tuple[str, ...] = ()
+    artifact_ids: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not _TASK_ID_RE.fullmatch(self.task_id):
+            raise ValueError("reconciliation task_id is invalid")
+        if isinstance(self.expired_epoch, bool) or self.expired_epoch < 1:
+            raise ValueError("reconciliation expired_epoch must be positive")
+        if not self.observed_branch.strip():
+            raise ValueError("reconciliation observed_branch must be non-empty")
+        if self.observed_head_sha is not None:
+            _require_sha(self.observed_head_sha, field_name="observed_head_sha")
+        object.__setattr__(self, "decision", ReconciliationDecision(self.decision))
+        for field_name in ("pr_ids", "ci_ids", "artifact_ids"):
+            values = tuple(str(value) for value in getattr(self, field_name))
+            if any(not value.strip() for value in values):
+                raise ValueError(f"reconciliation {field_name} must be non-empty")
+            if len(set(values)) != len(values):
+                raise ValueError(f"reconciliation {field_name} contains duplicates")
+            object.__setattr__(self, field_name, values)
+
+
+def _validate_grant_time(now: datetime, ttl: timedelta) -> float:
+    _require_aware(now, field_name="now")
+    ttl_seconds = ttl.total_seconds()
+    if ttl_seconds <= 0.0:
+        raise ValueError("lease ttl must be positive")
+    return ttl_seconds
+
+
+def _validate_reconciliation(
+    previous: LeaseRecord,
+    reconciliation: LeaseReconciliation | None,
+) -> LeaseReconciliation:
+    if reconciliation is None:
+        raise ValueError("expired lease requires reconciliation before reassignment")
+    if (
+        reconciliation.task_id != previous.task_id
+        or reconciliation.expired_epoch != previous.epoch
+        or reconciliation.observed_branch != previous.lease_branch
+    ):
+        raise ValueError("reconciliation does not match the expired lease")
+    return reconciliation
+
+
+def grant_lease(
+    packet: TaskPacket,
+    owner: str,
+    *,
+    epoch: int,
+    now: datetime,
+    ttl: timedelta,
+    previous: LeaseRecord | None = None,
+    reconciliation: LeaseReconciliation | None = None,
+) -> LeaseRecord:
+    """Grant or renew a fenced lease for a write task."""
+
+    if packet.execution_mode is ExecutionMode.READ_ONLY:
+        raise ValueError("read_only tasks do not receive writable leases")
+    ttl_seconds = _validate_grant_time(now, ttl)
+    owner_slug = _owner_slug(owner)
+    del owner_slug  # validation only; branch construction performs canonical slugging
+
+    if previous is None:
+        if reconciliation is not None:
+            raise ValueError("reconciliation is only valid with a previous lease")
+        branch = lease_branch_name(packet.task_id, epoch, owner)
+        return LeaseRecord(
+            task_id=packet.task_id,
+            task_revision=packet.task_revision,
+            task_contract_digest=packet.contract_digest(),
+            base_sha=packet.base_sha,
+            owner=owner,
+            epoch=epoch,
+            lease_branch=branch,
+            head_sha=None,
+            last_heartbeat_at=now,
+            expires_at=now + ttl,
+            ttl_seconds=ttl_seconds,
+        )
+
+    if previous.task_id != packet.task_id:
+        raise ValueError("previous lease belongs to a different task")
+    if now < previous.expires_at:
+        raise ValueError("active lease cannot be replaced")
+
+    resolved = _validate_reconciliation(previous, reconciliation)
+    if resolved.decision is ReconciliationDecision.RESUME:
+        if owner != previous.owner:
+            raise ValueError("resume must keep the previous owner")
+        if epoch != previous.epoch:
+            raise ValueError("resume must keep the previous epoch")
+        if (
+            previous.task_revision != packet.task_revision
+            or previous.task_contract_digest != packet.contract_digest()
+            or previous.base_sha != packet.base_sha
+        ):
+            raise ValueError("resume cannot cross task contract or base changes")
+        return LeaseRecord(
+            task_id=packet.task_id,
+            task_revision=packet.task_revision,
+            task_contract_digest=packet.contract_digest(),
+            base_sha=packet.base_sha,
+            owner=owner,
+            epoch=epoch,
+            lease_branch=previous.lease_branch,
+            head_sha=resolved.observed_head_sha,
+            last_heartbeat_at=now,
+            expires_at=now + ttl,
+            ttl_seconds=ttl_seconds,
+        )
+
+    if epoch != previous.epoch + 1:
+        raise ValueError("reassignment must use the next epoch")
+    branch = lease_branch_name(packet.task_id, epoch, owner)
+    if branch == previous.lease_branch:
+        raise ValueError("reassignment must use a new fenced lease branch")
+    return LeaseRecord(
+        task_id=packet.task_id,
+        task_revision=packet.task_revision,
+        task_contract_digest=packet.contract_digest(),
+        base_sha=packet.base_sha,
+        owner=owner,
+        epoch=epoch,
+        lease_branch=branch,
+        head_sha=None,
+        last_heartbeat_at=now,
+        expires_at=now + ttl,
+        ttl_seconds=ttl_seconds,
+    )
+
+
+def lease_is_current(
+    lease: LeaseRecord,
+    packet: TaskPacket,
+    *,
+    now: datetime,
+) -> bool:
+    """Return whether a lease still owns the exact current task contract."""
+
+    _require_aware(now, field_name="now")
+    return (
+        lease.task_id == packet.task_id
+        and lease.task_revision == packet.task_revision
+        and lease.task_contract_digest == packet.contract_digest()
+        and lease.base_sha == packet.base_sha
+        and now < lease.expires_at
+    )
+
+
+def heartbeat(
+    lease: LeaseRecord,
+    *,
+    head_sha: str,
+    observed_at: datetime,
+) -> LeaseRecord:
+    """Renew one lease after observing progress at an exact remote HEAD."""
+
+    _require_sha(head_sha, field_name="head_sha")
+    _require_aware(observed_at, field_name="observed_at")
+    if observed_at < lease.last_heartbeat_at:
+        raise ValueError("heartbeat time must be monotonic")
+    ttl = timedelta(seconds=lease.ttl_seconds)
+    return replace(
+        lease,
+        head_sha=head_sha,
+        last_heartbeat_at=observed_at,
+        expires_at=observed_at + ttl,
+    )
+
+
+__all__ = [
+    "LeaseRecord",
+    "LeaseReconciliation",
+    "ReconciliationDecision",
+    "grant_lease",
+    "heartbeat",
+    "lease_branch_name",
+    "lease_is_current",
+]

--- a/tools/agent_repo/coordination/model.py
+++ b/tools/agent_repo/coordination/model.py
@@ -183,9 +183,7 @@ class TaskPacket:
             self,
             "dependencies",
             tuple(
-                value
-                if isinstance(value, TaskDependency)
-                else TaskDependency(**value)  # type: ignore[arg-type]
+                value if isinstance(value, TaskDependency) else TaskDependency(**value)  # type: ignore[arg-type]
                 for value in self.dependencies
             ),
         )

--- a/tools/agent_repo/coordination/model.py
+++ b/tools/agent_repo/coordination/model.py
@@ -179,14 +179,7 @@ class TaskPacket:
             "capabilities",
             tuple(Capability(value) for value in self.capabilities),
         )
-        object.__setattr__(
-            self,
-            "dependencies",
-            tuple(
-                value if isinstance(value, TaskDependency) else TaskDependency(**value)  # type: ignore[arg-type]
-                for value in self.dependencies
-            ),
-        )
+        object.__setattr__(self, "dependencies", tuple(self.dependencies))
 
         dependency_ids = [value.task_id for value in self.dependencies]
         if len(set(dependency_ids)) != len(dependency_ids):

--- a/tools/agent_repo/coordination/model.py
+++ b/tools/agent_repo/coordination/model.py
@@ -1,0 +1,319 @@
+"""Immutable contracts for repository-local multi-agent coordination."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+_FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+_FULL_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+_TASK_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_RESOURCE_KEY_RE = re.compile(r"^[a-z][a-z0-9_-]*:.+$")
+
+
+class ExecutionMode(str, Enum):
+    READ_ONLY = "read_only"
+    WRITE = "write"
+
+
+class TaskPhase(str, Enum):
+    PLANNED = "planned"
+    READY = "ready"
+    EXECUTING = "executing"
+    REVIEW = "review"
+    VERIFICATION = "verification"
+    INTEGRATION = "integration"
+    COMPLETE = "complete"
+
+
+class TaskCondition(str, Enum):
+    HEALTHY = "healthy"
+    BLOCKED = "blocked"
+    STALE = "stale"
+    FAILED = "failed"
+    CONFLICTED = "conflicted"
+
+
+class RiskLevel(str, Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class DependencyKind(str, Enum):
+    HARD = "hard"
+    EVIDENCE = "evidence"
+    INTEGRATION = "integration"
+
+
+class EvidenceKind(str, Enum):
+    REVIEW = "review"
+    TEST = "test"
+    CI = "ci"
+    ARTIFACT = "artifact"
+    INTEGRATION = "integration"
+    POST_MERGE = "post_merge"
+
+
+class EvidenceResult(str, Enum):
+    PASS = "pass"
+    FAIL = "fail"
+
+
+class Capability(str, Enum):
+    REPOSITORY_READ = "repository_read"
+    LEASE_BRANCH_WRITE = "lease_branch_write"
+    DRAFT_PR_WRITE = "draft_pr_write"
+    ISSUE_COMMENT_WRITE = "issue_comment_write"
+    REVIEW_WRITE = "review_write"
+    CI_READ = "ci_read"
+    ARTIFACT_READ = "artifact_read"
+    INTEGRATION_WRITE = "integration_write"
+    MERGE_WRITE = "merge_write"
+
+
+def _tuple_strings(values: tuple[str, ...] | list[str]) -> tuple[str, ...]:
+    return tuple(str(value) for value in values)
+
+
+def _require_full_sha(value: str, *, field_name: str) -> None:
+    if not _FULL_SHA_RE.fullmatch(value):
+        raise ValueError(f"{field_name} must be a lowercase 40-hex Git SHA")
+
+
+def _require_digest(value: str, *, field_name: str) -> None:
+    if not _FULL_DIGEST_RE.fullmatch(value):
+        raise ValueError(f"{field_name} must be a lowercase 64-hex SHA-256 digest")
+
+
+@dataclass(frozen=True)
+class WriteScope:
+    allow: tuple[str, ...] = ()
+    deny: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "allow", _tuple_strings(self.allow))
+        object.__setattr__(self, "deny", _tuple_strings(self.deny))
+        if len(set(self.allow)) != len(self.allow):
+            raise ValueError("duplicate write allow path")
+        if len(set(self.deny)) != len(self.deny):
+            raise ValueError("duplicate write deny path")
+        if any(not value.strip() for value in (*self.allow, *self.deny)):
+            raise ValueError("write scope paths must be non-empty")
+
+    def canonical_payload(self) -> dict[str, list[str]]:
+        return {
+            "allow": sorted(self.allow),
+            "deny": sorted(self.deny),
+        }
+
+
+@dataclass(frozen=True)
+class TaskDependency:
+    task_id: str
+    kind: DependencyKind
+    requires_phase: TaskPhase = TaskPhase.COMPLETE
+
+    def __post_init__(self) -> None:
+        if not _TASK_ID_RE.fullmatch(self.task_id):
+            raise ValueError("dependency task_id is invalid")
+        object.__setattr__(self, "kind", DependencyKind(self.kind))
+        object.__setattr__(self, "requires_phase", TaskPhase(self.requires_phase))
+
+    def canonical_payload(self) -> dict[str, str]:
+        return {
+            "task_id": self.task_id,
+            "kind": self.kind.value,
+            "requires_phase": self.requires_phase.value,
+        }
+
+
+@dataclass(frozen=True)
+class TaskPacket:
+    task_id: str
+    task_revision: int
+    parent_issue: int | None
+    title: str
+    objective: str
+    execution_mode: ExecutionMode
+    non_goals: tuple[str, ...] = ()
+    dependencies: tuple[TaskDependency, ...] = ()
+    write_scope: WriteScope = field(default_factory=WriteScope)
+    resource_keys: tuple[str, ...] = ()
+    capabilities: tuple[Capability, ...] = (Capability.REPOSITORY_READ,)
+    acceptance_criteria: tuple[str, ...] = ()
+    test_oracle: tuple[str, ...] = ()
+    base_sha: str = ""
+    risk: RiskLevel = RiskLevel.MEDIUM
+    deliverable: str = "pull_request"
+
+    def __post_init__(self) -> None:
+        if not _TASK_ID_RE.fullmatch(self.task_id):
+            raise ValueError("task_id must be a non-empty stable identifier")
+        if isinstance(self.task_revision, bool) or self.task_revision < 1:
+            raise ValueError("task_revision must be a positive integer")
+        if self.parent_issue is not None and (
+            isinstance(self.parent_issue, bool) or self.parent_issue < 1
+        ):
+            raise ValueError("parent_issue must be a positive integer")
+        if not self.objective.strip():
+            raise ValueError("objective must be non-empty")
+        if not self.title.strip():
+            raise ValueError("title must be non-empty")
+        _require_full_sha(self.base_sha, field_name="base_sha")
+
+        object.__setattr__(self, "execution_mode", ExecutionMode(self.execution_mode))
+        object.__setattr__(self, "risk", RiskLevel(self.risk))
+        object.__setattr__(self, "non_goals", _tuple_strings(self.non_goals))
+        object.__setattr__(self, "resource_keys", _tuple_strings(self.resource_keys))
+        object.__setattr__(
+            self, "acceptance_criteria", _tuple_strings(self.acceptance_criteria)
+        )
+        object.__setattr__(self, "test_oracle", _tuple_strings(self.test_oracle))
+        object.__setattr__(
+            self,
+            "capabilities",
+            tuple(Capability(value) for value in self.capabilities),
+        )
+        object.__setattr__(
+            self,
+            "dependencies",
+            tuple(
+                value
+                if isinstance(value, TaskDependency)
+                else TaskDependency(**value)  # type: ignore[arg-type]
+                for value in self.dependencies
+            ),
+        )
+
+        dependency_ids = [value.task_id for value in self.dependencies]
+        if len(set(dependency_ids)) != len(dependency_ids):
+            raise ValueError("duplicate dependency task_id")
+        if self.task_id in dependency_ids:
+            raise ValueError("task cannot depend on itself")
+        if len(set(self.resource_keys)) != len(self.resource_keys):
+            raise ValueError("duplicate resource key")
+        if len(set(self.capabilities)) != len(self.capabilities):
+            raise ValueError("duplicate capability")
+        for key in self.resource_keys:
+            if not _RESOURCE_KEY_RE.fullmatch(key):
+                raise ValueError(f"invalid resource key: {key}")
+
+        if self.execution_mode is ExecutionMode.READ_ONLY:
+            if self.write_scope.allow:
+                raise ValueError("read_only task cannot declare writable allow paths")
+            forbidden = {
+                Capability.LEASE_BRANCH_WRITE,
+                Capability.DRAFT_PR_WRITE,
+                Capability.INTEGRATION_WRITE,
+                Capability.MERGE_WRITE,
+            }
+            if forbidden.intersection(self.capabilities):
+                raise ValueError("read_only task cannot request write capabilities")
+        elif not self.write_scope.allow:
+            raise ValueError("write task requires at least one allow path")
+
+    def canonical_payload(self) -> dict[str, Any]:
+        dependencies = sorted(
+            (value.canonical_payload() for value in self.dependencies),
+            key=lambda value: (
+                value["task_id"],
+                value["kind"],
+                value["requires_phase"],
+            ),
+        )
+        return {
+            "schema": "agent_task_v1",
+            "task_id": self.task_id,
+            "task_revision": self.task_revision,
+            "parent_issue": self.parent_issue,
+            "objective": self.objective,
+            "execution_mode": self.execution_mode.value,
+            "non_goals": list(self.non_goals),
+            "dependencies": dependencies,
+            "write_scope": self.write_scope.canonical_payload(),
+            "resource_keys": sorted(self.resource_keys),
+            "capabilities": sorted(value.value for value in self.capabilities),
+            "acceptance_criteria": list(self.acceptance_criteria),
+            "test_oracle": list(self.test_oracle),
+            "base_sha": self.base_sha,
+            "risk": self.risk.value,
+            "deliverable": self.deliverable,
+        }
+
+    def contract_digest(self) -> str:
+        encoded = json.dumps(
+            self.canonical_payload(),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+
+@dataclass(frozen=True)
+class TaskStatus:
+    phase: TaskPhase
+    condition: TaskCondition = TaskCondition.HEALTHY
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "phase", TaskPhase(self.phase))
+        object.__setattr__(self, "condition", TaskCondition(self.condition))
+        if self.reason is not None and not self.reason.strip():
+            raise ValueError("status reason must be non-empty when provided")
+
+
+@dataclass(frozen=True)
+class EvidenceRecord:
+    evidence_kind: EvidenceKind
+    task_id: str
+    task_revision: int
+    task_contract_digest: str
+    base_sha: str
+    head_sha: str
+    identifier: str
+    result: EvidenceResult
+    main_sha: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "evidence_kind", EvidenceKind(self.evidence_kind))
+        object.__setattr__(self, "result", EvidenceResult(self.result))
+        if not _TASK_ID_RE.fullmatch(self.task_id):
+            raise ValueError("task_id is invalid")
+        if isinstance(self.task_revision, bool) or self.task_revision < 1:
+            raise ValueError("task_revision must be a positive integer")
+        _require_digest(
+            self.task_contract_digest,
+            field_name="task_contract_digest",
+        )
+        _require_full_sha(self.base_sha, field_name="base_sha")
+        _require_full_sha(self.head_sha, field_name="head_sha")
+        if not self.identifier.strip():
+            raise ValueError("evidence identifier must be non-empty")
+        if self.main_sha is not None:
+            _require_full_sha(self.main_sha, field_name="main_sha")
+        if self.evidence_kind in {EvidenceKind.INTEGRATION, EvidenceKind.POST_MERGE}:
+            if self.main_sha is None:
+                raise ValueError("main_sha is required for integration evidence")
+
+
+__all__ = [
+    "Capability",
+    "DependencyKind",
+    "EvidenceKind",
+    "EvidenceRecord",
+    "EvidenceResult",
+    "ExecutionMode",
+    "RiskLevel",
+    "TaskCondition",
+    "TaskDependency",
+    "TaskPacket",
+    "TaskPhase",
+    "TaskStatus",
+    "WriteScope",
+]

--- a/tools/agent_repo/coordination/scheduler.py
+++ b/tools/agent_repo/coordination/scheduler.py
@@ -1,0 +1,93 @@
+"""Deterministic ready-set selection for Agent Coordination Plane tasks."""
+
+from __future__ import annotations
+
+from collections.abc import Collection, Mapping, Sequence
+
+from tools.agent_repo.coordination.conflicts import ConflictLevel, classify_conflict
+from tools.agent_repo.coordination.dependencies import DependencyGraph
+from tools.agent_repo.coordination.model import (
+    RiskLevel,
+    TaskCondition,
+    TaskPacket,
+    TaskPhase,
+    TaskStatus,
+)
+
+_RISK_ORDER = {
+    RiskLevel.LOW: 0,
+    RiskLevel.MEDIUM: 1,
+    RiskLevel.HIGH: 2,
+}
+
+
+def ready_tasks(
+    packets: Sequence[TaskPacket],
+    statuses: Mapping[str, TaskStatus],
+    *,
+    leased_task_ids: Collection[str],
+    evidence_task_ids: Collection[str],
+) -> tuple[str, ...]:
+    """Return a deterministic concurrently dispatchable set of task ids."""
+
+    graph = DependencyGraph(packets)
+    packet_by_id = {packet.task_id: packet for packet in packets}
+    leased = set(leased_task_ids)
+
+    unknown_status = set(statuses) - set(packet_by_id)
+    if unknown_status:
+        raise ValueError(f"status references unknown task: {sorted(unknown_status)[0]}")
+    unknown_leases = leased - set(packet_by_id)
+    if unknown_leases:
+        raise ValueError(f"lease references unknown task: {sorted(unknown_leases)[0]}")
+
+    active = [
+        packet_by_id[task_id]
+        for task_id, status in statuses.items()
+        if status.phase is TaskPhase.EXECUTING
+        and status.condition is TaskCondition.HEALTHY
+    ]
+    candidates: list[TaskPacket] = []
+    for packet in packets:
+        status = statuses.get(packet.task_id)
+        if status is None:
+            raise ValueError(f"missing status for task: {packet.task_id}")
+        if status.phase is not TaskPhase.READY:
+            continue
+        if status.condition is not TaskCondition.HEALTHY:
+            continue
+        if packet.task_id in leased:
+            continue
+        if not graph.dependencies_satisfied(
+            packet.task_id,
+            statuses,
+            evidence_task_ids=evidence_task_ids,
+        ):
+            continue
+        if any(
+            classify_conflict(packet, running) is ConflictLevel.HARD
+            for running in active
+        ):
+            continue
+        candidates.append(packet)
+
+    candidates.sort(
+        key=lambda packet: (
+            -graph.descendant_count(packet.task_id),
+            _RISK_ORDER[packet.risk],
+            packet.task_id,
+        )
+    )
+
+    selected: list[TaskPacket] = []
+    for candidate in candidates:
+        if any(
+            classify_conflict(candidate, existing) is ConflictLevel.HARD
+            for existing in selected
+        ):
+            continue
+        selected.append(candidate)
+    return tuple(packet.task_id for packet in selected)
+
+
+__all__ = ["ready_tasks"]

--- a/tools/agent_repo/coordination/state.py
+++ b/tools/agent_repo/coordination/state.py
@@ -1,0 +1,65 @@
+"""State transition and evidence freshness rules for coordinated tasks."""
+
+from __future__ import annotations
+
+from tools.agent_repo.coordination.model import (
+    EvidenceKind,
+    EvidenceRecord,
+    TaskPacket,
+    TaskPhase,
+)
+
+_ALLOWED_TRANSITIONS: dict[TaskPhase, frozenset[TaskPhase]] = {
+    TaskPhase.PLANNED: frozenset({TaskPhase.READY}),
+    TaskPhase.READY: frozenset({TaskPhase.EXECUTING}),
+    TaskPhase.EXECUTING: frozenset({TaskPhase.REVIEW}),
+    TaskPhase.REVIEW: frozenset({TaskPhase.EXECUTING, TaskPhase.VERIFICATION}),
+    TaskPhase.VERIFICATION: frozenset(
+        {TaskPhase.EXECUTING, TaskPhase.INTEGRATION, TaskPhase.COMPLETE}
+    ),
+    TaskPhase.INTEGRATION: frozenset(
+        {TaskPhase.EXECUTING, TaskPhase.VERIFICATION, TaskPhase.COMPLETE}
+    ),
+    TaskPhase.COMPLETE: frozenset(),
+}
+
+
+def validate_transition(current: TaskPhase, target: TaskPhase) -> None:
+    """Raise when a requested phase transition is outside the v1 protocol."""
+
+    current_phase = TaskPhase(current)
+    target_phase = TaskPhase(target)
+    if current_phase is TaskPhase.COMPLETE:
+        raise ValueError("complete is a terminal task phase")
+    if target_phase not in _ALLOWED_TRANSITIONS[current_phase]:
+        raise ValueError(
+            f"task phase transition is not allowed: "
+            f"{current_phase.value} -> {target_phase.value}"
+        )
+
+
+def evidence_is_current(
+    evidence: EvidenceRecord,
+    packet: TaskPacket,
+    *,
+    head_sha: str,
+    current_main_sha: str | None = None,
+) -> bool:
+    """Return whether evidence is bound to the current exact task snapshot."""
+
+    if evidence.task_id != packet.task_id:
+        return False
+    if evidence.task_revision != packet.task_revision:
+        return False
+    if evidence.task_contract_digest != packet.contract_digest():
+        return False
+    if evidence.base_sha != packet.base_sha:
+        return False
+    if evidence.head_sha != head_sha:
+        return False
+    if evidence.evidence_kind in {EvidenceKind.INTEGRATION, EvidenceKind.POST_MERGE}:
+        return current_main_sha is not None and evidence.main_sha == current_main_sha
+    return True
+
+
+__all__ = ["evidence_is_current", "validate_transition"]


### PR DESCRIPTION
## Status

Draft implementation for Issue #500, now retargeted directly to `main` after PR #475 (Agent Repository Control Plane v1) became canonical.

#475 was merged as main commit `045dc84fb40ada3b5d782028448b938d9a65dfea`. This PR still remains Draft: its own branch must be synchronized with then-current `main`, conflicts (if any) resolved, and its exact resulting HEAD independently reviewed and fully verified before integration. Do not reuse pre-retarget stacked CI as final evidence.

## Objective

Implement the Agent Coordination Plane v1 defined in `docs/specs/2026-09-12-agent-coordination-plane-v1-design.md`:

- versioned Task Packet + canonical contract digest;
- phase + condition state model;
- exact-snapshot evidence invalidation;
- dependency DAG and semantic/side-effect conflict graph;
- deterministic scheduler;
- lease epoch ownership and branch fencing;
- heartbeat/reconciliation/handoff recovery;
- strict GitHub status projection;
- human-readable dashboard;
- network-free operator CLI under the canonical `tools.agent_repo` owner;
- adversarial stale/race/main-movement tests.

## TDD / sequencing

Implementation follows `docs/plans/2026-09-12-agent-coordination-plane-v1-implementation.md` task-by-task. Production `trade_rl/**` semantics remain out of scope.

Do not merge while Draft. Final integration requires current-main containment, exact-head re-review/full CI, and post-merge main verification.