### PR TITLE
guide: eliminate oversized bundle warning

### DIFF
--- a/guide/README.md
+++ b/guide/README.md
@@ -12,7 +12,9 @@ Human-facing content lives in guide/content/topics/*.json.
 
 ## コード連動契約
 
-GuideはPython sourceをimport/executeせず、`guide/tools/code_symbols.py` がASTから `guide/.generated/code-symbols.json` を生成します。この生成物はcommitせず、`.gitignore` で除外します。indexは完全修飾symbol、kind、source path/line、signature、source SHA-256、同一function scopeの主要local名、**exact revision**を保持します。
+GuideはPython sourceをimport/executeせず、`guide/tools/code_symbols.py` がASTからcode-symbol indexを生成します。`guide/.generated/code-symbols.json` はsource-check・review用の**full index**、`guide/.generated/code-symbols-runtime.json` は現行topicの `code_references` が参照するunique symbolだけを保持する**browser配布用index**です。どちらもcommitせず、`guide/.gitignore` で除外します。各entryは完全修飾symbol、kind、source path/line、signature、source SHA-256、同一function scopeの主要local名、**exact revision**を保持します。
+
+runtime indexはfull indexを置き換えるものではありません。full AST indexを先に構築した上でreview済みCodeReferenceの参照集合へ射影し、参照symbolがfull indexに存在しなければ生成時にfail-closedで停止します。browserへ未参照の全symbolを配布しないことで、traceabilityを維持したままbundleを小さく保ちます。
 
 各topicの `code_references` は人間がレビューした日本語aliasと実symbolの対応です。`content_contract.py --check` はmissing symbol、wrong kind、stale source digest、存在しないvariable、missing/escaping test pathをfail-closedで拒否します。
 
@@ -48,7 +50,7 @@ npm run check
 npm run e2e
 ```
 
-`npm run check` はsource-doc/code freshness、ESLint、TypeScript、Vitest、production buildを順に検証します。`npm run e2e` はChromiumでdesktop/mobileの主要操作・accessibility・visual evidenceを確認します。Light/Darkの両テーマでaxeの`serious`/`critical` violationを0件に保つことを必須とします。
+`npm run check` はsource-doc/code freshness、ESLint、TypeScript、Vitest、production buildを順に検証します。production build後は `tools/bundle_budget.py` が `dist/**/*.js` の**実ファイルサイズ**を検査し、1 chunkでも500,000 bytesを超えればfailします。Viteのwarning閾値を引き上げて大きなbundleを隠す運用はしません。`npm run e2e` はChromiumでdesktop/mobileの主要操作・accessibility・visual evidenceを確認します。Light/Darkの両テーマでaxeの`serious`/`critical` violationを0件に保つことを必須とします。
 
 GitHub Actionsでは既存Python gateの`Lean Core`と独立した`Human Guide` jobで同じ検査を実行します。Human Guide job全体へPR headの `GUIDE_SOURCE_REV` を渡すため、unit/buildだけでなくPlaywright dev serverが再生成するcode indexも同じSHAへbindされます。Playwright reportやscreenshotはCI artifactとして短期保持します。
 
@@ -60,7 +62,7 @@ GitHub Actionsでは既存Python gateの`Lean Core`と独立した`Human Guide` 
 
 Repository Pages sourceは **GitHub Actions** を使用します。公開済み判定はworkflow fileの存在ではなく、Pages state、deployment成功、実公開URL smokeを合わせて確認します。
 
-生成済み`dist/`はcommitしません。deployment buildでも`source-check`を再実行し、正本とのfingerprintがstaleならpublishをfail-closedに停止します。
+生成済み`dist/`はcommitしません。deployment buildでも`source-check`とbundle budgetを再実行し、正本とのfingerprintがstale、またはJavaScript chunkがbudget超過ならpublishをfail-closedに停止します。
 
 公開後の検証はローカルE2Eとは分離します。
 
@@ -83,9 +85,10 @@ npm run e2e:public
 - `content/topics/*.json`: 日本語中心の説明、検索語、review済み可視化model、正本traceability、CodeReference。
 - `src/visualizations/`: 汎用的な図の描画・interaction。研究固有の真実を持たない。
 - `src/components/CodeInspector.tsx`: 日本語説明を先に、実identifier/path/signature/test/sourceを副表示する。
-- `src/content/codeSymbols.ts`: untracked AST indexのparse/lookup。
+- `src/content/codeSymbols.ts`: compact runtime AST indexのparse/lookup。
 - `src/components/` / `src/app/`: navigation、search、theme、layout、URL selection。
-- `tools/code_symbols.py`: production moduleを実行せずcode symbol indexを生成。
+- `tools/code_symbols.py`: production moduleを実行せずfull AST indexを生成し、browser用runtime indexをreview済み参照symbolへ射影する。
 - `tools/content_contract.py`: docs/codeとのstalenessをfail-closedで検出。
+- `tools/bundle_budget.py`: production buildのJavaScript chunkを500,000-byte budget内へ固定する。
 
 Desktopではsequence/code-mapと一つのinspectorを並べ、mobileではpan/zoomを必須にせずstep-throughまたは選択node近傍から同じ実装情報へ到達できるようにします。selectionを色だけで表現せず、keyboardとテキストoutlineでも意味を追える状態を維持します。

--- a/guide/package.json
+++ b/guide/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "predev": "npm run code-index",
     "dev": "vite",
-    "code-index": "python3 tools/code_symbols.py --write .generated/code-symbols.json",
+    "code-index": "python3 tools/code_symbols.py --write .generated/code-symbols.json && python3 tools/code_symbols.py --write .generated/code-symbols-runtime.json --topics content/topics",
     "source-check": "python3 tools/content_contract.py --check",
     "prelint": "npm run code-index",
     "lint": "eslint . --max-warnings=0",
@@ -19,6 +19,7 @@
     "test": "vitest run",
     "prebuild": "npm run code-index",
     "build": "tsc -b --pretty false && vite build",
+    "postbuild": "python3 tools/bundle_budget.py dist --max-bytes 500000",
     "e2e": "playwright test",
     "e2e:public": "playwright test --config playwright.public.config.ts",
     "check": "npm run source-check && npm run lint && npm run typecheck && npm run test && npm run build"

--- a/guide/src/content/codeSymbols.ts
+++ b/guide/src/content/codeSymbols.ts
@@ -1,4 +1,4 @@
-import generatedRaw from "../../.generated/code-symbols.json";
+import generatedRaw from "../../.generated/code-symbols-runtime.json";
 
 export type CodeSymbol = {
   qualified_name: string;

--- a/guide/tools/bundle_budget.py
+++ b/guide/tools/bundle_budget.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+DEFAULT_MAX_BYTES = 500_000
+
+
+class BundleBudgetError(ValueError):
+    """Raised when the built Guide exceeds its JavaScript bundle budget."""
+
+
+def check_javascript_bundle_budget(
+    dist: Path,
+    *,
+    max_bytes: int = DEFAULT_MAX_BYTES,
+) -> None:
+    if max_bytes <= 0:
+        raise BundleBudgetError("max_bytes must be positive")
+    if not dist.is_dir():
+        raise BundleBudgetError(f"missing build directory: {dist}")
+
+    chunks = sorted(path for path in dist.rglob("*.js") if path.is_file())
+    if not chunks:
+        raise BundleBudgetError(f"no JavaScript chunks found under: {dist}")
+
+    oversized = [
+        (path.relative_to(dist).as_posix(), path.stat().st_size)
+        for path in chunks
+        if path.stat().st_size > max_bytes
+    ]
+    if oversized:
+        details = ", ".join(f"{path}={size} bytes" for path, size in oversized)
+        raise BundleBudgetError(
+            f"JavaScript bundle budget exceeded ({max_bytes} bytes): {details}"
+        )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Check Human Guide JavaScript bundle size.")
+    parser.add_argument("dist", type=Path)
+    parser.add_argument("--max-bytes", type=int, default=DEFAULT_MAX_BYTES)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    try:
+        check_javascript_bundle_budget(args.dist, max_bytes=args.max_bytes)
+    except BundleBudgetError as exc:
+        print(f"guide bundle budget: {exc}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/guide/tools/code_symbols.py
+++ b/guide/tools/code_symbols.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_SOURCE_ROOT = ROOT / "trade_rl"
+DEFAULT_TOPICS_DIR = ROOT / "guide" / "content" / "topics"
 SCHEMA_VERSION = "guide-code-symbols-v1"
 _REVISION_RE = re.compile(r"^[0-9a-f]{40}$")
 
@@ -323,13 +324,90 @@ def build_symbol_index(source_root: Path, *, revision: str) -> dict[str, object]
     }
 
 
+def _runtime_symbol_names(topics_dir: Path) -> list[str]:
+    topics_dir = topics_dir.resolve()
+    if not topics_dir.is_dir():
+        raise GuideCodeSymbolError(f"topics directory does not exist: {topics_dir}")
+
+    topic_paths = sorted(topics_dir.glob("*.json"))
+    if not topic_paths:
+        raise GuideCodeSymbolError(f"no Guide topic JSON files found: {topics_dir}")
+
+    names: set[str] = set()
+    for path in topic_paths:
+        try:
+            resolved = path.resolve(strict=True)
+            resolved.relative_to(topics_dir)
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise GuideCodeSymbolError(f"Guide topic escapes topics directory: {path}") from exc
+        try:
+            topic = json.loads(resolved.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise GuideCodeSymbolError(f"cannot read Guide topic JSON: {path}") from exc
+        if not isinstance(topic, dict):
+            raise GuideCodeSymbolError(f"Guide topic JSON root must be an object: {path}")
+        references = topic.get("code_references", [])
+        if not isinstance(references, list):
+            raise GuideCodeSymbolError(f"Guide topic code_references must be a list: {path}")
+        for index, reference in enumerate(references):
+            if not isinstance(reference, dict):
+                raise GuideCodeSymbolError(
+                    f"Guide topic code reference must be an object: {path}#{index}"
+                )
+            symbol = reference.get("symbol")
+            if not isinstance(symbol, str) or not symbol:
+                raise GuideCodeSymbolError(
+                    f"Guide topic code reference requires symbol: {path}#{index}"
+                )
+            names.add(symbol)
+    return sorted(names)
+
+
+def build_runtime_symbol_index(
+    source_root: Path,
+    topics_dir: Path,
+    *,
+    revision: str,
+) -> dict[str, object]:
+    full_index = build_symbol_index(source_root, revision=revision)
+    raw_symbols = full_index["symbols"]
+    if not isinstance(raw_symbols, list):
+        raise GuideCodeSymbolError("code symbol index has malformed symbols")
+    symbols_by_name = {
+        str(symbol["qualified_name"]): symbol
+        for symbol in raw_symbols
+        if isinstance(symbol, dict) and "qualified_name" in symbol
+    }
+
+    selected: list[dict[str, object]] = []
+    for name in _runtime_symbol_names(topics_dir):
+        symbol = symbols_by_name.get(name)
+        if symbol is None:
+            raise GuideCodeSymbolError(f"missing referenced code symbol: {name}")
+        selected.append(symbol)
+
+    return {
+        "schema_version": full_index["schema_version"],
+        "source_revision": full_index["source_revision"],
+        "symbols": selected,
+    }
+
+
 def write_symbol_index(
     source_root: Path,
     output: Path,
     *,
     revision: str,
+    topics_dir: Path | None = None,
 ) -> None:
-    index = build_symbol_index(source_root, revision=revision)
+    if topics_dir is None:
+        index = build_symbol_index(source_root, revision=revision)
+    else:
+        index = build_runtime_symbol_index(
+            source_root,
+            topics_dir,
+            revision=revision,
+        )
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(
         json.dumps(index, ensure_ascii=False, indent=2) + "\n",
@@ -359,6 +437,12 @@ def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Generate the Human Guide code-symbol index.")
     parser.add_argument("--write", type=Path, required=True, metavar="OUTPUT")
     parser.add_argument("--revision")
+    parser.add_argument(
+        "--topics",
+        type=Path,
+        metavar="TOPICS_DIR",
+        help="Write only symbols referenced by Guide topic JSON files.",
+    )
     return parser
 
 
@@ -369,6 +453,7 @@ def main() -> int:
             DEFAULT_SOURCE_ROOT,
             args.write,
             revision=resolve_revision(args.revision),
+            topics_dir=args.topics,
         )
     except GuideCodeSymbolError as exc:
         print(f"guide code symbols: {exc}")

--- a/guide/tools/code_symbols.py
+++ b/guide/tools/code_symbols.py
@@ -12,7 +12,6 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_SOURCE_ROOT = ROOT / "trade_rl"
-DEFAULT_TOPICS_DIR = ROOT / "guide" / "content" / "topics"
 SCHEMA_VERSION = "guide-code-symbols-v1"
 _REVISION_RE = re.compile(r"^[0-9a-f]{40}$")
 

--- a/guide/vitest.config.ts
+++ b/guide/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "jsdom",
+    pool: "vmThreads",
     setupFiles: ["./src/test/setup.ts"],
     include: ["tests/**/*.test.{ts,tsx}"],
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,14 +71,6 @@ strict_equality = true
 show_error_codes = true
 pretty = true
 
-[[tool.mypy.overrides]]
-module = [
-    "gymnasium.*",
-    "stable_baselines3.*",
-    "torch.*",
-]
-ignore_missing_imports = true
-
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["."]

--- a/tests/architecture/test_human_guide_bundle_budget.py
+++ b/tests/architecture/test_human_guide_bundle_budget.py
@@ -1,18 +1,11 @@
-from __future__ import annotations
-
-import importlib
-import json
-from pathlib import Path
-
-
-ROOT = Path(__file__).resolve().parents[2]
+ROOT = __import__("pathlib").Path(__file__).resolve().parents[2]
 
 
 def _bundle_budget_module():
-    return importlib.import_module("guide.tools.bundle_budget")
+    return __import__("guide.tools.bundle_budget", fromlist=["*"])
 
 
-def test_bundle_budget_rejects_javascript_chunk_above_limit(tmp_path: Path) -> None:
+def test_bundle_budget_rejects_javascript_chunk_above_limit(tmp_path) -> None:
     bundle_budget = _bundle_budget_module()
     dist = tmp_path / "dist"
     assets = dist / "assets"
@@ -29,7 +22,7 @@ def test_bundle_budget_rejects_javascript_chunk_above_limit(tmp_path: Path) -> N
         raise AssertionError("expected BundleBudgetError for oversized JavaScript chunk")
 
 
-def test_bundle_budget_accepts_javascript_chunks_at_or_below_limit(tmp_path: Path) -> None:
+def test_bundle_budget_accepts_javascript_chunks_at_or_below_limit(tmp_path) -> None:
     bundle_budget = _bundle_budget_module()
     dist = tmp_path / "dist"
     assets = dist / "assets"
@@ -41,7 +34,9 @@ def test_bundle_budget_accepts_javascript_chunks_at_or_below_limit(tmp_path: Pat
 
 
 def test_guide_build_uses_compact_runtime_index_and_enforces_budget() -> None:
-    package = json.loads((ROOT / "guide" / "package.json").read_text(encoding="utf-8"))
+    package = __import__("json").loads(
+        (ROOT / "guide" / "package.json").read_text(encoding="utf-8")
+    )
     scripts = package["scripts"]
     assert isinstance(scripts, dict)
 

--- a/tests/architecture/test_human_guide_bundle_budget.py
+++ b/tests/architecture/test_human_guide_bundle_budget.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+
+def _bundle_budget_module():
+    return importlib.import_module("guide.tools.bundle_budget")
+
+
+def test_bundle_budget_rejects_javascript_chunk_above_limit(tmp_path: Path) -> None:
+    bundle_budget = _bundle_budget_module()
+    dist = tmp_path / "dist"
+    assets = dist / "assets"
+    assets.mkdir(parents=True)
+    (assets / "too-large.js").write_bytes(b"x" * 501)
+
+    try:
+        bundle_budget.check_javascript_bundle_budget(dist, max_bytes=500)
+    except bundle_budget.BundleBudgetError as exc:
+        assert "too-large.js" in str(exc)
+        assert "501" in str(exc)
+        assert "500" in str(exc)
+    else:
+        raise AssertionError("expected BundleBudgetError for oversized JavaScript chunk")
+
+
+def test_bundle_budget_accepts_javascript_chunks_at_or_below_limit(tmp_path: Path) -> None:
+    bundle_budget = _bundle_budget_module()
+    dist = tmp_path / "dist"
+    assets = dist / "assets"
+    assets.mkdir(parents=True)
+    (assets / "one.js").write_bytes(b"x" * 500)
+    (assets / "two.js").write_bytes(b"x" * 127)
+
+    bundle_budget.check_javascript_bundle_budget(dist, max_bytes=500)

--- a/tests/architecture/test_human_guide_bundle_budget.py
+++ b/tests/architecture/test_human_guide_bundle_budget.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import importlib
+import json
 from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
 
 
 def _bundle_budget_module():
@@ -34,3 +38,23 @@ def test_bundle_budget_accepts_javascript_chunks_at_or_below_limit(tmp_path: Pat
     (assets / "two.js").write_bytes(b"x" * 127)
 
     bundle_budget.check_javascript_bundle_budget(dist, max_bytes=500)
+
+
+def test_guide_build_uses_compact_runtime_index_and_enforces_budget() -> None:
+    package = json.loads((ROOT / "guide" / "package.json").read_text(encoding="utf-8"))
+    scripts = package["scripts"]
+    assert isinstance(scripts, dict)
+
+    code_index = scripts["code-index"]
+    assert ".generated/code-symbols.json" in code_index
+    assert ".generated/code-symbols-runtime.json" in code_index
+    assert "--topics content/topics" in code_index
+
+    postbuild = scripts["postbuild"]
+    assert "tools/bundle_budget.py" in postbuild
+    assert "--max-bytes 500000" in postbuild
+
+    browser_index = (ROOT / "guide" / "src" / "content" / "codeSymbols.ts").read_text(
+        encoding="utf-8"
+    )
+    assert 'from "../../.generated/code-symbols-runtime.json"' in browser_index

--- a/tests/architecture/test_human_guide_bundle_budget.py
+++ b/tests/architecture/test_human_guide_bundle_budget.py
@@ -19,7 +19,9 @@ def test_bundle_budget_rejects_javascript_chunk_above_limit(tmp_path) -> None:
         assert "501" in str(exc)
         assert "500" in str(exc)
     else:
-        raise AssertionError("expected BundleBudgetError for oversized JavaScript chunk")
+        raise AssertionError(
+            "expected BundleBudgetError for oversized JavaScript chunk"
+        )
 
 
 def test_bundle_budget_accepts_javascript_chunks_at_or_below_limit(tmp_path) -> None:

--- a/tests/architecture/test_human_guide_runtime_code_symbols.py
+++ b/tests/architecture/test_human_guide_runtime_code_symbols.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+
+def _code_symbols_module():
+    return importlib.import_module("guide.tools.code_symbols")
+
+
+def _symbol_names(index: dict[str, object]) -> list[str]:
+    raw = index["symbols"]
+    assert isinstance(raw, list)
+    return [str(entry["qualified_name"]) for entry in raw if isinstance(entry, dict)]
+
+
+def _write_topic(path: Path, *, symbol: str) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "id": path.stem,
+                "code_references": [
+                    {
+                        "id": "ref",
+                        "symbol": symbol,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_runtime_index_keeps_only_symbols_referenced_by_topics(tmp_path: Path) -> None:
+    code_symbols = _code_symbols_module()
+    package = tmp_path / "trade_rl"
+    package.mkdir()
+    (package / "demo.py").write_text(
+        "def keep(value: int) -> int:\n"
+        "    return value\n\n"
+        "def drop(value: int) -> int:\n"
+        "    return value + 1\n",
+        encoding="utf-8",
+    )
+    topics = tmp_path / "topics"
+    topics.mkdir()
+    _write_topic(topics / "one.json", symbol="trade_rl.demo.keep")
+    _write_topic(topics / "two.json", symbol="trade_rl.demo.keep")
+
+    index = code_symbols.build_runtime_symbol_index(
+        package,
+        topics,
+        revision="a" * 40,
+    )
+
+    assert _symbol_names(index) == ["trade_rl.demo.keep"]
+    assert index["source_revision"] == "a" * 40
+
+
+def test_runtime_index_rejects_unknown_referenced_symbol(tmp_path: Path) -> None:
+    code_symbols = _code_symbols_module()
+    package = tmp_path / "trade_rl"
+    package.mkdir()
+    (package / "demo.py").write_text(
+        "def known() -> None:\n    pass\n",
+        encoding="utf-8",
+    )
+    topics = tmp_path / "topics"
+    topics.mkdir()
+    _write_topic(topics / "demo.json", symbol="trade_rl.demo.missing")
+
+    try:
+        code_symbols.build_runtime_symbol_index(
+            package,
+            topics,
+            revision="b" * 40,
+        )
+    except code_symbols.GuideCodeSymbolError as exc:
+        assert "missing referenced code symbol" in str(exc)
+        assert "trade_rl.demo.missing" in str(exc)
+    else:
+        raise AssertionError("expected GuideCodeSymbolError for unknown runtime symbol")


### PR DESCRIPTION
## Status

**Completed and deployed.**

Merged PR: #520
Merged main SHA: `e91d8d51d5b2dcce038311221967b7701c72ecb3`
PR exact-head: `3f7b917baf8bf29b2b4254fb876a2beffcf07ca8`

## Objective

Viteの500 kB超chunk警告を閾値変更で隠さず、実際の配布bundleを縮小して解消する。併せて、安全に原因除去できるproject-level warning/hintも整理する。

## Root cause

ブラウザがsource-check用のfull AST code-symbol indexを丸ごとimportしていた一方、Guideの`code_references`が実際に必要とするのは少数のreview済みsymbolだけだった。未参照symbolの大量配布がmain JS chunk肥大化の主因だった。

## Changes

- full AST indexはsource-check/review用として維持。
- browser用に`code-symbols-runtime.json`を追加し、topicの`code_references`が参照するunique symbolだけへfull indexを射影。
- unknown referenced symbol / malformed topic referenceは生成時にfail-closed。
- browserの`codeSymbols.ts`はcompact runtime indexだけをimport。
- `guide/tools/bundle_budget.py`を追加し、production build後の`dist/**/*.js`実bytesを検査。1 chunkでも500,000 bytes超ならbuild failure。
- `chunkSizeWarningLimit`は変更していない。
- Vitestは`pool: "vmThreads"`へ変更し、jsdom isolationを保ったままworker内reuse。
- 現環境で不要なmypy ignore overrideを削除。warning suppressionは追加していない。
- durable contractを`guide/README.md`へ記録。

## TDD / adversarial evidence

Production変更前にsemantic REDを確認。
- `build_runtime_symbol_index`未実装による2 failures
- `guide.tools.bundle_budget`未実装による2 failures
- build wiringは旧full index import / budget未接続でRED

環境由来のimport-path failureはRED証拠として採用せず、semantic failureだけをoracleにした。

## Final verification

### PR exact-head CI

Run `34739121792` / #10008 — Lean Core / Human GuideともGreen。

### Main push CI

Run `34739332117` / #10009 — merged SHA `e91d8d51d5b2dcce038311221967b7701c72ecb3` をexact checkoutし、Lean Core / Human GuideともGreen。

- Ruff / formatter: Green
- mypy `trade_rl`: 133 source files, no issues
- repository tooling mypy: 20 source files, no issues
- stale mypy override由来の`unused section(s)` note: なし
- core tests: **1222 passed**
- Guide Vitest: **39/39**
- Guide Playwright: **19 passed / 3 project-specific skips / 0 failed**
- production JS: **311.71 kB minified / 96.92 kB gzip**
- before: **735.92 kB minified**
- reduction: 約57.6%
- Vite oversized-chunk warning: なし
- Vitest jsdom repeated-environment hint: なし
- 500,000-byte postbuild budget: Green

### Pages deploy

Deploy Human Guide run `34739382111` / #165:
- build: success
- deploy: success
- deployed SHA: `e91d8d51d5b2dcce038311221967b7701c72ecb3`
- deploy build JS: **311.71 kB / gzip 96.92 kB**
- bundle budget: Green

### Public smoke

`GUIDE_PUBLIC_URL=https://shuntatsu.github.io/trade_rl/`
`GUIDE_SOURCE_REV=e91d8d51d5b2dcce038311221967b7701c72ecb3`

Playwright public smoke: **3 passed / 1 project-specific skip / 0 failed**。
Desktop/mobileのcode-linked replay journeyと、mobile 320px horizontal overflowを実公開URLで確認。

## Safety boundaries

- `trade_rl/**` runtime source changes: **0**
- generated `.generated/` files / `dist/` はcommitしていない
- warning threshold increaseなし
- test skip追加・assertion弱体化なし
- unresolved review threads: 0

## Informational output intentionally retained

`npm`のfunding案内とGitHub Actions checkout時のtemporary repository初期branch hintは、project codeのwarningではなくupstream toolの情報表示なので抑制していない。正しい設定やrunner全体設定を歪めてまで消さない。