### PR TITLE
test: fix public Guide search smoke locator

### DIFF
--- a/guide/e2e/public-smoke.spec.ts
+++ b/guide/e2e/public-smoke.spec.ts
@@ -23,7 +23,10 @@ test("published Guide serves the code-linked replay journey", async ({ page }) =
   await page.keyboard.press("Control+K");
   const search = page.getByRole("textbox", { name: "ガイドを検索" });
   await search.fill("desired_quantity");
-  await page.getByRole("button", { name: /希望保有数量/ }).click();
+  await page
+    .getByRole("dialog", { name: "ガイド検索" })
+    .getByRole("button", { name: /希望保有数量/ })
+    .click();
   await expect(page).toHaveURL(
     /#implementation-replay\?symbol=trade_rl\.evaluation\.replay\.run_single_symbol_replay$/,
   );


### PR DESCRIPTION
## 原因

PR #515 merge後の最初のPages deployではbuild/deployは成功しましたが、public smokeが`desired_quantity`検索後のstrict locator ambiguityで失敗しました。

`getByRole("button", { name: /希望保有数量/ })` が検索結果に加えsequence controlsも拾っていました。

## 修正

検索結果クリックをsemanticな `role="dialog"`, `name="ガイド検索"` 配下へscopeしました。

- production UI/runtime: 変更なし
- Guide content: 変更なし
- test oracle: 弱体化なし
- changed files: `guide/e2e/public-smoke.spec.ts` のみ

## Verification

PR exact-head CI #9995: Lean Core / Human Guide Green。

Merge commit: `9ce35dee7148c4e9ad6d2e52947583452fa345cd`。
Post-merge main CI #9996 / run `34736537165`: Lean Core / Human Guide Green。
Pages run `34736592583` / #152:
- build: Green
- deploy: Green
- public smoke: **3 passed, 1 project-specific skip, 0 failed**

公開smokeは desktop/mobile のcode-linked replay journey、exact-SHA source link、`desired_quantity`検索遷移、dark mode、320px horizontal overflowを実公開URL `https://shuntatsu.github.io/trade_rl/` 上で検証しました。
