### PR TITLE
ci: monitor GitHub Actions pins with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Objective

Prevent GitHub Actions runtime/version drift from going unnoticed by enabling Dependabot version updates for GitHub Actions only.

## Scope

Adds only `.github/dependabot.yml`.

Configuration:
- `package-ecosystem: github-actions`
- `directory: /` so `.github/workflows` is monitored
- weekly checks
- at most 5 open version-update PRs

GitHub's current documentation explicitly supports GitHub Actions referenced by full commit SHA, so this preserves the repository's immutable full-SHA pinning policy while surfacing newer tagged action releases as reviewable PRs.

## Non-goals

- no automatic merge
- no npm/uv/Python dependency update automation
- no workflow/runtime/research change
- no change to Issue #511 frozen execution or verifier branches

## Acceptance

- exact-head permanent CI Green
- final diff contains only `.github/dependabot.yml`
- current workflow full-SHA pins remain unchanged